### PR TITLE
Fix inverted boolean in CoefficientThreshold truncation

### DIFF
--- a/crates/ppvm-runtime/src/strategy.rs
+++ b/crates/ppvm-runtime/src/strategy.rs
@@ -74,6 +74,6 @@ impl Strategy for CoefficientThreshold {
         H: std::hash::BuildHasher + Clone + Default,
         M: ACMap<S, V, H>,
     {
-        map.retain(|_, v| v.cutoff(self.0));
+        map.retain(|_, v| !v.cutoff(self.0));
     }
 }

--- a/crates/ppvm-runtime/src/strategy.rs
+++ b/crates/ppvm-runtime/src/strategy.rs
@@ -23,7 +23,7 @@ impl<S1: Strategy, S2: Strategy> Strategy for CombinedStrategy<S1, S2> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MaxPauliWeight(usize);
+pub struct MaxPauliWeight(pub usize);
 
 impl MaxPauliWeight {
     pub fn max_weight(&self) -> usize {

--- a/crates/ppvm-runtime/src/traits/coefficient.rs
+++ b/crates/ppvm-runtime/src/traits/coefficient.rs
@@ -25,6 +25,9 @@ pub trait Coefficient:
     fn mul_sign(&self, sign: i8) -> Self;
     fn half(&self) -> Self;
     fn sin_cos(&self) -> (Self, Self);
+
+    /// Determine whether this coefficient should be cutoff
+    /// Returns `true`, if the coefficient should be cut, and `false` else.
     fn cutoff(&self, threshold: f64) -> bool;
 }
 

--- a/crates/ppvm-runtime/tests/strategy.rs
+++ b/crates/ppvm-runtime/tests/strategy.rs
@@ -1,0 +1,22 @@
+use ppvm_runtime::{prelude::*, strategy::CoefficientThreshold};
+
+#[test]
+fn test_coefficient_threshold() {
+    let strat = CoefficientThreshold(1e-4);
+    let mut state: PauliSum<config::indexmap::ByteFxHashF64<4, CoefficientThreshold>> =
+        PauliSum::builder().n_qubits(2).strategy(strat).build();
+
+    state += ("ZZ", 1.0);
+    state += ("XX", 1e-3);
+    state += ("YY", 1e-5);
+    state += ("XZ", -0.5);
+    state.truncate();
+
+    let mut target_state: PauliSum<config::indexmap::ByteFxHashF64<4, CoefficientThreshold>> =
+        PauliSum::builder().strategy(strat).n_qubits(2).build();
+    target_state += ("ZZ", 1.0);
+    target_state += ("XX", 1e-3);
+    target_state += ("XZ", -0.5);
+
+    assert_eq!(state, target_state);
+}

--- a/crates/ppvm-runtime/tests/strategy.rs
+++ b/crates/ppvm-runtime/tests/strategy.rs
@@ -1,4 +1,7 @@
-use ppvm_runtime::{prelude::*, strategy::CoefficientThreshold};
+use ppvm_runtime::{
+    prelude::*,
+    strategy::{CoefficientThreshold, MaxPauliWeight},
+};
 
 #[test]
 fn test_coefficient_threshold() {
@@ -17,6 +20,29 @@ fn test_coefficient_threshold() {
     target_state += ("ZZ", 1.0);
     target_state += ("XX", 1e-3);
     target_state += ("XZ", -0.5);
+
+    assert_eq!(state, target_state);
+}
+
+#[test]
+fn test_pauli_weight() {
+    let strat = MaxPauliWeight(2);
+
+    let mut state: PauliSum<config::indexmap::ByteFxHashF64<4, MaxPauliWeight>> =
+        PauliSum::builder().n_qubits(3).strategy(strat).build();
+
+    state += ("XXX", 1.0);
+    state += ("ZZI", 1e-4);
+    state += ("YZY", -10.0);
+    state += ("IXX", -0.1);
+
+    state.truncate();
+
+    let mut target_state: PauliSum<config::indexmap::ByteFxHashF64<4, MaxPauliWeight>> =
+        PauliSum::builder().n_qubits(3).strategy(strat).build();
+
+    target_state += ("ZZI", 1e-4);
+    target_state += ("IXX", -0.1);
 
     assert_eq!(state, target_state);
 }

--- a/crates/ppvm-runtime/tests/strategy.rs
+++ b/crates/ppvm-runtime/tests/strategy.rs
@@ -1,6 +1,6 @@
 use ppvm_runtime::{
     prelude::*,
-    strategy::{CoefficientThreshold, MaxPauliWeight},
+    strategy::{CoefficientThreshold, CombinedStrategy, MaxPauliWeight},
 };
 
 #[test]
@@ -42,6 +42,46 @@ fn test_pauli_weight() {
         PauliSum::builder().n_qubits(3).strategy(strat).build();
 
     target_state += ("ZZI", 1e-4);
+    target_state += ("IXX", -0.1);
+
+    assert_eq!(state, target_state);
+}
+
+#[test]
+fn test_combined_strategy() {
+    let cutoff_strategy = CoefficientThreshold(1e-4);
+    let max_weight_strategy = MaxPauliWeight(2);
+    let strat = CombinedStrategy(cutoff_strategy, max_weight_strategy);
+
+    let mut state: PauliSum<
+        config::indexmap::ByteFxHashF64<4, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>,
+    > = PauliSum::builder()
+        .n_qubits(3)
+        .capacity(8)
+        .strategy(strat)
+        .build();
+
+    state += ("ZZI", 1.0);
+    state += ("XIX", 1e-3);
+    state += ("IYY", 1e-5);
+    state += ("XIZ", -0.5);
+
+    state += ("XXX", 1.0);
+    state += ("ZIZ", 1e-4);
+    state += ("YZY", -10.0);
+    state += ("IXX", -0.1);
+
+    state.truncate();
+
+    let mut target_state: PauliSum<
+        config::indexmap::ByteFxHashF64<4, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>,
+    > = PauliSum::builder().n_qubits(3).strategy(strat).build();
+
+    target_state += ("ZZI", 1.0);
+    target_state += ("XIX", 1e-3);
+    target_state += ("XIZ", -0.5);
+
+    target_state += ("ZIZ", 1e-4);
     target_state += ("IXX", -0.1);
 
     assert_eq!(state, target_state);


### PR DESCRIPTION
The coefficient truncation strategy is a little too eager in its current state :D 

We could equivalently change the `<` to `>` in the `cutoff` impl, but I took that to mean `return true, if coefficient should be cut`. I also added a docstring to make sure it's not ambiguous.

**Edit**: In the second commit, I added another test for `MaxPauliWeight` and had to make its `usize` attribute public.