### PR TITLE
Fix default capacity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.DS_Store

--- a/crates/ppvm-runtime/Cargo.toml
+++ b/crates/ppvm-runtime/Cargo.toml
@@ -44,3 +44,7 @@ harness = false
 [[bench]]
 name = "trotter"
 harness = false
+
+[[bench]]
+name = "trotter-scaling"
+harness = false

--- a/crates/ppvm-runtime/benches/trotter-scaling.rs
+++ b/crates/ppvm-runtime/benches/trotter-scaling.rs
@@ -1,0 +1,122 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use ppvm_runtime::prelude::*;
+use ppvm_runtime::strategy::CoefficientThreshold;
+use rayon::current_num_threads;
+
+fn trotter_func<T: Config<Coeff = f64, Strategy = CoefficientThreshold>>(
+    state: &mut PauliSum<T>,
+    n: usize,
+    total_time: &f64,
+    dt: &f64,
+    interaction_strength: &f64,
+    external_field: &f64,
+    noise_params: [f64; 3],
+) {
+    let steps = (total_time / dt) as usize;
+
+    let theta_zz = dt * interaction_strength;
+    let theta_x = dt * external_field;
+    for _ in 0..steps {
+        // perform trotter step
+
+        // truncate after each gate application to be consistent with PP.jl
+        for i in 0..n {
+            state.rx(i, theta_x);
+            state.truncate();
+
+            state.pauli_error(i, noise_params);
+            state.truncate();
+        }
+        for i in 0..n - 1 {
+            state.rzz(i, i + 1, theta_zz);
+            state.truncate();
+
+            state.pauli_error(i, noise_params);
+            state.truncate();
+
+            state.pauli_error(i + 1, noise_params);
+            state.truncate();
+        }
+    }
+}
+
+pub fn benchmark_suite_trotter<T: Config<Coeff = f64, Strategy = CoefficientThreshold>>(
+    c: &mut Criterion,
+    name: impl AsRef<str>,
+) {
+    let mut group = c.benchmark_group(name.as_ref());
+
+    // parameters
+    let h = 1.0;
+    let dt = 0.1 / h;
+    let time = 1.0 / h;
+    let j = 1.0 / 8.0 * h;
+
+    let strat = CoefficientThreshold(1e-6);
+
+    for n_qubits in (2..65).step_by(4) {
+        let mut state: PauliSum<T> = PauliSum::builder()
+            .n_qubits(n_qubits)
+            .capacity(n_qubits.pow(2))
+            .strategy(strat)
+            .build();
+
+        // initial state: let's calculate the expectation value of Sum(Z(i))
+        let tmp = vec!['I'; n_qubits];
+        for i in 0..n_qubits {
+            let mut zi = tmp.clone();
+            zi[i] = 'Z';
+            let zi_string: String = zi.iter().collect();
+            state += (zi_string, 1.0);
+        }
+
+        let noise_params = [1e-4 / 4.0; 3];
+
+        group.bench_function(format!("trotter-scaling-{}", n_qubits), |b| {
+            b.iter_batched_ref(
+                || state.clone(),
+                |state| {
+                    trotter_func(state, n_qubits, &time, &dt, &j, &h, noise_params);
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+pub fn trotter_benchmarks(c: &mut Criterion) {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build_global()
+        .unwrap();
+    println!("Using {} threads", current_num_threads());
+    // benchmark_suite_trotter::<config::gxhash::ByteF64<2, CoefficientThreshold>>(
+    //     c,
+    //     "ByteF64GxHashMap<2, CoefficientThreshold>",
+    // );
+    // benchmark_suite_trotter::<config::fxhash::ByteF64<2, CoefficientThreshold>>(
+    //     c,
+    //     "ByteF64FxHashMap<2, CoefficientThreshold>",
+    // );
+    // benchmark_suite_trotter::<config::dashmap::ByteFxHashF64<2, CoefficientThreshold>>(
+    //     c,
+    //     "ByteF64FxDashMap<2, CoefficientThreshold>",
+    // );
+    // benchmark_suite_trotter::<config::dashmap::ByteGxHashF64<2, CoefficientThreshold>>(
+    //     c,
+    //     "ByteF64GxDashMap<2, CoefficientThreshold>",
+    // );
+    benchmark_suite_trotter::<config::indexmap::ByteFxHashF64<8, CoefficientThreshold>>(
+        c,
+        "ByteF64FxIndexMap<8, CoefficientThreshold>",
+    );
+    // benchmark_suite_trotter::<config::indexmap::ByteGxHashF64<2, CoefficientThreshold>>(
+    //     c,
+    //     "ByteF64GxIndexMap<2, CoefficientThreshold>",
+    // );
+}
+
+criterion_group!(benches, trotter_benchmarks);
+criterion_main!(benches);

--- a/crates/ppvm-runtime/benches/trotter.rs
+++ b/crates/ppvm-runtime/benches/trotter.rs
@@ -57,6 +57,7 @@ pub fn benchmark_suite_trotter<T: Config<Coeff = f64, Strategy = CoefficientThre
     let mut state: PauliSum<T> = PauliSum::builder()
         .n_qubits(n_qubits)
         .strategy(strat)
+        .capacity(n_qubits.pow(3))
         .build();
 
     // initial state: let's calculate the expectation value of Sum(Z(i))

--- a/crates/ppvm-runtime/benches/trotter.rs
+++ b/crates/ppvm-runtime/benches/trotter.rs
@@ -57,7 +57,7 @@ pub fn benchmark_suite_trotter<T: Config<Coeff = f64, Strategy = CoefficientThre
     let mut state: PauliSum<T> = PauliSum::builder()
         .n_qubits(n_qubits)
         .strategy(strat)
-        .capacity(n_qubits.pow(3))
+        .capacity(n_qubits.pow(2))
         .build();
 
     // initial state: let's calculate the expectation value of Sum(Z(i))

--- a/crates/ppvm-runtime/src/strategy.rs
+++ b/crates/ppvm-runtime/src/strategy.rs
@@ -39,7 +39,9 @@ impl Default for MaxPauliWeight {
 
 impl Strategy for MaxPauliWeight {
     fn capacity(&self, n_qubits: usize) -> usize {
-        (0..=self.0).map(|k| binomial(n_qubits, k)).sum()
+        // the number here should scale binomially, but that can get large
+        // since the capacity has a direct impact on performance, let's be conservative
+        n_qubits * 10
     }
 
     fn truncate<S, V, H, M>(&self, map: &mut M)
@@ -64,7 +66,8 @@ impl Default for CoefficientThreshold {
 
 impl Strategy for CoefficientThreshold {
     fn capacity(&self, n_qubits: usize) -> usize {
-        1 << n_qubits
+        // clearing maps scales as O(capacity), so let's be conservative here
+        n_qubits * 10
     }
 
     fn truncate<S, V, H, M>(&self, map: &mut M)

--- a/crates/ppvm-runtime/src/strategy.rs
+++ b/crates/ppvm-runtime/src/strategy.rs
@@ -1,5 +1,3 @@
-use num::integer::binomial;
-
 use crate::traits::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]

--- a/crates/ppvm-runtime/src/sum/ops.rs
+++ b/crates/ppvm-runtime/src/sum/ops.rs
@@ -112,7 +112,6 @@ where
 {
     fn add_assign(&mut self, rhs: PauliSum<T>) {
         debug_assert_eq!(self.n_qubits(), rhs.n_qubits());
-        debug_assert!(self.len() + rhs.len() <= self.capacity());
         self.extend(rhs.into_iter())
     }
 }
@@ -125,7 +124,6 @@ where
 {
     fn add_assign(&mut self, rhs: &'a PauliSum<T>) {
         debug_assert_eq!(self.n_qubits(), rhs.n_qubits());
-        debug_assert!(self.len() + rhs.len() <= self.capacity());
         self.extend(rhs.data().iter().map(|(k, v)| (k.clone(), v.clone())))
     }
 }
@@ -139,7 +137,6 @@ where
     fn add_assign(&mut self, rhs: (P, T::Coeff)) {
         let key = rhs.0.into();
         debug_assert_eq!(self.n_qubits(), key.n_qubits());
-        debug_assert!(self.len() + 1 <= self.capacity());
         ACMapAddAssign::add_assign(self.data_mut(), key, rhs.1);
     }
 }
@@ -153,7 +150,6 @@ where
     fn add_assign(&mut self, rhs: P) {
         let key = rhs.into();
         debug_assert_eq!(self.n_qubits(), key.n_qubits());
-        debug_assert!(self.len() + 1 <= self.capacity());
         ACMapAddAssign::add_assign(self.data_mut(), key, T::Coeff::one());
     }
 }

--- a/examples/trotter.rs
+++ b/examples/trotter.rs
@@ -18,7 +18,11 @@ fn main() {
     let j = 1.0 / 8.0 * h;
 
     let strat = CoefficientThreshold(1e-6);
-    let mut state: State = PauliSum::builder().n_qubits(n).strategy(strat).build();
+    let mut state: State = PauliSum::builder()
+        .n_qubits(n)
+        .strategy(strat)
+        .capacity(n.pow(3)) // NOTE: the capacity setting has a big impact on performance
+        .build();
 
     // initial state: let's calculate the expectation value of Sum(Z(i))
     let tmp = vec!['I'; n];

--- a/examples/trotter.rs
+++ b/examples/trotter.rs
@@ -21,7 +21,7 @@ fn main() {
     let mut state: State = PauliSum::builder()
         .n_qubits(n)
         .strategy(strat)
-        .capacity(n.pow(3)) // NOTE: the capacity setting has a big impact on performance
+        .capacity(n.pow(2)) // NOTE: the capacity setting has a big impact on performance
         .build();
 
     // initial state: let's calculate the expectation value of Sum(Z(i))


### PR DESCRIPTION
* Sets the capacity in trotter example & benchmarks
* Adds a benchmark for trotter as function of qubit number
* Changes the default capacity for strategies