### PR TITLE
chore: separate skill dirs + improve autotune workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,33 +10,5 @@ ppvm-python/extended_tests/stim/stim-programs/
 
 # Managed by ion
 CLAUDE.md
-.agents/skills/ion-cli
-.claude/skills/ion-cli
-.agents/skills/receiving-code-review
-.claude/skills/receiving-code-review
-.agents/skills/requesting-code-review
-.claude/skills/requesting-code-review
-.agents/skills/using-git-worktrees
-.claude/skills/using-git-worktrees
-.agents/skills/brainstorming
-.claude/skills/brainstorming
-.agents/skills/dispatching-parallel-agents
-.claude/skills/dispatching-parallel-agents
-.agents/skills/executing-plans
-.claude/skills/executing-plans
-.agents/skills/finishing-a-development-branch
-.claude/skills/finishing-a-development-branch
-.agents/skills/subagent-driven-development
-.claude/skills/subagent-driven-development
-.agents/skills/systematic-debugging
-.claude/skills/systematic-debugging
-.agents/skills/test-driven-development
-.claude/skills/test-driven-development
-.agents/skills/using-superpowers
-.claude/skills/using-superpowers
-.agents/skills/verification-before-completion
-.claude/skills/verification-before-completion
-.agents/skills/writing-plans
-.claude/skills/writing-plans
-.agents/skills/writing-skills
-.claude/skills/writing-skills
+.agents/skills/
+.claude/skills/

--- a/Ion.lock
+++ b/Ion.lock
@@ -1,9 +1,15 @@
 [[skill]]
+name = "autotune"
+source = ""
+kind = "local"
+checksum = "sha256:bbf35167348a10718574c76d1a828f53685da8bd251a3fa5557b68cc06a567cd"
+
+[[skill]]
 name = "brainstorming"
 source = "https://github.com/obra/superpowers.git"
 kind = "git"
 path = "skills/brainstorming"
-commit = "eafe962b18f6c5dc70fb7c8cc7e83e61f4cdde06"
+commit = "917e5f53b16b115b70a3a355ed5f4993b9f8b73d"
 checksum = "sha256:1518efecf35139a9a5b9e60906b71de874af08322200fab18a54848cea8c15fe"
 
 [[skill]]
@@ -11,7 +17,7 @@ name = "dispatching-parallel-agents"
 source = "https://github.com/obra/superpowers.git"
 kind = "git"
 path = "skills/dispatching-parallel-agents"
-commit = "eafe962b18f6c5dc70fb7c8cc7e83e61f4cdde06"
+commit = "917e5f53b16b115b70a3a355ed5f4993b9f8b73d"
 checksum = "sha256:e21044ae7496fc285f1df9ff3fb518a3a20bea6f5216c1f59f4987e12c769a0a"
 
 [[skill]]
@@ -19,7 +25,7 @@ name = "executing-plans"
 source = "https://github.com/obra/superpowers.git"
 kind = "git"
 path = "skills/executing-plans"
-commit = "eafe962b18f6c5dc70fb7c8cc7e83e61f4cdde06"
+commit = "917e5f53b16b115b70a3a355ed5f4993b9f8b73d"
 checksum = "sha256:2f709d1a2c7564f8ce6a9bb707e7f5451117ba80f8e8e2302662c29bc61246a6"
 
 [[skill]]
@@ -27,15 +33,21 @@ name = "finishing-a-development-branch"
 source = "https://github.com/obra/superpowers.git"
 kind = "git"
 path = "skills/finishing-a-development-branch"
-commit = "eafe962b18f6c5dc70fb7c8cc7e83e61f4cdde06"
+commit = "917e5f53b16b115b70a3a355ed5f4993b9f8b73d"
 checksum = "sha256:9edba9a38684c060fdc38290f640e1dc0c37de286723ac9be73bacacf7cd6f3d"
