### PR TITLE
Add trotter example as benchmark

### DIFF
--- a/crates/ppvm-runtime/Cargo.toml
+++ b/crates/ppvm-runtime/Cargo.toml
@@ -36,3 +36,7 @@ approx = ["dep:approx"]
 [[bench]]
 name = "gate"
 harness = false
+
+[[bench]]
+name = "trotter"
+harness = false

--- a/crates/ppvm-runtime/benches/trotter.rs
+++ b/crates/ppvm-runtime/benches/trotter.rs
@@ -1,0 +1,115 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use ppvm_runtime::prelude::*;
+use ppvm_runtime::strategy::CoefficientThreshold;
+use rayon::current_num_threads;
+
+fn trotter_func<T: Config<Coeff = f64, Strategy = CoefficientThreshold>>(
+    state: &mut PauliSum<T>,
+    n: usize,
+    total_time: &f64,
+    dt: &f64,
+    interaction_strength: &f64,
+    external_field: &f64,
+    noise_params: [f64; 3],
+) {
+    let steps = (total_time / dt) as usize;
+
+    let theta_zz = dt * interaction_strength;
+    let theta_x = dt * external_field;
+    for _ in 0..steps {
+        // perform trotter step
+        for i in 0..n {
+            state.rx(i, theta_x);
+            state.pauli_error(i, noise_params);
+        }
+        for i in 0..n - 1 {
+            state.rzz(i, i + 1, theta_zz);
+            state.pauli_error(i, noise_params);
+            state.pauli_error(i + 1, noise_params);
+        }
+
+        // truncate state in each iteration
+        state.truncate();
+    }
+}
+
+pub fn benchmark_suite_trotter<T: Config<Coeff = f64, Strategy = CoefficientThreshold>>(
+    c: &mut Criterion,
+    name: impl AsRef<str>,
+) {
+    let mut group = c.benchmark_group(name.as_ref());
+
+    // parameters
+    let n_qubits = 12;
+    let h = 1.0;
+    let dt = 0.1 / h;
+    let time = 1.0 / h;
+    let j = 1.0 / 8.0 * h;
+
+    let strat = CoefficientThreshold(1e-6);
+    let mut state: PauliSum<T> = PauliSum::builder()
+        .n_qubits(n_qubits)
+        .capacity(1 << 20)
+        .strategy(strat)
+        .build();
+
+    // initial state: let's calculate the expectation value of Sum(Z(i))
+    let tmp = vec!['I'; n_qubits];
+    for i in 0..n_qubits {
+        let mut zi = tmp.clone();
+        zi[i] = 'Z';
+        let zi_string: String = zi.iter().collect();
+        state += (zi_string, 1.0);
+    }
+
+    println!("Initial state has {} terms", state.len());
+
+    let noise_params = [1e-4; 3];
+
+    group.bench_function("trotter", |b| {
+        b.iter_batched_ref(
+            || state.clone(),
+            |state| {
+                trotter_func(state, n_qubits, &time, &dt, &j, &h, noise_params);
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+pub fn trotter_benchmarks(c: &mut Criterion) {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build_global()
+        .unwrap();
+    println!("Using {} threads", current_num_threads());
+    benchmark_suite_trotter::<config::gxhash::ByteF64<4, CoefficientThreshold>>(
+        c,
+        "ByteF64GxHashMap<4, CoefficientThreshold>",
+    );
+    benchmark_suite_trotter::<config::fxhash::ByteF64<4, CoefficientThreshold>>(
+        c,
+        "ByteF64FxHashMap<4, CoefficientThreshold>",
+    );
+    benchmark_suite_trotter::<config::dashmap::ByteFxHashF64<4, CoefficientThreshold>>(
+        c,
+        "ByteF64FxDashMap<4, CoefficientThreshold>",
+    );
+    benchmark_suite_trotter::<config::dashmap::ByteGxHashF64<4, CoefficientThreshold>>(
+        c,
+        "ByteF64GxDashMap<4, CoefficientThreshold>",
+    );
+    benchmark_suite_trotter::<config::indexmap::ByteFxHashF64<4, CoefficientThreshold>>(
+        c,
+        "ByteF64FxIndexMap<4, CoefficientThreshold>",
+    );
+    benchmark_suite_trotter::<config::indexmap::ByteGxHashF64<4, CoefficientThreshold>>(
+        c,
+        "ByteF64GxIndexMap<4, CoefficientThreshold>",
+    );
+}
+
+criterion_group!(benches, trotter_benchmarks);
+criterion_main!(benches);

--- a/crates/ppvm-runtime/benches/trotter.rs
+++ b/crates/ppvm-runtime/benches/trotter.rs
@@ -18,18 +18,25 @@ fn trotter_func<T: Config<Coeff = f64, Strategy = CoefficientThreshold>>(
     let theta_x = dt * external_field;
     for _ in 0..steps {
         // perform trotter step
+
+        // truncate after each gate application to be consistent with PP.jl
         for i in 0..n {
             state.rx(i, theta_x);
+            state.truncate();
+
             state.pauli_error(i, noise_params);
+            state.truncate();
         }
         for i in 0..n - 1 {
             state.rzz(i, i + 1, theta_zz);
-            state.pauli_error(i, noise_params);
-            state.pauli_error(i + 1, noise_params);
-        }
+            state.truncate();
 
-        // truncate state in each iteration
-        state.truncate();
+            state.pauli_error(i, noise_params);
+            state.truncate();
+
+            state.pauli_error(i + 1, noise_params);
+            state.truncate();
+        }
     }
 }
 
@@ -49,7 +56,6 @@ pub fn benchmark_suite_trotter<T: Config<Coeff = f64, Strategy = CoefficientThre
     let strat = CoefficientThreshold(1e-6);
     let mut state: PauliSum<T> = PauliSum::builder()
         .n_qubits(n_qubits)
-        .capacity(1 << 20)
         .strategy(strat)
         .build();
 
@@ -64,7 +70,7 @@ pub fn benchmark_suite_trotter<T: Config<Coeff = f64, Strategy = CoefficientThre
 
     println!("Initial state has {} terms", state.len());
 
-    let noise_params = [1e-4; 3];
+    let noise_params = [1e-4 / 4.0; 3];
 
     group.bench_function("trotter", |b| {
         b.iter_batched_ref(
@@ -85,29 +91,29 @@ pub fn trotter_benchmarks(c: &mut Criterion) {
         .build_global()
         .unwrap();
     println!("Using {} threads", current_num_threads());
-    benchmark_suite_trotter::<config::gxhash::ByteF64<4, CoefficientThreshold>>(
+    benchmark_suite_trotter::<config::gxhash::ByteF64<12, CoefficientThreshold>>(
         c,
-        "ByteF64GxHashMap<4, CoefficientThreshold>",
+        "ByteF64GxHashMap<12, CoefficientThreshold>",
     );
-    benchmark_suite_trotter::<config::fxhash::ByteF64<4, CoefficientThreshold>>(
+    benchmark_suite_trotter::<config::fxhash::ByteF64<12, CoefficientThreshold>>(
         c,
-        "ByteF64FxHashMap<4, CoefficientThreshold>",
+        "ByteF64FxHashMap<12, CoefficientThreshold>",
     );
-    benchmark_suite_trotter::<config::dashmap::ByteFxHashF64<4, CoefficientThreshold>>(
+    benchmark_suite_trotter::<config::dashmap::ByteFxHashF64<12, CoefficientThreshold>>(
         c,
-        "ByteF64FxDashMap<4, CoefficientThreshold>",
+        "ByteF64FxDashMap<12, CoefficientThreshold>",
     );
-    benchmark_suite_trotter::<config::dashmap::ByteGxHashF64<4, CoefficientThreshold>>(
+    benchmark_suite_trotter::<config::dashmap::ByteGxHashF64<12, CoefficientThreshold>>(
         c,
-        "ByteF64GxDashMap<4, CoefficientThreshold>",
+        "ByteF64GxDashMap<12, CoefficientThreshold>",
     );
-    benchmark_suite_trotter::<config::indexmap::ByteFxHashF64<4, CoefficientThreshold>>(
+    benchmark_suite_trotter::<config::indexmap::ByteFxHashF64<12, CoefficientThreshold>>(
         c,
-        "ByteF64FxIndexMap<4, CoefficientThreshold>",
+        "ByteF64FxIndexMap<12, CoefficientThreshold>",
     );
-    benchmark_suite_trotter::<config::indexmap::ByteGxHashF64<4, CoefficientThreshold>>(
+    benchmark_suite_trotter::<config::indexmap::ByteGxHashF64<12, CoefficientThreshold>>(
         c,
-        "ByteF64GxIndexMap<4, CoefficientThreshold>",
+        "ByteF64GxIndexMap<12, CoefficientThreshold>",
     );
 }
 

--- a/crates/ppvm-runtime/benches/trotter.rs
+++ b/crates/ppvm-runtime/benches/trotter.rs
@@ -91,29 +91,29 @@ pub fn trotter_benchmarks(c: &mut Criterion) {
         .build_global()
         .unwrap();
     println!("Using {} threads", current_num_threads());
-    benchmark_suite_trotter::<config::gxhash::ByteF64<12, CoefficientThreshold>>(
+    benchmark_suite_trotter::<config::gxhash::ByteF64<2, CoefficientThreshold>>(
         c,
-        "ByteF64GxHashMap<12, CoefficientThreshold>",
+        "ByteF64GxHashMap<2, CoefficientThreshold>",
     );
-    benchmark_suite_trotter::<config::fxhash::ByteF64<12, CoefficientThreshold>>(
+    benchmark_suite_trotter::<config::fxhash::ByteF64<2, CoefficientThreshold>>(
         c,
-        "ByteF64FxHashMap<12, CoefficientThreshold>",
+        "ByteF64FxHashMap<2, CoefficientThreshold>",
     );
-    benchmark_suite_trotter::<config::dashmap::ByteFxHashF64<12, CoefficientThreshold>>(
+    benchmark_suite_trotter::<config::dashmap::ByteFxHashF64<2, CoefficientThreshold>>(
         c,
-        "ByteF64FxDashMap<12, CoefficientThreshold>",
+        "ByteF64FxDashMap<2, CoefficientThreshold>",
     );
-    benchmark_suite_trotter::<config::dashmap::ByteGxHashF64<12, CoefficientThreshold>>(
+    benchmark_suite_trotter::<config::dashmap::ByteGxHashF64<2, CoefficientThreshold>>(
         c,
-        "ByteF64GxDashMap<12, CoefficientThreshold>",
+        "ByteF64GxDashMap<2, CoefficientThreshold>",
     );
-    benchmark_suite_trotter::<config::indexmap::ByteFxHashF64<12, CoefficientThreshold>>(
+    benchmark_suite_trotter::<config::indexmap::ByteFxHashF64<2, CoefficientThreshold>>(
         c,
-        "ByteF64FxIndexMap<12, CoefficientThreshold>",
+        "ByteF64FxIndexMap<2, CoefficientThreshold>",
     );
-    benchmark_suite_trotter::<config::indexmap::ByteGxHashF64<12, CoefficientThreshold>>(
+    benchmark_suite_trotter::<config::indexmap::ByteGxHashF64<2, CoefficientThreshold>>(
         c,
-        "ByteF64GxIndexMap<12, CoefficientThreshold>",
+        "ByteF64GxIndexMap<2, CoefficientThreshold>",
     );
 }
 

--- a/julia-benchmarks/Manifest.toml
+++ b/julia-benchmarks/Manifest.toml
@@ -1,0 +1,355 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.12.1"
+manifest_format = "2.0"
+project_hash = "b0a235a0ac3523e7eaec1b005e719c1a4981bb1a"
+
+[[deps.AliasTables]]
+deps = ["PtrArrays", "Random"]
+git-tree-sha1 = "9876e1e164b144ca45e9e3198d0b689cadfed9ff"
+uuid = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"
+version = "1.1.3"
+
+[[deps.ArnoldiMethod]]
+deps = ["LinearAlgebra", "Random", "StaticArrays"]
+git-tree-sha1 = "d57bd3762d308bded22c3b82d033bff85f6195c6"
+uuid = "ec485272-7323-5ecc-a04f-4719b315124d"
+version = "0.4.0"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.AutoHashEquals]]
+git-tree-sha1 = "4ec6b48702dacc5994a835c1189831755e4e76ef"
+uuid = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
+version = "2.2.0"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.BenchmarkTools]]
+deps = ["Compat", "JSON", "Logging", "Printf", "Profile", "Statistics", "UUIDs"]
+git-tree-sha1 = "7fecfb1123b8d0232218e2da0c213004ff15358d"
+uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+version = "1.6.3"
+
+[[deps.BitIntegers]]
+deps = ["Random"]
+git-tree-sha1 = "f98cfeaba814d9746617822032d50a31c9926604"
+uuid = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
+version = "0.3.5"
+
+[[deps.Bits]]
+deps = ["Test"]
+git-tree-sha1 = "525d055f0c6b9476e6dcf032286383ea941a395c"
+uuid = "1654ce90-6ed3-553a-957f-9452c3a40996"
+version = "0.2.0"
+
+[[deps.Compat]]
+deps = ["TOML", "UUIDs"]
+git-tree-sha1 = "9d8a54ce4b17aa5bdce0ea5c34bc5e7c340d16ad"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.18.1"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.3.0+1"
+
+[[deps.DataAPI]]
+git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.16.0"
+
+[[deps.DataStructures]]
+deps = ["OrderedCollections"]
+git-tree-sha1 = "f0d05ae68d39d73a96883fc89c61bfe127290472"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.19.2"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+version = "1.11.0"
+
+[[deps.DocStringExtensions]]
+git-tree-sha1 = "7442a5dfe1ebb773c29cc2962a8980f47221d76c"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.9.5"
+
+[[deps.Graphs]]
+deps = ["ArnoldiMethod", "DataStructures", "Distributed", "Inflate", "LinearAlgebra", "Random", "SharedArrays", "SimpleTraits", "SparseArrays", "Statistics"]
+git-tree-sha1 = "7a98c6502f4632dbe9fb1973a4244eaa3324e84d"
+uuid = "86223c79-3864-5bf0-83f7-82e725a168b6"
+version = "1.13.1"
+
+[[deps.Inflate]]
+git-tree-sha1 = "d1b1b796e47d94588b3757fe84fbf65a5ec4a80d"
+uuid = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
+version = "0.1.5"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
+
+[[deps.IrrationalConstants]]
+git-tree-sha1 = "b2d91fe939cae05960e760110b328288867b5758"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.2.6"
+
+[[deps.JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.4"
+
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.12.0"
+
+[[deps.LogExpFunctions]]
+deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "13ca9e2586b89836fd20cccf56e57e2b9ae7f38f"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.3.29"
+
+    [deps.LogExpFunctions.extensions]
+    LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
+    LogExpFunctionsChangesOfVariablesExt = "ChangesOfVariables"
+    LogExpFunctionsInverseFunctionsExt = "InverseFunctions"
+
+    [deps.LogExpFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
+
+[[deps.MacroTools]]
+git-tree-sha1 = "1e0228a030642014fe5cfe68c2c0a818f9e3f522"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.16"
+
+[[deps.Markdown]]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+[[deps.Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "ec4f7fbeab05d7747bdf98eb74d130a2a2ed298d"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "1.2.0"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.29+0"
+
+[[deps.OrderedCollections]]
+git-tree-sha1 = "05868e21324cede2207c6f0f466b4bfef6d5e7ee"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.8.1"
+
+[[deps.ParserCombinator]]
+deps = ["AutoHashEquals", "Printf"]
+git-tree-sha1 = "5f2ab6899c7a056d475194d03393299e61a0425c"
+uuid = "fae87a5f-d1ad-5cf0-8f61-c941e1580b46"
+version = "2.2.1"
+
+[[deps.Parsers]]
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "7d2f8f21da5db6a806faf7b9b292296da42b2810"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.8.3"
+
+[[deps.PauliPropagation]]
+deps = ["BitIntegers", "Bits", "JSON", "LinearAlgebra", "PlotGraphviz", "Random", "StatsBase", "Test", "UUIDs"]
+git-tree-sha1 = "f97568ff3acf59bbcfb2b918febad483ca974fcb"
+uuid = "293282d5-3c99-4fb6-92d0-fd3280a19750"
+version = "0.5.1"
+
+[[deps.PlotGraphviz]]
+deps = ["Graphs", "ParserCombinator", "ShowGraphviz", "SimpleWeightedGraphs"]
+git-tree-sha1 = "146ff79274dd012a38d07af8ee5a3b9e01f9fb95"
+uuid = "78a92bc3-407c-4e2f-aae5-75bb47a6fe36"
+version = "0.6.3"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "07a921781cab75691315adc645096ed5e370cb77"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.3"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "0f27480397253da18fe2c12a4ba4eb9eb208bf3d"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.0"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.Profile]]
+deps = ["StyledStrings"]
+uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
+version = "1.11.0"
+
+[[deps.PtrArrays]]
+git-tree-sha1 = "1d36ef11a9aaf1e8b74dacc6a731dd1de8fd493d"
+uuid = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
+version = "1.3.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[deps.SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+version = "1.11.0"
+
+[[deps.ShowGraphviz]]
+git-tree-sha1 = "f619f73202df0b9f13a2faf3c5b35d74db560299"
+uuid = "14e20f5a-e304-4f94-b7d9-bca841234ddf"
+version = "0.1.0"
+
+[[deps.SimpleTraits]]
+deps = ["InteractiveUtils", "MacroTools"]
+git-tree-sha1 = "be8eeac05ec97d379347584fa9fe2f5f76795bcb"
+uuid = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+version = "0.9.5"
+
+[[deps.SimpleWeightedGraphs]]
+deps = ["Graphs", "LinearAlgebra", "Markdown", "SparseArrays"]
+git-tree-sha1 = "3e5f165e58b18204aed03158664c4982d691f454"
+uuid = "47aef6b3-ad0c-573a-a1e2-d07658019622"
+version = "1.5.0"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
+
+[[deps.SortingAlgorithms]]
+deps = ["DataStructures"]
+git-tree-sha1 = "64d974c2e6fdf07f8155b5b2ca2ffa9069b608d9"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "1.2.2"
+
+[[deps.SparseArrays]]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.12.0"
+
+[[deps.StaticArrays]]
+deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
+git-tree-sha1 = "b8693004b385c842357406e3af647701fe783f98"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.9.15"
+
+    [deps.StaticArrays.extensions]
+    StaticArraysChainRulesCoreExt = "ChainRulesCore"
+    StaticArraysStatisticsExt = "Statistics"
+
+    [deps.StaticArrays.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[deps.StaticArraysCore]]
+git-tree-sha1 = "6ab403037779dae8c514bad259f32a447262455a"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.4.4"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.11.1"
+weakdeps = ["SparseArrays"]
+
+    [deps.Statistics.extensions]
+    SparseArraysExt = ["SparseArrays"]
+
+[[deps.StatsAPI]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "9d72a13a3f4dd3795a195ac5a44d7d6ff5f552ff"
+uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
+version = "1.7.1"
+
+[[deps.StatsBase]]
+deps = ["AliasTables", "DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "a136f98cefaf3e2924a66bd75173d1c891ab7453"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.34.7"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
+
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "7.8.3+2"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.15.0+0"

--- a/julia-benchmarks/Project.toml
+++ b/julia-benchmarks/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+PauliPropagation = "293282d5-3c99-4fb6-92d0-fd3280a19750"

--- a/julia-benchmarks/README.md
+++ b/julia-benchmarks/README.md
@@ -1,0 +1,14 @@
+# Julia benchmarks for comparison
+
+Start Julia in the local project with
+
+```bash
+# cd julia-benchmarks
+julia --project=@. -t 4
+```
+
+Then, run benchmarks with e.g.
+
+```julia
+julia> include("benches/trotter.jl")
+```

--- a/julia-benchmarks/benches/trotter.jl
+++ b/julia-benchmarks/benches/trotter.jl
@@ -1,0 +1,64 @@
+using PauliPropagation
+using BenchmarkTools
+
+
+function trotter_circuit(n, total_time, dt, interaction_strength, external_field, noise_param)
+
+    circuit = Gate[]
+
+    steps = Int(total_time / dt)
+    theta_zz = dt * interaction_strength
+    theta_x = dt * external_field
+
+    
+    for _ in 1:steps
+
+        for i in 1:n
+            rx = PauliRotation([:X], [i], theta_x)
+            push!(circuit, rx)
+            push!(circuit, DepolarizingNoise(i, noise_param))
+        end
+
+        for i in 1:n-1
+            rzz = PauliRotation([:Z, :Z], [i, i+1], theta_zz)
+            push!(circuit, rzz)
+
+            push!(circuit, DepolarizingNoise(i, noise_param))
+            push!(circuit, DepolarizingNoise(i + 1, noise_param))
+        end
+
+
+
+    end
+
+    return circuit
+end
+
+function run_benchmark()
+    # set parameters here
+    n_qubits = 12
+    h = 1.0
+    dt = 0.1 / h
+    time = 1.0 / h
+    j = 1.0 / 8.0 * h
+    noise_param = 1e-4
+
+
+    initial_state = PauliSum(n_qubits)
+
+    for i = 1:n_qubits
+        add!(initial_state, PauliString(n_qubits, [:Z], [i]))
+    end
+
+    println("Using $(Threads.nthreads()) threads")
+
+
+
+    circuit = trotter_circuit(n_qubits, time, dt, j, h, noise_param)
+
+    return @benchmark propagate!($circuit, state; min_abs_coeff = 1e-6) setup = (state = copy($initial_state))
+end
+
+
+
+bench = run_benchmark()


### PR DESCRIPTION
Some preliminary results using 4 threads when running:

The best case using ppvm is:

```rust
ByteF64FxIndexMap<2, CoefficientThreshold>/trotter
                        time:   [435.68 µs 435.99 µs 436.31 µs]
                        change: [−0.8025% −0.6446% −0.4815%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe
```

The Julia benchmark returns:

```julia
BenchmarkTools.Trial: 4786 samples with 1 evaluation per sample.
 Range (min … max):  996.000 μs …  2.812 ms  ┊ GC (min … max): 0.00% … 60.37%
 Time  (median):       1.031 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):     1.042 ms ± 70.999 μs  ┊ GC (mean ± σ):  0.42% ±  2.99%

    ▁▃▆▇█▇█▇▂                                                   
  ▃▅██████████▆▅▅▄▄▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▁▂▁▁▁▂ ▃
  996 μs          Histogram: frequency by time         1.27 ms <

 Memory estimate: 140.39 KiB, allocs estimate: 2314.
```