### PR TITLE
Workable version of loss & reset

### DIFF
--- a/crates/ppvm-runtime/src/char.rs
+++ b/crates/ppvm-runtime/src/char.rs
@@ -6,6 +6,7 @@ pub enum Pauli {
     X = 1, // 0b01
     Z = 2, // 0b10
     Y = 3, // 0b11
+    L = 4, // Projector on leakage state
 }
 
 impl std::fmt::Display for Pauli {
@@ -15,6 +16,7 @@ impl std::fmt::Display for Pauli {
             Pauli::X => write!(f, "X"),
             Pauli::Y => write!(f, "Y"),
             Pauli::Z => write!(f, "Z"),
+            Pauli::L => write!(f, "L"),
         }
     }
 }

--- a/crates/ppvm-runtime/src/phase/clifford.rs
+++ b/crates/ppvm-runtime/src/phase/clifford.rs
@@ -10,26 +10,43 @@ where
     H: BuildHasher + Clone + Default,
 {
     fn x(&mut self, index: usize) {
+        if self.word.lbits[index] {
+            // NOTE: loss is not affected by any gates
+            // the key here is that e.g. X the gate is different from PauliX (PauliX * L == 0)
+            return;
+        }
         let phase = (self.word.zbits[index]) as u8;
         self.word.x(index);
         self.add_phase(phase << 1);
     }
     fn y(&mut self, index: usize) {
+        if self.word.lbits[index] {
+            return;
+        }
         let phase = (self.word.xbits[index] ^ self.word.zbits[index]) as u8;
         self.word.y(index);
         self.add_phase(phase << 1);
     }
     fn z(&mut self, index: usize) {
+        if self.word.lbits[index] {
+            return;
+        }
         let phase = (self.word.xbits[index]) as u8;
         self.word.z(index);
         self.add_phase(phase << 1);
     }
     fn h(&mut self, index: usize) {
+        if self.word.lbits[index] {
+            return;
+        }
         let phase = (self.word.xbits[index] & self.word.zbits[index]) as u8;
         self.word.h(index);
         self.add_phase(phase << 1);
     }
     fn s(&mut self, index: usize) {
+        if self.word.lbits[index] {
+            return;
+        }
         let phase = (self.word.xbits[index] & !self.word.zbits[index]) as u8;
         self.word.s(index);
         self.add_phase(phase << 1);
@@ -39,6 +56,9 @@ where
         // xx zz    xx zz
         // 11 11 -> 10 01, 2
         // 10 01 -> 11 11, 2
+        if self.word.lbits[control] || self.word.lbits[target] {
+            return;
+        }
         let phase = ((self.word.xbits[control] & self.word.zbits[target])
             & (self.word.xbits[target] == self.word.zbits[control])) as u8;
         self.word.cnot(control, target);
@@ -48,6 +68,9 @@ where
         // phase = 11 10, 11 01 = 11 ab where a ^ b = 1
         // 11 01 -> 11 10, 2
         // 11 10 -> 11 01, 2
+        if self.word.lbits[control] || self.word.lbits[target] {
+            return;
+        }
         let phase = ((self.word.xbits[control] & self.word.xbits[target])
             & (self.word.zbits[control] ^ self.word.zbits[target])) as u8;
         self.word.cz(control, target);

--- a/crates/ppvm-runtime/src/sum/clifford.rs
+++ b/crates/ppvm-runtime/src/sum/clifford.rs
@@ -5,6 +5,11 @@ macro_rules! map_scale {
         fn $name(&mut self, $($index: usize),*) {
             self.scale(|k, v| {
                 let mut p: PhasedPauliWord<T::Storage, T::BuildHasher> = k.clone().into();
+                let l = p.word.lbits;
+                if $( l[$index] )||* {
+                    *v *= 0.0;
+                    return;
+                }
                 p.$name($($index),*);
                 if !p.is_positive() {
                     *v *= -1.0;
@@ -15,11 +20,40 @@ macro_rules! map_scale {
 }
 
 macro_rules! map_word {
-    ($name:ident, $($index:ident),*) => {
-        fn $name(&mut self, $($index: usize),*) {
+    ($name:ident, $index:ident) => {
+        fn $name(&mut self, $index: usize) {
             self.map_add(|k, v| {
                 let mut p: PhasedPauliWord<T::Storage, T::BuildHasher> = k.clone().into();
-                p.$name($($index),*);
+
+                let l = p.word.lbits;
+                if l[$index] {
+                    return (p.word, v.clone() * 0.0);
+                }
+
+                p.$name($index);
+                if p.is_positive() {
+                    (p.word, v.clone())
+                } else {
+                    (p.word, -v.clone())
+                }
+            })
+        }
+    };
+    ($name:ident, $first:ident, $second:ident) => {
+        fn $name(&mut self, $first: usize, $second: usize) {
+            self.map_add(|k, v| {
+                let mut p: PhasedPauliWord<T::Storage, T::BuildHasher> = k.clone().into();
+
+                let l = p.word.lbits;
+                if l[$second] {
+                    return (p.word, v.clone() * 0.0);
+                }
+
+                if l[$first] {
+                    return (p.word, v.clone());
+                }
+
+                p.$name($first, $second);
                 if p.is_positive() {
                     (p.word, v.clone())
                 } else {

--- a/crates/ppvm-runtime/src/sum/clifford.rs
+++ b/crates/ppvm-runtime/src/sum/clifford.rs
@@ -3,13 +3,9 @@ use crate::{config::Config, phase::PhasedPauliWord, sum::PauliSum, traits::Cliff
 macro_rules! map_scale {
     ($name:ident, $($index:ident),*) => {
         fn $name(&mut self, $($index: usize),*) {
+            // TODO: we could check for leakage states here to avoid cloning
             self.scale(|k, v| {
                 let mut p: PhasedPauliWord<T::Storage, T::BuildHasher> = k.clone().into();
-                let l = p.word.lbits;
-                if $( l[$index] )||* {
-                    *v *= 0.0;
-                    return;
-                }
                 p.$name($($index),*);
                 if !p.is_positive() {
                     *v *= -1.0;
@@ -20,40 +16,12 @@ macro_rules! map_scale {
 }
 
 macro_rules! map_word {
-    ($name:ident, $index:ident) => {
-        fn $name(&mut self, $index: usize) {
+    ($name:ident, $($index:ident),*) => {
+        fn $name(&mut self, $($index: usize),*) {
+            // TODO: we could check for leakage states here to avoid cloning
             self.map_add(|k, v| {
                 let mut p: PhasedPauliWord<T::Storage, T::BuildHasher> = k.clone().into();
-
-                let l = p.word.lbits;
-                if l[$index] {
-                    return (p.word, v.clone() * 0.0);
-                }
-
-                p.$name($index);
-                if p.is_positive() {
-                    (p.word, v.clone())
-                } else {
-                    (p.word, -v.clone())
-                }
-            })
-        }
-    };
-    ($name:ident, $first:ident, $second:ident) => {
-        fn $name(&mut self, $first: usize, $second: usize) {
-            self.map_add(|k, v| {
-                let mut p: PhasedPauliWord<T::Storage, T::BuildHasher> = k.clone().into();
-
-                let l = p.word.lbits;
-                if l[$second] {
-                    return (p.word, v.clone() * 0.0);
-                }
-
-                if l[$first] {
-                    return (p.word, v.clone());
-                }
-
-                p.$name($first, $second);
+                p.$name($($index),*);
                 if p.is_positive() {
                     (p.word, v.clone())
                 } else {

--- a/crates/ppvm-runtime/src/sum/noise.rs
+++ b/crates/ppvm-runtime/src/sum/noise.rs
@@ -11,7 +11,7 @@ where
     fn pauli_error(&mut self, addr0: usize, p: [<T as Config>::Coeff; 3]) {
         self.scale(|k, v| {
             match k.get(addr0) {
-                Pauli::I => {}
+                Pauli::I | Pauli::L => {}
                 Pauli::X => {
                     *v *= 1.0f64 - 2.0f64 * p[1].clone() - 2.0f64 * p[2].clone();
                 }
@@ -214,6 +214,7 @@ where
                     - 2.0f64 * p[6].clone()
                     - 2.0f64 * p[7].clone();
             }
+            _ => {unimplemented!("Need to handle leakage states in two-qubit pauli error")}
         })
     }
 }

--- a/crates/ppvm-runtime/src/sum/noise.rs
+++ b/crates/ppvm-runtime/src/sum/noise.rs
@@ -214,7 +214,46 @@ where
                     - 2.0f64 * p[6].clone()
                     - 2.0f64 * p[7].clone();
             }
-            _ => {unimplemented!("Need to handle leakage states in two-qubit pauli error")}
+            _ => {
+                unimplemented!("Need to handle leakage states in two-qubit pauli error")
+            }
         })
+    }
+}
+
+impl<T: Config> LossChannel<T> for PauliSum<T>
+where
+    f64: std::ops::Sub<T::Coeff, Output = T::Coeff>,
+{
+    fn loss_channel(&mut self, addr0: usize, p: T::Coeff) {
+        self.map_insert(|k, v| match k.get(addr0) {
+            Pauli::L => {
+                let new_v = v.clone() * p.clone();
+                let mut new_k = k.clone();
+                new_k.set(addr0, Pauli::I);
+                Some((new_k, new_v))
+            }
+            Pauli::I | Pauli::X | Pauli::Y | Pauli::Z => {
+                *v *= 1.0f64 - p.clone();
+                None
+            }
+        });
+    }
+}
+
+impl<T: Config> ResetLossChannel<T> for PauliSum<T> {
+    fn reset_loss_channel(&mut self, addr0: usize) {
+        self.map_insert(|k, v| match k.get(addr0) {
+            Pauli::L => {
+                *v *= 0.0;
+                None
+            }
+            Pauli::I | Pauli::Z => {
+                let mut new_k = k.clone();
+                new_k.set(addr0, Pauli::L);
+                Some((new_k, v.clone()))
+            }
+            Pauli::X | Pauli::Y => None,
+        });
     }
 }

--- a/crates/ppvm-runtime/src/sum/snapshots/ppvm_runtime__sum__data__tests__pauli_sum_creation-5.snap
+++ b/crates/ppvm-runtime/src/sum/snapshots/ppvm_runtime__sum__data__tests__pauli_sum_creation-5.snap
@@ -2,4 +2,4 @@
 source: crates/ppvm-runtime/src/sum/data.rs
 expression: sum.to_string()
 ---
-3.000 * IIII + 3.000 * XIII + 1.000 * IYII
+3.000 * IIII + 1.000 * IYII + 3.000 * XIII

--- a/crates/ppvm-runtime/src/traits/mod.rs
+++ b/crates/ppvm-runtime/src/traits/mod.rs
@@ -15,7 +15,10 @@ pub use map::{
     ACMap, ACMapAddAssign, ACMapBase, ACMapConsume, ACMapContains, ACMapInsert, ACMapIter,
     ACMapMulAssign, ACMapRetain, ACMapScale,
 };
-pub use noise::{AmplitudeDamping, Depolarizing, PauliError, PauliErrorAll, TwoQubitPauliError};
+pub use noise::{
+    AmplitudeDamping, Depolarizing, LossChannel, PauliError, PauliErrorAll, ResetLossChannel,
+    TwoQubitPauliError,
+};
 pub use storage::PauliStorage;
 pub use strategy::{NoStrategy, Strategy};
 pub use trace::Trace;

--- a/crates/ppvm-runtime/src/traits/noise.rs
+++ b/crates/ppvm-runtime/src/traits/noise.rs
@@ -21,3 +21,11 @@ pub trait Depolarizing<T: Config> {
 pub trait AmplitudeDamping<T: Config> {
     fn amplitude_damping(&mut self, addr0: usize, gamma: T::Coeff);
 }
+
+pub trait LossChannel<T: Config> {
+    fn loss_channel(&mut self, addr0: usize, p: T::Coeff);
+}
+
+pub trait ResetLossChannel<T: Config> {
+    fn reset_loss_channel(&mut self, addr0: usize);
+}

--- a/crates/ppvm-runtime/src/word/clifford.rs
+++ b/crates/ppvm-runtime/src/word/clifford.rs
@@ -31,6 +31,9 @@ where
         // H * X * H = Z    10 -> 01, 0
         // H * Z * H = X    01 -> 10, 0
         // H * Y * H = -Y   11 -> 11, 1
+        if self.lbits[index] {
+            return;
+        }
         let index_x = self.xbits[index];
         let index_z = self.zbits[index];
         self.xbits.set(index, index_z);
@@ -42,6 +45,9 @@ where
         // S * X * S = Y    10 -> 11, 0
         // S * Z * S = Z    01 -> 01, 0
         // S * Y * S = -X   11 -> 10, 1
+        if self.lbits[index] {
+            return;
+        }
         let z = self.xbits[index] ^ self.zbits[index];
         self.zbits.set(index, z);
         self.rehash();
@@ -67,6 +73,9 @@ where
         // CNOT * YX * CNOT == YI,  11 10 -> 10 10, 0
         // CNOT * YY * CNOT == -XZ, 11 11 -> 10 01, 1
         // CNOT * YZ * CNOT == XY,  10 11 -> 11 01, 0
+        if self.lbits[control] || self.lbits[target] {
+            return;
+        }
         let control_z = self.zbits[target] ^ self.zbits[control];
         let target_x = self.xbits[control] ^ self.xbits[target];
         self.zbits.set(control, control_z);
@@ -101,6 +110,10 @@ where
         // xx: 01, 00 -> 10, 01 -> 11, 10 -> 00, 11 -> 01
         // xx: 10, 00 -> 01, 01 -> 00, 10 -> 11, 11 -> 10
         // xx: 11, 00 -> 11, 01 -> 10, 10 -> 01, 11 -> 00
+
+        if self.lbits[control] || self.lbits[target] {
+            return;
+        }
 
         // flip the control z if target x is 1
         let control_z = self.zbits[control] ^ self.xbits[target];

--- a/crates/ppvm-runtime/src/word/data.rs
+++ b/crates/ppvm-runtime/src/word/data.rs
@@ -8,6 +8,7 @@ use std::ops::Index;
 pub struct PauliWord<A: PauliStorage, S = fxhash::FxBuildHasher> {
     pub xbits: BitArray<A>,
     pub zbits: BitArray<A>,
+    pub lbits: BitArray<A>,
     /// Number of qubits
     nqubits: usize,
     hash_cache: u64,
@@ -26,7 +27,9 @@ impl<A: PauliStorage, S> Eq for PauliWord<A, S> {}
 
 impl<A: PauliStorage, S> PartialEq for PauliWord<A, S> {
     fn eq(&self, other: &Self) -> bool {
-        self.xbits.data == other.xbits.data && self.zbits.data == other.zbits.data
+        self.xbits.data == other.xbits.data
+            && self.zbits.data == other.zbits.data
+            && self.lbits.data == other.lbits.data
     }
 }
 
@@ -36,6 +39,7 @@ impl<A: PauliStorage, S: BuildHasher + Clone + Default> PauliWord<A, S> {
         Self {
             xbits: BitArray::ZERO,
             zbits: BitArray::ZERO,
+            lbits: BitArray::ZERO,
             nqubits,
             hash_cache: 0,
             _phantom: std::marker::PhantomData,
@@ -48,7 +52,7 @@ impl<A: PauliStorage, S: BuildHasher + Clone + Default> PauliWord<A, S> {
 
     pub fn weight(&self) -> usize {
         (0..self.nqubits)
-            .filter(|&i| self.xbits[i] || self.zbits[i])
+            .filter(|&i| self.xbits[i] || self.zbits[i] || self.lbits[i]) // TODO: should we actually count L bits?
             .count()
     }
 
@@ -57,6 +61,7 @@ impl<A: PauliStorage, S: BuildHasher + Clone + Default> PauliWord<A, S> {
         let mut hasher = S::default().build_hasher();
         self.xbits.data.hash(&mut hasher);
         self.zbits.data.hash(&mut hasher);
+        self.lbits.data.hash(&mut hasher);
         self.hash_cache = hasher.finish();
     }
 
@@ -65,11 +70,13 @@ impl<A: PauliStorage, S: BuildHasher + Clone + Default> PauliWord<A, S> {
         if index >= self.nqubits {
             panic!("Index out of bounds");
         }
-        match (self.xbits[index], self.zbits[index]) {
-            (false, false) => Pauli::I,
-            (false, true) => Pauli::Z,
-            (true, false) => Pauli::X,
-            (true, true) => Pauli::Y,
+        match (self.xbits[index], self.zbits[index], self.lbits[index]) {
+            (false, false, false) => Pauli::I,
+            (false, true, false) => Pauli::Z,
+            (true, false, false) => Pauli::X,
+            (true, true, false) => Pauli::Y,
+            (false, false, true) => Pauli::L,
+            _ => panic!("Invalid Pauli representation"),
         }
     }
 
@@ -101,6 +108,7 @@ impl<A: PauliStorage, S: BuildHasher + Clone + Default> PauliWord<A, S> {
         for (i, &idx) in indices.iter().enumerate() {
             self.xbits.set(idx, values.xbits[i]);
             self.zbits.set(idx, values.zbits[i]);
+            self.lbits.set(idx, values.lbits[i]);
         }
         self.rehash();
     }
@@ -113,13 +121,16 @@ impl<A: PauliStorage, S: BuildHasher + Clone + Default> PauliWord<A, S> {
         let n_qubits = slice.len();
         let mut xbits = BitArray::ZERO;
         let mut zbits = BitArray::ZERO;
+        let mut lbits = BitArray::ZERO;
         for (i, idx) in slice.into_iter().enumerate() {
             xbits.set(i, self.xbits[idx]);
             zbits.set(i, self.zbits[idx]);
+            lbits.set(i, self.lbits[idx]);
         }
         let mut ret = Self {
             xbits,
             zbits,
+            lbits,
             nqubits: n_qubits,
             hash_cache: 0,
             _phantom: std::marker::PhantomData,
@@ -134,10 +145,11 @@ impl<A: PauliStorage, S: BuildHasher + Clone + Default> PauliWord<A, S> {
             panic!("Index out of bounds");
         }
         match pauli {
-            Pauli::I => !self.xbits[index] && !self.zbits[index],
-            Pauli::X => self.xbits[index] && !self.zbits[index],
-            Pauli::Z => !self.xbits[index] && self.zbits[index],
-            Pauli::Y => self.xbits[index] && self.zbits[index],
+            Pauli::I => !self.xbits[index] && !self.zbits[index] && !self.lbits[index],
+            Pauli::X => self.xbits[index] && !self.zbits[index] && !self.lbits[index],
+            Pauli::Z => !self.xbits[index] && self.zbits[index] && !self.lbits[index],
+            Pauli::Y => self.xbits[index] && self.zbits[index] && !self.lbits[index],
+            Pauli::L => !self.xbits[index] && !self.zbits[index] && self.lbits[index],
         }
     }
 
@@ -150,18 +162,27 @@ impl<A: PauliStorage, S: BuildHasher + Clone + Default> PauliWord<A, S> {
             Pauli::I => {
                 self.xbits.set(index, false);
                 self.zbits.set(index, false);
+                self.lbits.set(index, false);
             }
             Pauli::X => {
                 self.xbits.set(index, true);
                 self.zbits.set(index, false);
+                self.lbits.set(index, false);
             }
             Pauli::Z => {
                 self.xbits.set(index, false);
                 self.zbits.set(index, true);
+                self.lbits.set(index, false);
             }
             Pauli::Y => {
                 self.xbits.set(index, true);
                 self.zbits.set(index, true);
+                self.lbits.set(index, false);
+            }
+            Pauli::L => {
+                self.xbits.set(index, false);
+                self.zbits.set(index, false);
+                self.lbits.set(index, true);
             }
         }
         self.rehash();
@@ -201,6 +222,7 @@ impl<A: PauliStorage, S> Ord for PauliWord<A, S> {
         self.xbits
             .cmp(&other.xbits)
             .then(self.zbits.cmp(&other.zbits))
+            .then(self.lbits.cmp(&other.lbits))
     }
 }
 
@@ -212,7 +234,8 @@ impl<A: PauliStorage, S> PartialOrd for PauliWord<A, S> {
         Some(
             self.xbits
                 .cmp(&other.xbits)
-                .then(self.zbits.cmp(&other.zbits)),
+                .then(self.zbits.cmp(&other.zbits))
+                .then(self.lbits.cmp(&other.lbits)),
         )
     }
 }
@@ -229,6 +252,7 @@ impl<A: PauliStorage, S: BuildHasher + Clone + Default> From<String> for PauliWo
         let mut chars = value.chars();
         let mut x = BitArray::ZERO;
         let mut z = BitArray::ZERO;
+        let mut l = BitArray::ZERO;
 
         let mut i = 0;
         while let Some(ch) = chars.next() {
@@ -249,6 +273,9 @@ impl<A: PauliStorage, S: BuildHasher + Clone + Default> From<String> for PauliWo
                     x.set(i, true);
                     z.set(i, true);
                 }
+                'L' => {
+                    l.set(i, true);
+                }
                 '_' => {
                     continue;
                 }
@@ -260,6 +287,7 @@ impl<A: PauliStorage, S: BuildHasher + Clone + Default> From<String> for PauliWo
         let mut ret = Self {
             xbits: x,
             zbits: z,
+            lbits: l,
             nqubits: n_qubits,
             hash_cache: 0,
             _phantom: std::marker::PhantomData,
@@ -291,11 +319,13 @@ impl<A: PauliStorage, S> Index<usize> for PauliWord<A, S> {
             panic!("Index out of bounds");
         }
 
-        match (self.xbits[index], self.zbits[index]) {
-            (false, false) => &Pauli::I,
-            (false, true) => &Pauli::Z,
-            (true, false) => &Pauli::X,
-            (true, true) => &Pauli::Y,
+        match (self.xbits[index], self.zbits[index], self.lbits[index]) {
+            (false, false, false) => &Pauli::I,
+            (false, true, false) => &Pauli::Z,
+            (true, false, false) => &Pauli::X,
+            (true, true, false) => &Pauli::Y,
+            (false, false, true) => &Pauli::L,
+            _ => panic!("Invalid Pauli representation"),
         }
     }
 }

--- a/crates/ppvm-runtime/src/word/mul.rs
+++ b/crates/ppvm-runtime/src/word/mul.rs
@@ -22,10 +22,16 @@ where
 {
     fn mul_assign(&mut self, rhs: Self) {
         for i in 0..self.n_qubits() {
-            let x_i = self.xbits[i] ^ rhs.xbits[i];
-            let z_i = self.zbits[i] ^ rhs.zbits[i];
+            // TODO: this should actually return 0 if there are L bits in either
+            if self.lbits[i] || rhs.lbits[i] {
+                panic!("Multiplication involving L bits is not defined");
+            }
+            let l_i = self.lbits[i] & rhs.lbits[i];
+            let x_i = (self.xbits[i] ^ rhs.xbits[i]) & !l_i;
+            let z_i = (self.zbits[i] ^ rhs.zbits[i]) & !l_i;
             self.xbits.set(i, x_i);
             self.zbits.set(i, z_i);
+            self.lbits.set(i, l_i);
         }
         self.rehash();
     }

--- a/examples/loss.rs
+++ b/examples/loss.rs
@@ -1,0 +1,169 @@
+use ppvm_runtime::prelude::*;
+
+fn test_reset_channel() {
+    let mut state = PauliSum::<config::fxhash::Byte<1, f64>>::builder()
+        .n_qubits(1)
+        .build();
+
+    state += ("X", 1.0);
+    println!("Before {}", state);
+    state.reset_loss_channel(0);
+    println!("After {}", state);
+
+    let mut state = PauliSum::<config::fxhash::Byte<1, f64>>::builder()
+        .n_qubits(1)
+        .build();
+
+    state += ("Y", 1.0);
+    println!("Before {}", state);
+    state.reset_loss_channel(0);
+    println!("After {}", state);
+
+    let mut state = PauliSum::<config::fxhash::Byte<1, f64>>::builder()
+        .n_qubits(1)
+        .build();
+
+    state += ("I", 1.0);
+    println!("Before {}", state);
+    state.reset_loss_channel(0);
+    println!("After {}", state);
+
+    let mut state = PauliSum::<config::fxhash::Byte<1, f64>>::builder()
+        .n_qubits(1)
+        .build();
+
+    state += ("Z", 1.0);
+    println!("Before {}", state);
+    state.reset_loss_channel(0);
+    println!("After {}", state);
+
+    let mut state = PauliSum::<config::fxhash::Byte<1, f64>>::builder()
+        .n_qubits(1)
+        .build();
+
+    state += ("L", 1.0);
+    println!("Before {}", state);
+    state.reset_loss_channel(0);
+    println!("After {}", state);
+}
+
+fn test_loss_channel() {
+    let mut state = PauliSum::<config::fxhash::Byte<1, f64>>::builder()
+        .n_qubits(1)
+        .build();
+
+    state += ("X", 1.0);
+    println!("Before {}", state);
+    state.loss_channel(0, 0.2);
+    println!("After {}", state);
+
+    let mut state = PauliSum::<config::fxhash::Byte<1, f64>>::builder()
+        .n_qubits(1)
+        .build();
+
+    state += ("Y", 1.0);
+    println!("Before {}", state);
+    state.loss_channel(0, 0.2);
+    println!("After {}", state);
+
+    let mut state = PauliSum::<config::fxhash::Byte<1, f64>>::builder()
+        .n_qubits(1)
+        .build();
+
+    state += ("I", 1.0);
+    println!("Before {}", state);
+    state.loss_channel(0, 0.2);
+    println!("After {}", state);
+
+    let mut state = PauliSum::<config::fxhash::Byte<1, f64>>::builder()
+        .n_qubits(1)
+        .build();
+
+    state += ("Z", 1.0);
+    println!("Before {}", state);
+    state.loss_channel(0, 0.2);
+    println!("After {}", state);
+
+    let mut state = PauliSum::<config::fxhash::Byte<1, f64>>::builder()
+        .n_qubits(1)
+        .build();
+
+    state += ("L", 1.0);
+    println!("Before {}", state);
+    state.loss_channel(0, 0.2);
+    println!("After {}", state);
+}
+
+fn test_single_qubit_loss() {
+    let mut state = PauliSum::<config::fxhash::Byte<1, f64>>::builder()
+        .n_qubits(1)
+        .build();
+
+    state += ("Z", 1.0);
+
+    state.reset_loss_channel(0);
+    println!("After reset loss channel: {}", state);
+
+    state.x(0);
+    state.x(0);
+
+    println!("After two X: {}", state);
+
+    state.loss_channel(0, 0.1);
+
+    state.x(0);
+
+    println!("Final state: {}", state);
+
+    let zero_pattern: PauliPattern = "Z?*".into();
+    let overlap = state.trace(&zero_pattern);
+    println!("Overlap with {}: {}", zero_pattern, overlap);
+}
+
+fn test_ghz() {
+    let mut state = PauliSum::<config::fxhash::Byte<2, f64>>::builder()
+        .n_qubits(2)
+        .build();
+
+    let p_l = 0.1;
+
+    state += ("ZZ", 1.0);
+
+    println!("Initial state: {}", state);
+
+    state.reset_loss_channel(0);
+    state.reset_loss_channel(1);
+
+    // Applying some identity gates shouldn't affect loss
+    state.x(0);
+    state.x(1);
+    state.x(0);
+    state.x(1);
+
+    state.loss_channel(0, p_l);
+    state.loss_channel(1, p_l);
+
+    println!("After loss channels: {}", state);
+    // state.loss_channel(1, 0.1);
+
+    state.cnot(0, 1);
+    state.h(0);
+
+    println!("Final state: {}", state);
+
+    let zero_pattern: PauliPattern = "Z?*".into();
+    let overlap = state.trace(&zero_pattern);
+    println!("Overlap with {}: {}", zero_pattern, overlap);
+
+    let prob = 0.5 + 0.5 * ((1.0 - p_l) * (1.0 - p_l) - 2.0 * p_l * (1.0 - p_l) + p_l * p_l);
+    println!("Expected overlap: {}", prob);
+
+    assert!((overlap - prob).abs() < 1e-10);
+}
+
+fn main() {
+    // test_reset_channel();
+    // test_loss_channel();
+    // test_single_qubit_loss();
+    test_ghz();
+}

--- a/examples/loss.rs
+++ b/examples/loss.rs
@@ -120,7 +120,9 @@ fn test_single_qubit_loss() {
     println!("Overlap with {}: {}", zero_pattern, overlap);
 }
 
-fn test_ghz() {
+fn test_ghz_final_loss() {
+    // GHZ state circuit, with loss channels at the end, causing uncorrelated ZZ
+    // expectation values some of the time.
     let mut state = PauliSum::<config::fxhash::Byte<2, f64>>::builder()
         .n_qubits(2)
         .build();
@@ -161,9 +163,49 @@ fn test_ghz() {
     assert!((overlap - prob).abs() < 1e-10);
 }
 
+fn test_ghz() {
+    let mut state = PauliSum::<config::fxhash::Byte<2, f64>>::builder()
+        .n_qubits(2)
+        .build();
+
+    let p_l = 0.1;
+
+    state += ("ZZ", 1.0);
+
+    println!("Initial state: {}", state);
+
+    state.reset_loss_channel(0);
+    state.reset_loss_channel(1);
+
+    state.loss_channel(0, p_l);
+    state.loss_channel(1, p_l);
+
+    println!("After loss channels: {}", state);
+
+    state.cnot(0, 1);
+
+    state.loss_channel(0, 2.0 * p_l);
+    state.h(0);
+
+    println!("Final state: {}", state);
+
+    let zero_pattern: PauliPattern = "Z?*".into();
+    let overlap = state.trace(&zero_pattern);
+    println!("Overlap with {}: {}", zero_pattern, overlap);
+
+    // in 2p_l cases, the first qubit is lost after hadamard
+    let prob = 2.0 * p_l
+        + (1.0 - 2.0 * p_l)
+            * (0.5 + 0.5 * ((1.0 - p_l) * (1.0 - p_l) - 2.0 * p_l * (1.0 - p_l) + p_l * p_l));
+    println!("Expected overlap: {}", prob);
+
+    assert!((overlap - prob).abs() < 1e-10);
+}
+
 fn main() {
     // test_reset_channel();
     // test_loss_channel();
     // test_single_qubit_loss();
+    // test_ghz_final_loss();
     test_ghz();
 }


### PR DESCRIPTION
This PR just serves as documentation. Here, I implemented  a working version channels that describe loss and a reset channel. The latter corresponds to moving loss population back into the $|0\rangle$ state, which is equivalent to counting a lost qubit as a 0 bit in a measurement. This was the tricky part which we need to faithfully describe what happens on hardware.

To capture this, I added another operator $L$ to the basis, which is just the projector on the leakage state. The remaining Pauli operators are unchanged, so the basis used here is

$$\\{I, X, Y, Z, L\\}$$

All operators except $L$ have a $0$ contribution to the leakage state. For example, $I = \text{diag}(1,1,0)$.
One point of confusion I originally ran into here is this: the operators used when applying gates **are no longer equal to the Pauli basis operators**. Specifically, any gate applied to $L$ should leave $L$ invariant. Otherwise, this would result in a 0 amplitude state.

The respective channels are:

### Reset

$$\mathcal{E}(P) = P, ~ P\in\{X, Y\}$$
$$\mathcal{E}(P) = P + L, ~ P\in \{I, Z\}$$
$$\mathcal{E}(L) = 0$$

### Loss channel

$$\mathcal{E}(P) = (1 - p_L) P, ~ P\in\{I, X, Y, Z\}$$
$$\mathcal{E}(L) = L + p_L I$$

## Implementation details

* Right now, I just added another list of bits `lbits` to `word`s. However, we only really need this when dealing with loss, so I'm not sure if we always want to pay this extra cost. We could think about separating the implementation into a `LossyPauliWord` and `LossyPauliSum` or something similar. This would come at the cost of quite some code duplication however. Just a design decision we need to make.
* The loss channel branches in $L$. Branches there are not too bad, since they scale with $p_L$ and any reasonable coefficient threshold truncation should take care of terms that are of higher order than $O(p_L ^ 3)$ given somewhat realistic loss numbers.
* The real problem, however, is the reset channel: this has to be applied at the end of the circuit (meaning at the beginning when doing PP), and branches in both $I$ and $Z$. However, there might be some tricks we can still pull. For example, we could assume that any word with a lot of $L$ contributions (e.g. $LLLXYZ$) will only have a minor contribution since it is in some sense proportional to $~\langle L\rangle ^ 3 = p_L ^ 3$ (neglecting strong correlations with $L$ for the moment). We could then come up with a custom truncation strategy to get rid of those terms (or simply assign a large wight to $L$?).

FYI, @Roger-luo @rafaelha .