+
+[[skill]]
+name = "ion-cli"
+source = ""
+kind = "local"
+checksum = "sha256:4207f3d4f43e93120acd5fdc26c60badab389e59d1a2caab74724ab0776a49ff"
 
 [[skill]]
 name = "receiving-code-review"
 source = "https://github.com/obra/superpowers.git"
 kind = "git"
 path = "skills/receiving-code-review"
-commit = "eafe962b18f6c5dc70fb7c8cc7e83e61f4cdde06"
+commit = "917e5f53b16b115b70a3a355ed5f4993b9f8b73d"
 checksum = "sha256:2760c85d4f4117b0006e7ba755f4bbd61f8f4c185f347999763c97f507274e30"
 
 [[skill]]
@@ -43,7 +55,7 @@ name = "requesting-code-review"
 source = "https://github.com/obra/superpowers.git"
 kind = "git"
 path = "skills/requesting-code-review"
-commit = "eafe962b18f6c5dc70fb7c8cc7e83e61f4cdde06"
+commit = "917e5f53b16b115b70a3a355ed5f4993b9f8b73d"
 checksum = "sha256:046180bd8519589b176d575e32a720c43cf6834f2e4d182277faf8943fe03564"
 
 [[skill]]
@@ -51,7 +63,7 @@ name = "subagent-driven-development"
 source = "https://github.com/obra/superpowers.git"
 kind = "git"
 path = "skills/subagent-driven-development"
-commit = "eafe962b18f6c5dc70fb7c8cc7e83e61f4cdde06"
+commit = "917e5f53b16b115b70a3a355ed5f4993b9f8b73d"
 checksum = "sha256:96697eb8dde8631ee7cd5e1cb29c6d7c0b8ef2869c0875dd2eedf07762e5feae"
 
 [[skill]]
@@ -59,7 +71,7 @@ name = "systematic-debugging"
 source = "https://github.com/obra/superpowers.git"
 kind = "git"
 path = "skills/systematic-debugging"
-commit = "eafe962b18f6c5dc70fb7c8cc7e83e61f4cdde06"
+commit = "917e5f53b16b115b70a3a355ed5f4993b9f8b73d"
 checksum = "sha256:6fddb1f3952f65f1f3a2ef267ae4ab6919ff70a8b36672ea908640ae21a34ea0"
 
 [[skill]]
@@ -67,7 +79,7 @@ name = "test-driven-development"
 source = "https://github.com/obra/superpowers.git"
 kind = "git"
 path = "skills/test-driven-development"
-commit = "eafe962b18f6c5dc70fb7c8cc7e83e61f4cdde06"
+commit = "917e5f53b16b115b70a3a355ed5f4993b9f8b73d"
 checksum = "sha256:126f1ebf6ccd414f42544f6e83d8cc5adb089e1108eaffb7c400701e37eecd9f"
 
 [[skill]]
@@ -75,7 +87,7 @@ name = "using-git-worktrees"
 source = "https://github.com/obra/superpowers.git"
 kind = "git"
 path = "skills/using-git-worktrees"
-commit = "eafe962b18f6c5dc70fb7c8cc7e83e61f4cdde06"
+commit = "917e5f53b16b115b70a3a355ed5f4993b9f8b73d"
 checksum = "sha256:52bbb4b6e80918e83e92a1514f3b3757712154c2a8a42de24919e48a794c54fc"
 
 [[skill]]
@@ -83,15 +95,15 @@ name = "using-superpowers"
 source = "https://github.com/obra/superpowers.git"
 kind = "git"
 path = "skills/using-superpowers"
-commit = "eafe962b18f6c5dc70fb7c8cc7e83e61f4cdde06"
-checksum = "sha256:35dd683a4d78ccf35bc8bf2b878a89900fa92e72bc2370a0daac0df086c4a41f"
+commit = "917e5f53b16b115b70a3a355ed5f4993b9f8b73d"
+checksum = "sha256:8ae2ec915dd4b5e4b758ee8110190fd792e85eb05d670fece942a76603e31cb8"
 
 [[skill]]
 name = "verification-before-completion"
 source = "https://github.com/obra/superpowers.git"
 kind = "git"
 path = "skills/verification-before-completion"
