### PR TITLE
Draft impl for ::PauliSum.trace(::PauliSum)

### DIFF
--- a/crates/ppvm-runtime/src/map/dashmap.rs
+++ b/crates/ppvm-runtime/src/map/dashmap.rs
@@ -95,32 +95,35 @@ where
 //     }
 // }
 
-impl<'a, S, C, Hasher> Trace<'a, PauliWord<S, Hasher>> for DashMap<PauliWord<S, Hasher>, C, Hasher>
+impl<'a, S, C, Hasher> Trace<'a, PauliWord<S, Hasher>, C>
+    for DashMap<PauliWord<S, Hasher>, C, Hasher>
 where
     S: PauliStorage + 'a,
-    C: Coefficient + Send + Sync + 'a,
+    C: Coefficient + Send + Sync + 'a + From<bool>,
     Hasher: Clone + BuildHasher + Default + Send + Sync + 'a,
 {
-    type Output = C;
-    fn trace(&'a self, value: &'a PauliWord<S, Hasher>) -> Self::Output {
+    fn trace(&'a self, value: &'a PauliWord<S, Hasher>) -> C {
         self.par_iter()
-            .filter(|entry| value.trace(entry.key()))
-            .map(|entry| entry.value().clone())
+            .map(|entry| {
+                let tr: C = value.trace(entry.key());
+                tr * entry.value().clone()
+            })
             .sum()
     }
 }
 
-impl<'a, S, C, State> Trace<'a, PauliPattern> for DashMap<PauliWord<S>, C, State>
+impl<'a, S, C, State> Trace<'a, PauliPattern, C> for DashMap<PauliWord<S>, C, State>
 where
     S: PauliStorage + 'a,
-    C: Coefficient + Send + Sync + 'a,
+    C: Coefficient + Send + Sync + 'a + From<bool>,
     State: Clone + BuildHasher + 'a + Send + Sync,
 {
-    type Output = C;
-    fn trace(&'a self, value: &'a PauliPattern) -> Self::Output {
+    fn trace(&'a self, value: &'a PauliPattern) -> C {
         self.par_iter()
-            .filter(|entry| entry.key().trace(value))
-            .map(|entry| entry.value().clone())
+            .map(|entry| {
+                let tr: C = value.trace(entry.key());
+                tr * entry.value().clone()
+            })
             .sum()
     }
 }

--- a/crates/ppvm-runtime/src/map/hashmap.rs
+++ b/crates/ppvm-runtime/src/map/hashmap.rs
@@ -103,18 +103,18 @@ macro_rules! impl_acmap_iter {
 
 macro_rules! impl_acmap_trace {
     ($($seg:ident)::+) => {
-        impl<'a, P, S, C, Hasher> crate::traits::Trace<'a, P> for $($seg)::+<PauliWord<S, Hasher>, C, Hasher>
+        impl<'a, P, S, C, Hasher> crate::traits::Trace<'a, P, C> for $($seg)::+<PauliWord<S, Hasher>, C, Hasher>
         where
-            P: crate::traits::Trace<'a, PauliWord<S, Hasher>, Output = bool> + 'a,
+            P: crate::traits::Trace<'a, PauliWord<S, Hasher>, C> + 'a,
             S: PauliStorage + 'a,
             C: Coefficient + 'a,
             Hasher: Default + Clone + BuildHasher + 'a,
         {
-            type Output = C;
-            fn trace(&'a self, value: &'a P) -> Self::Output {
+            fn trace(&'a self, value: &'a P) -> C {
                 let sum = C::zero();
                 self.iter().fold(sum, |mut acc, (k, v)| {
-                    value.trace(k).then(|| acc += v.clone());
+                    let val = value.trace(k);
+                    acc += v.clone() * val;
                     acc
                 })
             }

--- a/crates/ppvm-runtime/src/pattern/trace.rs
+++ b/crates/ppvm-runtime/src/pattern/trace.rs
@@ -5,24 +5,24 @@ use crate::traits::{PauliStorage, Trace};
 use crate::word::PauliWord;
 use std::hash::BuildHasher;
 
-impl<'a, A, H> Trace<'a, PauliPattern> for PauliWord<A, H>
+impl<'a, A, H, T> Trace<'a, PauliPattern, T> for PauliWord<A, H>
 where
     A: PauliStorage + 'a,
     H: Default + BuildHasher + Clone + 'a,
+    T: From<bool>,
 {
-    type Output = bool;
-    fn trace(&'a self, value: &'a PauliPattern) -> Self::Output {
-        value.contains(&self)
+    fn trace(&'a self, value: &'a PauliPattern) -> T {
+        T::from(value.contains(&self))
     }
 }
 
-impl<'a, A, H> Trace<'a, PauliWord<A, H>> for PauliPattern
+impl<'a, A, H, T> Trace<'a, PauliWord<A, H>, T> for PauliPattern
 where
     A: PauliStorage + 'a,
     H: Default + BuildHasher + Clone + 'a,
+    T: From<bool>,
 {
-    type Output = bool;
-    fn trace(&'a self, value: &'a PauliWord<A, H>) -> Self::Output {
-        self.contains(value)
+    fn trace(&'a self, value: &'a PauliWord<A, H>) -> T {
+        T::from(self.contains(value))
     }
 }

--- a/crates/ppvm-runtime/src/sum/trace.rs
+++ b/crates/ppvm-runtime/src/sum/trace.rs
@@ -1,16 +1,15 @@
 use crate::{config::Config, sum::PauliSum, traits::Trace, word::PauliWord};
 use num::Zero;
 
-impl<'a, T: Config, Rhs> Trace<'a, Rhs> for PauliSum<T>
+impl<'a, T: Config, Rhs> Trace<'a, Rhs, T::Coeff> for PauliSum<T>
 where
     <T as Config>::Coeff: Zero + Clone + std::ops::AddAssign + 'a,
     <T as Config>::Storage: 'a,
-    <T as Config>::Map: Trace<'a, Rhs, Output = <T as Config>::Coeff>,
+    <T as Config>::Map: Trace<'a, Rhs, T::Coeff>,
     <T as Config>::BuildHasher: 'a,
-    Rhs: Trace<'a, PauliWord<T::Storage, T::BuildHasher>, Output = bool> + 'a,
+    Rhs: Trace<'a, PauliWord<T::Storage, T::BuildHasher>, T::Coeff> + 'a,
 {
-    type Output = T::Coeff;
-    fn trace(&'a self, value: &'a Rhs) -> Self::Output {
+    fn trace(&'a self, value: &'a Rhs) -> T::Coeff {
         self.data().trace(value)
     }
 }

--- a/crates/ppvm-runtime/src/traits/trace.rs
+++ b/crates/ppvm-runtime/src/traits/trace.rs
@@ -1,6 +1,5 @@
 /// Trait for computing trace(self * RHS)
 /// if type implements `Trace` an implementation of `TraceBy` is also provided.
-pub trait Trace<'a, RHS: 'a> {
-    type Output;
-    fn trace(&'a self, value: &'a RHS) -> Self::Output;
+pub trait Trace<'a, RHS: 'a, T> {
+    fn trace(&'a self, value: &'a RHS) -> T;
 }

--- a/crates/ppvm-runtime/src/word/trace.rs
+++ b/crates/ppvm-runtime/src/word/trace.rs
@@ -3,13 +3,13 @@ use std::hash::BuildHasher;
 use super::data::PauliWord;
 use crate::traits::{PauliStorage, Trace};
 
-impl<'a, A, H> Trace<'a, PauliWord<A, H>> for PauliWord<A, H>
+impl<'a, A, H, T> Trace<'a, PauliWord<A, H>, T> for PauliWord<A, H>
 where
     A: PauliStorage + 'a,
     H: Default + BuildHasher + Clone + 'a,
+    T: From<bool>,
 {
-    type Output = bool;
-    fn trace(&'a self, value: &'a PauliWord<A, H>) -> Self::Output {
+    fn trace(&'a self, value: &'a PauliWord<A, H>) -> T {
         debug_assert_eq!(
             self.n_qubits(),
             value.n_qubits(),
@@ -17,6 +17,6 @@ where
             self.n_qubits(),
             value.n_qubits()
         );
-        self == value
+        T::from(self == value)
     }
 }

--- a/crates/ppvm-runtime/tests/ghz.rs
+++ b/crates/ppvm-runtime/tests/ghz.rs
@@ -62,6 +62,22 @@ fn test_ghz_backward() {
     // zero state
     let zero_state: PauliPattern = "Z?*".into();
     let result = state.trace(&zero_state);
+    state.data().trace(&zero_state);
+    state.data().iter();
+
+    println!("{:?}", state.data());
 
     assert_eq!(result, 1.0);
+}
+
+#[test]
+fn test_pauli_sum_trace() {
+    let mut state1: PauliSum<config::indexmap::ByteFxHashF64<4>> =
+        PauliSum::builder().n_qubits(2).build();
+
+    // prepare "state" as the final expectation value we want
+    state1 += ("ZZ", 0.5);
+    let state2 = state1.clone();
+    let result = state1.trace(&state2);
+    assert_eq!(result, 0.25);
 }

--- a/crates/ppvm-sym/src/coeff.rs
+++ b/crates/ppvm-sym/src/coeff.rs
@@ -46,6 +46,12 @@ impl std::ops::Neg for Term {
     }
 }
 
+impl From<bool> for Term {
+    fn from(value: bool) -> Self {
+        Term::from_f64(f64::from(value))
+    }
+}
+
 impl From<f32> for Term {
     fn from(value: f32) -> Self {
         Term::from_f64(value as f64)


### PR DESCRIPTION
Probably shouldn't merged, but just so we can discuss how to best do this. The problem is that the generic trait implementation for `PauliSum` also covers the case `PauliSum.trace(PauliSum)`, but the typing is off.

This also requires some changes to the underlying `trace` methods on `D/HashMap`, so this might affect performance.