-commit = "eafe962b18f6c5dc70fb7c8cc7e83e61f4cdde06"
+commit = "917e5f53b16b115b70a3a355ed5f4993b9f8b73d"
 checksum = "sha256:9b446f0c7fe1cfb560b1d34439523b1a76d5f177290007b2c053a1c749a4a8ba"
 
 [[skill]]
@@ -99,7 +111,7 @@ name = "writing-plans"
 source = "https://github.com/obra/superpowers.git"
 kind = "git"
 path = "skills/writing-plans"
-commit = "eafe962b18f6c5dc70fb7c8cc7e83e61f4cdde06"
+commit = "917e5f53b16b115b70a3a355ed5f4993b9f8b73d"
 checksum = "sha256:90185bbb1bd9d4959826104c1c1900424180b8a4011f4432da886df599922788"
 
 [[skill]]
@@ -107,5 +119,5 @@ name = "writing-skills"
 source = "https://github.com/obra/superpowers.git"
 kind = "git"
 path = "skills/writing-skills"
-commit = "eafe962b18f6c5dc70fb7c8cc7e83e61f4cdde06"
+commit = "917e5f53b16b115b70a3a355ed5f4993b9f8b73d"
 checksum = "sha256:272ccd701f41b94e1119aaa99455a52cdb8e07283cb6a6aab32a7722d96bef45"

--- a/Ion.toml
+++ b/Ion.toml
@@ -1,5 +1,6 @@
 [skills]
 ion-cli = { type = "local" }
+autotune = { type = "local", path = "skills/autotune" }
 receiving-code-review = { source = "obra/superpowers/skills/receiving-code-review" }
 requesting-code-review = { source = "obra/superpowers/skills/requesting-code-review" }
 using-git-worktrees = { source = "obra/superpowers/skills/using-git-worktrees" }
@@ -14,10 +15,8 @@ using-superpowers = { source = "obra/superpowers/skills/using-superpowers" }
 verification-before-completion = { source = "obra/superpowers/skills/verification-before-completion" }
 writing-plans = { source = "obra/superpowers/skills/writing-plans" }
 writing-skills = { source = "obra/superpowers/skills/writing-skills" }
-autotune = { type = "local", path = "skills/autotune" }
 
 [options]
-skills-dir = "skills"
 
 [options.targets]
 claude = ".claude/skills"

--- a/skills/autotune/SKILL.md
+++ b/skills/autotune/SKILL.md
@@ -7,8 +7,6 @@ description: Run autonomous benchmark-driven performance tuning loops for this r
 
 Use this skill only for a narrow, measurable performance target. If the request is vague or broad, narrow it to one or two numeric metrics before starting.
 
-See `references/autotune-workflow.md` for the full loop, workflow, and helper script usage.
-
 ## Core Rules
 
 - Prefer targeted microbenchmarks and profiling over full benchmark suites.
@@ -18,11 +16,62 @@ See `references/autotune-workflow.md` for the full loop, workflow, and helper sc
 - Record every attempt with `keep`, `discard`, or `crash`.
 - Keep ledger updates in a separate commit from code changes so discarded results survive code reverts.
 
+## Branching Model
+
+The autotune loop uses a two-level branch structure to keep the user's starting branch clean:
+
+1. **Working branch** (`autotune/<task>`): Created at the start of the experiment from the user's current HEAD. All experiment commits (code changes, metric records, log entries, reverts) happen here. The user's starting branch is never touched.
+2. **Iteration branches** (created automatically by the Agent tool's `isolation: "worktree"` parameter): Each iteration's implementation work happens in an isolated worktree on its own branch. After benchmarking, the iteration branch is always merged back to the working branch — even if the result is discarded — so there is a complete record of every attempt.
+
+### Setup sequence
+
+```
+git checkout -b autotune/<task>   # create working branch from current HEAD
+```
+
+### After each iteration
+
+- **Always** merge the iteration's worktree branch back to the working branch. This preserves the implementation history regardless of outcome.
+- **If keep**: the merge stands as-is. Record result in a separate commit.
+- **If discard**: after merging, revert the merge commit on the working branch, then record the result. This way the attempt is visible in history but the code is undone.
+- **If crash**: same as discard — merge, revert, record.
+
 ## Experiment Setup
 
 Use `scripts/init_experiment.py` to create `docs/autotune/<task>/metric.toml` and `docs/autotune/<task>/log.md`.
+
+## The Iteration Loop
+
+See `references/autotune-workflow.md` for the detailed step-by-step. The high-level flow for each iteration:
+
+1. **Plan**: Read the ledger and log, choose one hypothesis.
+2. **Implement**: Dispatch a subagent with `isolation: "worktree"` to implement the approach. The subagent only writes code — it does not run benchmarks.
+3. **Benchmark**: The host agent runs the relevant microbenchmarks on the worktree code.
+4. **Integrate**: Merge the worktree branch to the working branch (always).
+5. **Decide**: If the metric improved, keep. Otherwise, revert the merge on the working branch.
+6. **Record**: Append the result to `metric.toml` and any findings to `log.md` in a separate commit.
+
+### Subagent Prompts
+
+When dispatching the implementation subagent, the prompt must be self-contained because the subagent has no memory of this conversation. Include:
+
+- What to optimize and why (the hypothesis).
+- Which files are in scope (crate `src/` directories only).
+- What NOT to touch (benchmarks, tests, docs beyond `docs/autotune/`).
+- Relevant findings from previous iterations (copy from `log.md`).
+- The specific benchmark command that will be used to measure (so the subagent understands the target).
+- Instruction to commit all changes before finishing.
+
+### Crash Policy
+
+- Fix obvious trivial failures (typo, missing import) and rerun.
+- Mark fundamentally broken ideas as `crash` and continue.
 
 ## Recording Results
 
 Use `scripts/record_result.py` to append benchmark data to `metric.toml`.
 Use `scripts/add_log_entry.py` to append durable findings to `log.md`.
+
+## Autonomy
+
+Once the experiment loop has begun, do NOT pause to ask the human if you should continue. The human may be away and expects you to work autonomously until manually interrupted. If you run out of ideas, think harder — re-read the code for new angles, try combining previous near-misses, try more radical approaches. The loop runs until the human interrupts.

--- a/skills/autotune/references/autotune-workflow.md
+++ b/skills/autotune/references/autotune-workflow.md
@@ -4,28 +4,96 @@
 
 - Ensure the target metric is numeric and available from a focused benchmark.
 - If no good target exists, inspect benchmarks or profile and propose one.
+- Identify the exact benchmark command (e.g., `cargo bench -p crate --bench micro -- "gates/x"`).
 
 ## 2. Prepare the experiment
 
-- Generate a memorable `<task>` name.
-- Create `docs/autotune/<task>/`.
-- Initialize `metric.toml` and `log.md`.
+1. Generate a memorable `<task>` name (e.g., `tableau-x-gate`).
+2. Run `scripts/init_experiment.py <task>` to create `docs/autotune/<task>/metric.toml` and `log.md`.
+3. Create the working branch: `git checkout -b autotune/<task>`.
+4. Run the baseline benchmark, record it with `scripts/record_result.py`, and commit.
 
 ## 3. Run one iteration
 
-1. Read the existing ledger and findings log.
-2. Choose one hypothesis.
-3. Create a worktree branch named `auto-tune-<task>-<approach>`.
-4. Create `docs/autotune/<task>/<approach>/prompts.md`.
-5. Dispatch a subagent to implement only the approach.
-6. Run the relevant microbenchmarks.
-7. Commit the code changes on the worktree branch first.
-8. If the code change wins, switch back to the canonical branch, integrate the code commit from the worktree branch there, and keep that code commit separate from the later ledger update.
-9. Append the measured winning result to the ledger on the canonical branch in a separate commit.
-10. If the code change loses or crashes, do not integrate the code commit into the canonical branch; still append the measured result to the ledger on the canonical branch in a separate commit so the attempt is preserved.
-11. Append any durable finding to `log.md`.
+### 3a. Plan the approach
+
+1. Read `docs/autotune/<task>/metric.toml` and `log.md`.
+2. Choose one hypothesis to test. Give it a short name (e.g., `simd-phase-update`).
+3. Create `docs/autotune/<task>/<approach>/prompts.md` describing the approach, target metrics, and relevant prior findings.
+
+### 3b. Implement via subagent in a worktree
+
+Dispatch an implementation subagent using the **Agent tool with `isolation: "worktree"`**. This creates an isolated git worktree automatically. The subagent:
+
+- Reads the prompts.md you wrote.
+- Implements the approach (edits only crate `src/` directories).
+- Does NOT run benchmarks — the host agent does that.
+- Commits all changes before finishing.
+
+Example Agent call:
+
+```
+Agent({
+  description: "Implement <approach>",
+  prompt: "<self-contained prompt with hypothesis, file scope, prior findings, and commit instruction>",
+  isolation: "worktree"
+})
+```
+
+The Agent tool returns the worktree path and branch name when the subagent makes changes.
+
+### 3c. Benchmark
+
+After the subagent returns, run the targeted microbenchmark **in the worktree directory** (use the returned path). Only run the benchmarks related to the target metric — not the full suite.
+
+### 3d. Integrate the worktree branch
+
+**Always merge the worktree branch to the working branch**, regardless of outcome. This preserves a record of every attempt in git history.
+
+```bash
+# Switch back to the working branch
+git checkout autotune/<task>
+# Merge the iteration branch
+git merge <worktree-branch> --no-ff -m "merge: autotune iteration <approach>"
+```
+
+### 3e. Decide: keep or discard
+
+- **If the metric improved (keep):** The merge stands. The code change is preserved on the working branch.
+- **If the metric regressed or is unchanged (discard):** Revert the merge commit on the working branch.
+  ```bash
+  git revert -m 1 HEAD --no-edit
+  ```
+- **If the subagent crashed:** Same as discard — merge, then revert.
+
+### 3f. Record the result
+
+In a **separate commit** on the working branch (not mixed with code changes):
+
+1. Append the benchmark data to `metric.toml` via `scripts/record_result.py`.
+2. Append any durable finding to `log.md` via `scripts/add_log_entry.py`.
+3. Commit these ledger updates.
+
+This separation ensures that discarded experiments still have their metrics recorded even after code reverts.
+
+### 3g. Clean up the worktree
+
+Remove the worktree directory (git does this automatically if you used the Agent tool's `isolation: "worktree"`, but verify it's cleaned up).
 
 ## 4. Crash policy
 
-- Fix obvious trivial failures and rerun.
-- Mark fundamentally broken ideas as `crash` and continue.
+- Fix obvious trivial failures (typo, missing import) and rerun.
+- Mark fundamentally broken ideas as `crash` and continue to the next iteration.
+
+## 5. Role separation summary
+
+| Responsibility | Host agent | Subagent (worktree) |
+|---|---|---|
+| Read ledger + choose hypothesis | Yes | No |
+| Write prompts.md | Yes | No |
+| Implement code changes | No | Yes |
+| Run benchmarks | Yes | No |
+| Merge worktree to working branch | Yes | No |
+| Decide keep/discard/revert | Yes | No |
+| Record results (metric.toml, log.md) | Yes | No |
+| Commit ledger updates | Yes | No |


### PR DESCRIPTION
## Summary
- Separate local and remote skill directories
- Improve autotune skill workflow with proper branching model, subagent isolation via worktrees, and merge-back discipline
- Add role separation table and self-contained subagent prompt checklist

## Test plan
- [x] Ran end-to-end test of new autotune workflow (create working branch, dispatch subagent with `isolation: "worktree"`, benchmark, merge back, revert on discard, record result in separate commit)
- [x] Verified user's starting branch remains untouched
- [x] Verified git history shows correct merge/revert structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)