### PR TITLE
refactor(traits): consolidate noise/Clifford impls and trim where clauses

### DIFF
--- a/crates/ppvm-runtime/src/loss/clifford.rs
+++ b/crates/ppvm-runtime/src/loss/clifford.rs
@@ -1,226 +1,12 @@
-use std::hash::BuildHasher;
-
-use super::data::LossyPauliWord;
-use crate::traits::{Clifford, CliffordExtensions, PauliStorage, PauliWordTrait};
-
-impl<A, H> Clifford for LossyPauliWord<A, H>
-where
-    A: PauliStorage,
-    H: BuildHasher + Clone + Default,
-{
-    fn x(&mut self, _index: usize) {
-        // X * I * X = I    00 -> 00, 0
-        // X * X * X = X    10 -> 10, 0
-        // X * Z * X = -Z   01 -> 01, 1
-        // X * Y * X = -Y.  11 -> 11, 1
-    }
-    fn y(&mut self, _index: usize) {
-        // Y * I * Y = I    00 -> 00, 0
-        // Y * X * Y = -X   10 -> 10, 1
-        // Y * Z * Y = -Z   01 -> 01, 1
-        // Y * Y * Y = Y    11 -> 11, 0
-    }
-    fn z(&mut self, _index: usize) {
-        // Z * I * Z = I    00 -> 00, 0
-        // Z * X * Z = -X   10 -> 10, 1
-        // Z * Z * Z = Z    01 -> 01, 0
-        // Z * Y * Z = -Y   11 -> 11, 1
-    }
-    fn h(&mut self, index: usize) {
-        // H * I * H = I    00 -> 00, 0
-        // H * X * H = Z    10 -> 01, 0
-        // H * Z * H = X    01 -> 10, 0
-        // H * Y * H = -Y   11 -> 11, 1
-        if self.lbits[index] {
-            // Hadamard on loss gives loss
-            return;
-        }
-        let index_x = self.xbits[index];
-        let index_z = self.zbits[index];
-        self.xbits.set(index, index_z);
-        self.zbits.set(index, index_x);
-        self.rehash();
-    }
-    fn s(&mut self, index: usize) {
-        // S * I * S = I    00 -> 00, 0
-        // S * X * S = Y    10 -> 11, 0
-        // S * Z * S = Z    01 -> 01, 0
-        // S * Y * S = -X   11 -> 10, 1
-        if self.lbits[index] {
-            // S on loss gives loss
-            return;
-        }
-        let z = self.xbits[index] ^ self.zbits[index];
-        self.zbits.set(index, z);
-        self.rehash();
-    }
-    fn cnot(&mut self, control: usize, target: usize) {
-        //                          xx zz    xx zz  phase
-        // CNOT * II * CNOT == II,  00 00 -> 00 00, 0
-        // CNOT * IX * CNOT == IX,  01 00 -> 01 00, 0
-        // CNOT * IZ * CNOT == ZZ,  00 01 -> 00 11, 0
-        // CNOT * IY * CNOT == ZY,  01 01 -> 01 11, 0
-
-        // CNOT * XI * CNOT == XX,  10 00 -> 11 00, 0
-        // CNOT * XX * CNOT == XI,  11 00 -> 10 00, 0
-        // CNOT * XY * CNOT == YZ,  11 01 -> 10 11, 0
-        // CNOT * XZ * CNOT == -YY, 10 01 -> 11 11, 1
-
-        // CNOT * ZI * CNOT == ZI,  00 10 -> 00 10, 0
-        // CNOT * ZX * CNOT == ZX,  01 10 -> 01 10, 0
-        // CNOT * ZY * CNOT == IY,  01 11 -> 01 01, 0
-        // CNOT * ZZ * CNOT == IZ,  00 11 -> 00 01, 0
-
-        // CNOT * YI * CNOT == YX,  10 10 -> 11 10, 0
-        // CNOT * YX * CNOT == YI,  11 10 -> 10 10, 0
-        // CNOT * YY * CNOT == -XZ, 11 11 -> 10 01, 1
-        // CNOT * YZ * CNOT == XY,  10 11 -> 11 01, 0
-        if self.lbits[control] || self.lbits[target] {
-            return;
-        }
-        let control_z = self.zbits[target] ^ self.zbits[control];
-        let target_x = self.xbits[control] ^ self.xbits[target];
-        self.zbits.set(control, control_z);
-        self.xbits.set(target, target_x);
-        self.rehash();
-    }
-    fn cz(&mut self, control: usize, target: usize) {
-        // CZ = |0><0| I + |1><1| Z
-        // CZ * II * CZ = II,   00 00 -> 00 00, 0
-        // CZ * IX * CZ = ZX,   01 00 -> 01 10, 0
-        // CZ * IY * CZ = ZY,   01 01 -> 01 11, 0
-        // CZ * IZ * CZ = ZZ,   00 01 -> 00 01, 0
-
-        // CZ * XI * CZ = XZ,   10 00 -> 10 01, 0
-        // CZ * XX * CZ = YY,   11 00 -> 11 11, 0
-        // CZ * XY * CZ = -YX,  11 01 -> 11 10, 1
-        // CZ * XZ * CZ = XI,   10 01 -> 10 00, 0
-
-        // CZ * ZI * CZ == ZI,  00 10 -> 00 10, 0
-        // CZ * ZX * CZ == IX,  01 10 -> 01 00, 0
-        // CZ * ZY * CZ == IY,  01 11 -> 01 01, 0
-        // CZ * ZZ * CZ == ZZ,  00 11 -> 00 11, 0
-
-        // CZ * YI * CZ == YZ,  10 10 -> 10 11, 0
-        // CZ * YX * CZ == -XY, 11 10 -> 11 01, 1
-        // CZ * YY * CZ == XX,  11 11 -> 11 00, 0
-        // CZ * YZ * CZ == YI,  10 11 -> 10 10, 0
-
-        // xx: identity
-        // zz:
-        // xx: 00, identity
-        // xx: 01, 00 -> 10, 01 -> 11, 10 -> 00, 11 -> 01
-        // xx: 10, 00 -> 01, 01 -> 00, 10 -> 11, 11 -> 10
-        // xx: 11, 00 -> 11, 01 -> 10, 10 -> 01, 11 -> 00
-
-        if self.lbits[control] || self.lbits[target] {
-            return;
-        }
-
-        // flip the control z if target x is 1
-        let control_z = self.zbits[control] ^ self.xbits[target];
-        self.zbits.set(control, control_z);
-        // flip the target z if control x is 1
-        let target_z = self.zbits[target] ^ self.xbits[control];
-        self.zbits.set(target, target_z);
-        self.rehash();
-    }
-}
-
-impl<A, H> CliffordExtensions for LossyPauliWord<A, H>
-where
-    A: PauliStorage,
-    H: BuildHasher + Clone + Default,
-{
-    // |    Gate    |  X  |  Y  |  Z  |
-    // |:----------:|:---:|:---:|:---:|
-    // |     s      | -Y  |  X  |  Z  |
-    // |   s_adj    |  Y  | -X  |  Z  |
-    // |   sqrt_x   |  X  | -Z  |  Y  |
-    // | sqrt*x*adj |  X  |  Z  | -Y  |
-    // |   sqrt_y   |  Z  |  Y  | -X  |
-    // | sqrt*y*adj | -Z  |  Y  |  X  |
-
-    #[inline]
-    fn s_adj(&mut self, addr0: usize) {
-        if self.lbits[addr0] {
-            return;
-        }
-        self.s(addr0);
-    }
-
-    #[inline]
-    fn sqrt_x(&mut self, addr0: usize) {
-        if self.lbits[addr0] {
-            return;
-        }
-        let x = self.xbits[addr0];
-        let z = self.zbits[addr0];
-        self.set_xbit(addr0, x ^ z);
-        self.rehash();
-    }
-
-    #[inline]
-    fn sqrt_y(&mut self, addr0: usize) {
-        if self.lbits[addr0] {
-            return;
-        }
-        let x = self.xbits[addr0];
-        let z = self.zbits[addr0];
-        self.set_xbit(addr0, z);
-        self.set_zbit(addr0, x);
-        self.rehash();
-    }
-
-    #[inline]
-    fn sqrt_x_adj(&mut self, addr0: usize) {
-        if self.lbits[addr0] {
-            return;
-        }
-        let x = self.xbits[addr0];
-        let z = self.zbits[addr0];
-        self.set_xbit(addr0, x ^ z);
-        self.rehash();
-    }
-
-    #[inline]
-    fn sqrt_y_adj(&mut self, addr0: usize) {
-        if self.lbits[addr0] {
-            return;
-        }
-        let x = self.xbits[addr0];
-        let z = self.zbits[addr0];
-        self.set_xbit(addr0, z);
-        self.set_zbit(addr0, x);
-        self.rehash();
-    }
-
-    // | CY  |  I  |  X  |  Y  |  Z  |
-    // |:---:|:---:|:---:|:---:|:---:|
-    // |  I  | II  | ZX  | IY  | ZZ  |
-    // |  X  | XY  | -YZ | XI  | YX  |
-    // |  Y  | YY  | XZ  | YI  | -XX |
-    // |  Z  | ZI  | IX  | ZY  | IZ  |
-
-    #[inline]
-    fn cy(&mut self, addr0: usize, addr1: usize) {
-        if self.lbits[addr0] || self.lbits[addr1] {
-            return;
-        }
-        let xc = self.xbits[addr0];
-        let zc = self.zbits[addr0];
-        let xt = self.xbits[addr1];
-        let zt = self.zbits[addr1];
-        self.set_zbit(addr0, zc ^ xt ^ zt);
-        self.set_xbit(addr1, xt ^ xc);
-        self.set_zbit(addr1, zt ^ xc);
-        self.rehash();
-    }
-}
+// Clifford behavior for `LossyPauliWord` is provided by the blanket impl
+// `impl<T: PauliWordTrait> Clifford for T` in `crate::traits::clifford`.
+// `LossyPauliWord::get_lbit` reports actual loss bits, so the gates correctly
+// no-op on lost qubits.
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::super::data::LossyPauliWord;
+    use crate::traits::{Clifford, CliffordExtensions};
 
     #[test]
     fn test_x() {
@@ -248,26 +34,6 @@ mod tests {
             assert_eq!((input, output.to_string()), (input, target.to_string()));
         }
     }
-
-    // CNOT * II * CNOT == II,  00 00 -> 00 00, 0
-    // CNOT * IX * CNOT == IX,  01 00 -> 01 00, 0
-    // CNOT * IZ * CNOT == ZZ,  00 01 -> 00 11, 0
-    // CNOT * IY * CNOT == ZY,  01 01 -> 01 11, 0
-
-    // CNOT * XI * CNOT == XX,  10 00 -> 11 00, 0
-    // CNOT * XX * CNOT == XI,  11 00 -> 10 00, 0
-    // CNOT * XY * CNOT == YZ,  11 01 -> 10 11, 0
-    // CNOT * XZ * CNOT == -YY, 10 01 -> 11 11, 1
-
-    // CNOT * ZI * CNOT == ZI,  00 10 -> 00 10, 0
-    // CNOT * ZX * CNOT == ZX,  01 10 -> 01 10, 0
-    // CNOT * ZY * CNOT == IY,  01 11 -> 01 01, 0
-    // CNOT * ZZ * CNOT == IZ,  00 11 -> 00 01, 0
-
-    // CNOT * YI * CNOT == YX,  10 10 -> 11 10, 0
-    // CNOT * YX * CNOT == YI,  11 10 -> 10 10, 0
-    // CNOT * YY * CNOT == -XZ, 11 11 -> 10 01, 1
-    // CNOT * YZ * CNOT == XY,  10 11 -> 11 01, 0
 
     #[test]
     fn test_cnot() {
@@ -306,7 +72,6 @@ mod tests {
 
     #[test]
     fn test_h() {
-        // NOTE: phase on "Y" not added in words
         for (input, target) in [("I", "I"), ("X", "Z"), ("Y", "Y"), ("Z", "X"), ("L", "L")] {
             let mut output: LossyPauliWord<u64> = LossyPauliWord::from(input);
             output.h(0);

--- a/crates/ppvm-runtime/src/sum/clifford.rs
+++ b/crates/ppvm-runtime/src/sum/clifford.rs
@@ -2,9 +2,8 @@ use crate::{
     config::Config,
     phase::PhasedPauliWord,
     sum::PauliSum,
-    traits::{Clifford, CliffordExtensions, PauliStorage, PauliWordTrait},
+    traits::{Clifford, CliffordExtensions, PauliWordTrait},
 };
-use std::hash::BuildHasher;
 
 macro_rules! map_word {
     ($name:ident, $($index:ident),*) => {
@@ -22,14 +21,11 @@ macro_rules! map_word {
     };
 }
 
-// NOTE: impl for PauliWord only; not a blanket, since PhasedPauliWord Clifford also isn't
-impl<S, H, T> Clifford for PauliSum<T>
-where
-    S: PauliStorage,
-    H: BuildHasher + Clone + Default,
-    T: Config<Storage = S, BuildHasher = H>,
-    T::PauliWordType: Clifford,
-{
+// Single- and two-qubit Clifford action on a `PauliSum`. Single-qubit gates
+// are specialised to bit-level updates so we avoid round-tripping through
+// `PhasedPauliWord`; the two-qubit gates still go through the macro because
+// their sign rules are easier to reuse from the `PhasedPauliWord` impl.
+impl<T: Config> Clifford for PauliSum<T> {
     #[inline]
     fn x(&mut self, index: usize) {
         // X conjugation: only flips sign for Z and Y (zbit set); word unchanged
@@ -105,13 +101,7 @@ where
     map_word!(cz, a, b);
 }
 
-impl<S, H, T> CliffordExtensions for PauliSum<T>
-where
-    S: PauliStorage,
-    H: BuildHasher + Clone + Default,
-    T: Config<Storage = S, BuildHasher = H>,
-    T::PauliWordType: Clifford + CliffordExtensions,
-{
+impl<T: Config> CliffordExtensions for PauliSum<T> {
     #[inline]
     fn s_adj(&mut self, addr0: usize) {
         // S†: same bit map as S; phase flip for Y (both bits set)

--- a/crates/ppvm-runtime/src/sum/noise.rs
+++ b/crates/ppvm-runtime/src/sum/noise.rs
@@ -10,16 +10,12 @@ fn pauli_code<W: PauliWordTrait>(word: &W, addr: usize) -> usize {
     (word.get_xbit(addr) as usize) | ((word.get_zbit(addr) as usize) << 1)
 }
 
-impl<T: Config> PauliError<T> for PauliSum<T>
-where
-    f64: std::ops::Mul<T::Coeff, Output = T::Coeff>
-        + std::ops::Add<T::Coeff, Output = T::Coeff>
-        + std::ops::Sub<T::Coeff, Output = T::Coeff>,
-{
+impl<T: Config> PauliError<T> for PauliSum<T> {
     fn pauli_error(&mut self, addr0: usize, p: [<T as Config>::Coeff; 3]) {
-        let x_factor = 1.0f64 - 2.0f64 * p[1].clone() - 2.0f64 * p[2].clone();
-        let z_factor = 1.0f64 - 2.0f64 * p[0].clone() - 2.0f64 * p[1].clone();
-        let y_factor = 1.0f64 - 2.0f64 * p[0].clone() - 2.0f64 * p[2].clone();
+        let one = T::Coeff::from(1.0);
+        let x_factor = one.clone() - p[1].clone() * 2.0 - p[2].clone() * 2.0;
+        let z_factor = one.clone() - p[0].clone() * 2.0 - p[1].clone() * 2.0;
+        let y_factor = one - p[0].clone() * 2.0 - p[2].clone() * 2.0;
 
         self.scale(move |k, v| {
             if k.get_lbit(addr0) {
@@ -36,195 +32,65 @@ where
     }
 }
 
-impl<T: Config> TwoQubitPauliError<T> for PauliSum<T>
-where
-    f64: std::ops::Mul<T::Coeff, Output = T::Coeff>
-        + std::ops::Add<T::Coeff, Output = T::Coeff>
-        + std::ops::Sub<T::Coeff, Output = T::Coeff>,
-{
+/// Helper: compute `1 - 2 * (p[i_0] + p[i_1] + ... + p[i_n])`.
+#[inline]
+fn one_minus_two_sum<C: Coefficient, const N: usize>(p: &[C; 15], indices: [usize; N]) -> C {
+    let mut acc = C::from(1.0);
+    for i in indices {
+        acc = acc - p[i].clone() * 2.0;
+    }
+    acc
+}
+
+impl<T: Config> TwoQubitPauliError<T> for PauliSum<T> {
     fn two_qubit_pauli_error(&mut self, addr0: usize, addr1: usize, p: [<T as Config>::Coeff; 15]) {
         self.scale(|k, v| match (k.get(addr0), k.get(addr1)) {
             (Pauli::I, Pauli::I) => {}
             (Pauli::I, Pauli::X) => {
-                *v *= 1.0f64
-                    - 2.0f64 * p[1].clone()
-                    - 2.0f64 * p[10].clone()
-                    - 2.0f64 * p[13].clone()
-                    - 2.0f64 * p[14].clone()
-                    - 2.0f64 * p[2].clone()
-                    - 2.0f64 * p[5].clone()
-                    - 2.0f64 * p[6].clone()
-                    - 2.0f64 * p[9].clone();
+                *v *= one_minus_two_sum(&p, [1, 10, 13, 14, 2, 5, 6, 9]);
             }
-
             (Pauli::I, Pauli::Y) => {
-                *v *= 1.0f64
-                    - 2.0f64 * p[0].clone()
-                    - 2.0f64 * p[10].clone()
-                    - 2.0f64 * p[12].clone()
-                    - 2.0f64 * p[14].clone()
-                    - 2.0f64 * p[2].clone()
-                    - 2.0f64 * p[4].clone()
-                    - 2.0f64 * p[6].clone()
-                    - 2.0f64 * p[8].clone();
+                *v *= one_minus_two_sum(&p, [0, 10, 12, 14, 2, 4, 6, 8]);
             }
-
             (Pauli::I, Pauli::Z) => {
-                *v *= 1.0f64
-                    - 2.0f64 * p[0].clone()
-                    - 2.0f64 * p[1].clone()
-                    - 2.0f64 * p[12].clone()
-                    - 2.0f64 * p[13].clone()
-                    - 2.0f64 * p[4].clone()
-                    - 2.0f64 * p[5].clone()
-                    - 2.0f64 * p[8].clone()
-                    - 2.0f64 * p[9].clone();
+                *v *= one_minus_two_sum(&p, [0, 1, 12, 13, 4, 5, 8, 9]);
             }
-
             (Pauli::X, Pauli::I) => {
-                *v *= 1.0f64
-                    - 2.0f64 * p[10].clone()
-                    - 2.0f64 * p[11].clone()
-                    - 2.0f64 * p[12].clone()
-                    - 2.0f64 * p[13].clone()
-                    - 2.0f64 * p[14].clone()
-                    - 2.0f64 * p[7].clone()
-                    - 2.0f64 * p[8].clone()
-                    - 2.0f64 * p[9].clone();
+                *v *= one_minus_two_sum(&p, [10, 11, 12, 13, 14, 7, 8, 9]);
             }
-
             (Pauli::X, Pauli::X) => {
-                *v *= 1.0f64
-                    - 2.0f64 * p[1].clone()
-                    - 2.0f64 * p[11].clone()
-                    - 2.0f64 * p[12].clone()
-                    - 2.0f64 * p[2].clone()
-                    - 2.0f64 * p[5].clone()
-                    - 2.0f64 * p[6].clone()
-                    - 2.0f64 * p[7].clone()
-                    - 2.0f64 * p[8].clone();
+                *v *= one_minus_two_sum(&p, [1, 11, 12, 2, 5, 6, 7, 8]);
             }
-
             (Pauli::X, Pauli::Y) => {
-                *v *= 1.0f64
-                    - 2.0f64 * p[0].clone()
-                    - 2.0f64 * p[11].clone()
-                    - 2.0f64 * p[13].clone()
-                    - 2.0f64 * p[2].clone()
-                    - 2.0f64 * p[4].clone()
-                    - 2.0f64 * p[6].clone()
-                    - 2.0f64 * p[7].clone()
-                    - 2.0f64 * p[9].clone();
+                *v *= one_minus_two_sum(&p, [0, 11, 13, 2, 4, 6, 7, 9]);
             }
-
             (Pauli::X, Pauli::Z) => {
-                *v *= 1.0f64
-                    - 2.0f64 * p[0].clone()
-                    - 2.0f64 * p[1].clone()
-                    - 2.0f64 * p[10].clone()
-                    - 2.0f64 * p[11].clone()
-                    - 2.0f64 * p[14].clone()
-                    - 2.0f64 * p[4].clone()
-                    - 2.0f64 * p[5].clone()
-                    - 2.0f64 * p[7].clone();
+                *v *= one_minus_two_sum(&p, [0, 1, 10, 11, 14, 4, 5, 7]);
             }
-
             (Pauli::Y, Pauli::I) => {
-                *v *= 1.0f64
-                    - 2.0f64 * p[11].clone()
-                    - 2.0f64 * p[12].clone()
-                    - 2.0f64 * p[13].clone()
-                    - 2.0f64 * p[14].clone()
-                    - 2.0f64 * p[3].clone()
-                    - 2.0f64 * p[4].clone()
-                    - 2.0f64 * p[5].clone()
-                    - 2.0f64 * p[6].clone();
+                *v *= one_minus_two_sum(&p, [11, 12, 13, 14, 3, 4, 5, 6]);
             }
-
             (Pauli::Y, Pauli::X) => {
-                *v *= 1.0f64
-                    - 2.0f64 * p[1].clone()
-                    - 2.0f64 * p[10].clone()
-                    - 2.0f64 * p[11].clone()
-                    - 2.0f64 * p[12].clone()
-                    - 2.0f64 * p[2].clone()
-                    - 2.0f64 * p[3].clone()
-                    - 2.0f64 * p[4].clone()
-                    - 2.0f64 * p[9].clone();
+                *v *= one_minus_two_sum(&p, [1, 10, 11, 12, 2, 3, 4, 9]);
             }
-
             (Pauli::Y, Pauli::Y) => {
-                *v *= 1.0f64
-                    - 2.0f64 * p[0].clone()
-                    - 2.0f64 * p[10].clone()
-                    - 2.0f64 * p[11].clone()
-                    - 2.0f64 * p[13].clone()
-                    - 2.0f64 * p[2].clone()
-                    - 2.0f64 * p[3].clone()
-                    - 2.0f64 * p[5].clone()
-                    - 2.0f64 * p[8].clone();
+                *v *= one_minus_two_sum(&p, [0, 10, 11, 13, 2, 3, 5, 8]);
             }
-
             (Pauli::Y, Pauli::Z) => {
-                *v *= 1.0f64
-                    - 2.0f64 * p[0].clone()
-                    - 2.0f64 * p[1].clone()
-                    - 2.0f64 * p[11].clone()
-                    - 2.0f64 * p[14].clone()
-                    - 2.0f64 * p[3].clone()
-                    - 2.0f64 * p[6].clone()
-                    - 2.0f64 * p[8].clone()
-                    - 2.0f64 * p[9].clone();
+                *v *= one_minus_two_sum(&p, [0, 1, 11, 14, 3, 6, 8, 9]);
             }
-
             (Pauli::Z, Pauli::I) => {
-                *v *= 1.0f64
-                    - 2.0f64 * p[10].clone()
-                    - 2.0f64 * p[3].clone()
-                    - 2.0f64 * p[4].clone()
-                    - 2.0f64 * p[5].clone()
-                    - 2.0f64 * p[6].clone()
-                    - 2.0f64 * p[7].clone()
-                    - 2.0f64 * p[8].clone()
-                    - 2.0f64 * p[9].clone();
+                *v *= one_minus_two_sum(&p, [10, 3, 4, 5, 6, 7, 8, 9]);
             }
-
             (Pauli::Z, Pauli::X) => {
-                *v *= 1.0f64
-                    - 2.0f64 * p[1].clone()
-                    - 2.0f64 * p[13].clone()
-                    - 2.0f64 * p[14].clone()
-                    - 2.0f64 * p[2].clone()
-                    - 2.0f64 * p[3].clone()
-                    - 2.0f64 * p[4].clone()
-                    - 2.0f64 * p[7].clone()
-                    - 2.0f64 * p[8].clone();
+                *v *= one_minus_two_sum(&p, [1, 13, 14, 2, 3, 4, 7, 8]);
             }
-
             (Pauli::Z, Pauli::Y) => {
-                *v *= 1.0f64
-                    - 2.0f64 * p[0].clone()
-                    - 2.0f64 * p[12].clone()
-                    - 2.0f64 * p[14].clone()
-                    - 2.0f64 * p[2].clone()
-                    - 2.0f64 * p[3].clone()
-                    - 2.0f64 * p[5].clone()
-                    - 2.0f64 * p[7].clone()
-                    - 2.0f64 * p[9].clone();
+                *v *= one_minus_two_sum(&p, [0, 12, 14, 2, 3, 5, 7, 9]);
             }
-
             (Pauli::Z, Pauli::Z) => {
-                *v *= 1.0f64
-                    - 2.0f64 * p[0].clone()
-                    - 2.0f64 * p[1].clone()
-                    - 2.0f64 * p[10].clone()
-                    - 2.0f64 * p[12].clone()
-                    - 2.0f64 * p[13].clone()
-                    - 2.0f64 * p[3].clone()
-                    - 2.0f64 * p[6].clone()
-                    - 2.0f64 * p[7].clone();
+                *v *= one_minus_two_sum(&p, [0, 1, 10, 12, 13, 3, 6, 7]);
             }
-
             _ => {
                 // NOTE: if just one atom is lost, then there is no
                 // well-defined noise channel on the other atom
@@ -234,14 +100,9 @@ where
     }
 }
 
-impl<T: Config> Depolarizing<T> for PauliSum<T>
-where
-    f64: std::ops::Mul<T::Coeff, Output = T::Coeff>
-        + std::ops::Add<T::Coeff, Output = T::Coeff>
-        + std::ops::Sub<T::Coeff, Output = T::Coeff>,
-{
+impl<T: Config> Depolarizing<T> for PauliSum<T> {
     fn depolarize(&mut self, addr0: usize, p: T::Coeff) {
-        let factor = 1.0f64 - 4.0f64 / 3.0f64 * p;
+        let factor = T::Coeff::from(1.0) - p * (4.0 / 3.0);
         self.scale(move |k, v| {
             if !k.get_lbit(addr0) && pauli_code(k, addr0) != 0 {
                 *v *= factor.clone();
@@ -250,14 +111,9 @@ where
     }
 }
 
-impl<T: Config> Depolarizing2<T> for PauliSum<T>
-where
-    f64: std::ops::Mul<T::Coeff, Output = T::Coeff>
-        + std::ops::Add<T::Coeff, Output = T::Coeff>
-        + std::ops::Sub<T::Coeff, Output = T::Coeff>,
-{
+impl<T: Config> Depolarizing2<T> for PauliSum<T> {
     fn depolarize2(&mut self, addr0: usize, addr1: usize, p: T::Coeff) {
-        let factor = 1.0f64 - (16.0f64 / 15.0f64) * p;
+        let factor = T::Coeff::from(1.0) - p * (16.0 / 15.0);
         self.scale(move |k, v| {
             if k.get_lbit(addr0) || k.get_lbit(addr1) {
                 return;
@@ -271,7 +127,6 @@ where
 
 impl<T: Config> AmplitudeDamping<T> for PauliSum<T>
 where
-    f64: std::ops::Sub<T::Coeff, Output = T::Coeff>,
     T::Coeff: Float,
 {
     fn amplitude_damping(&mut self, addr0: usize, gamma: <T as Config>::Coeff) {
@@ -279,7 +134,7 @@ where
             Pauli::I | Pauli::L => None,
 
             Pauli::X | Pauli::Y => {
-                *v *= (1.0 - gamma).sqrt();
+                *v *= (T::Coeff::from(1.0) - gamma).sqrt();
                 None
             }
 
@@ -289,7 +144,7 @@ where
                 let mut new_k = k.clone();
                 new_k.set(addr0, Pauli::I);
 
-                *v *= 1.0 - gamma;
+                *v *= T::Coeff::from(1.0) - gamma;
 
                 Some((new_k, new_v))
             }
@@ -303,10 +158,7 @@ where
 /// While this is technically correct, you may want to count loss as a contribution
 /// to the zero state of a qubit. Refer to `LossyPauliWord` and the `ResetLossChannel`
 /// trait for that functionality.
-impl<T: Config> LossChannel<T> for PauliSum<T>
-where
-    f64: std::ops::Sub<T::Coeff, Output = T::Coeff>,
-{
+impl<T: Config> LossChannel<T> for PauliSum<T> {
     fn loss_channel(&mut self, addr0: usize, p: T::Coeff) {
         self.map_insert(|k, v| match k.get(addr0) {
             Pauli::L => {
@@ -316,18 +168,14 @@ where
                 Some((new_k, new_v))
             }
             Pauli::I | Pauli::X | Pauli::Y | Pauli::Z => {
-                *v *= 1.0f64 - p.clone();
+                *v *= T::Coeff::from(1.0) - p.clone();
                 None
             }
         });
     }
 }
 
-impl<T: Config> CorrelatedLossChannel<T> for PauliSum<T>
-where
-    f64: std::ops::Sub<<T as Config>::Coeff, Output = T::Coeff>
-        + std::ops::Mul<<T as Config>::Coeff, Output = T::Coeff>,
-{
+impl<T: Config> CorrelatedLossChannel<T> for PauliSum<T> {
     /// Apply a correlated loss channel to qubits at `addr0` and `addr1`.
     ///
     /// The three probabilities are:
@@ -368,7 +216,7 @@ where
                     new_k.set(addr1, Pauli::I);
                     let new_v = v.clone() * p[1].clone();
 
-                    *v *= 1.0_f64 - p[2].clone();
+                    *v *= T::Coeff::from(1.0) - p[2].clone();
 
                     Some(Vec::from([(new_k, new_v)]))
                 }
@@ -380,14 +228,14 @@ where
                     new_k.set(addr0, Pauli::I);
                     let new_v = v.clone() * p[1].clone();
 
-                    *v *= 1.0_f64 - p[2].clone();
+                    *v *= T::Coeff::from(1.0) - p[2].clone();
 
                     Some(Vec::from([(new_k, new_v)]))
                 }
 
                 (_, _) => {
                     // case both qubits in qubit subspace
-                    *v *= 1.0_f64 - 2.0_f64 * p[1].clone() - p[0].clone();
+                    *v *= T::Coeff::from(1.0) - p[1].clone() * 2.0 - p[0].clone();
                     None
                 }
             }

--- a/crates/ppvm-runtime/src/sum/rot1.rs
+++ b/crates/ppvm-runtime/src/sum/rot1.rs
@@ -36,13 +36,10 @@ pub(crate) fn rotate_1_map_insert_closure<T: Config>(
     }
 }
 
-impl<T, S, H> RotationOne<T> for PauliSum<T>
+impl<T: Config> RotationOne<T> for PauliSum<T>
 where
-    S: PauliStorage,
-    H: std::hash::BuildHasher + Clone + Default,
-    T: Config<Storage = S, BuildHasher = H>,
     T::Coeff: std::ops::MulAssign,
-    T::Map: ACMapInsert<S, T::Coeff, H, T::PauliWordType> + ACMapConsume,
+    T::Map: ACMapInsert<T::Storage, T::Coeff, T::BuildHasher, T::PauliWordType> + ACMapConsume,
 {
     fn rotate_1(&mut self, axis: Pauli, addr0: usize, theta: <T as Config>::Coeff) {
         let (sin, cos) = theta.sin_cos();

--- a/crates/ppvm-runtime/src/sum/rot2.rs
+++ b/crates/ppvm-runtime/src/sum/rot2.rs
@@ -4,11 +4,8 @@ use crate::{char::Pauli, config::Config, sum::PauliSum};
 
 const PAULIS: [Pauli; 4] = [Pauli::I, Pauli::X, Pauli::Z, Pauli::Y];
 
-impl<T, S, H> RotationTwo<T> for PauliSum<T>
+impl<T: Config> RotationTwo<T> for PauliSum<T>
 where
-    S: PauliStorage,
-    H: std::hash::BuildHasher + Clone + Default,
-    T: Config<Storage = S, BuildHasher = H>,
     T::Coeff: std::ops::MulAssign,
     T::Map: ACMapInsert<T::Storage, T::Coeff, T::BuildHasher, T::PauliWordType> + ACMapConsume,
 {

--- a/crates/ppvm-runtime/src/traits/clifford.rs
+++ b/crates/ppvm-runtime/src/traits/clifford.rs
@@ -1,3 +1,5 @@
+use crate::traits::PauliWordTrait;
+
 pub trait Clifford {
     fn x(&mut self, index: usize);
     fn y(&mut self, index: usize);
@@ -16,4 +18,175 @@ pub trait CliffordExtensions: Clifford {
     fn sqrt_y_adj(&mut self, addr0: usize);
 
     fn cy(&mut self, addr0: usize, addr1: usize);
+}
+
+// === Blanket Clifford impl for PauliWordTrait ===
+//
+// Any type implementing [`PauliWordTrait`] automatically gets word-level
+// Clifford gate behavior. X/Y/Z are no-ops at the word level (they only
+// affect phase, tracked separately in `PhasedPauliWord`). H, S, CNOT, CZ
+// transform the bit representation. All gates honor loss bits via
+// `get_lbit`, which returns `false` for non-lossy types.
+//
+// New PauliWordTrait implementors get this behavior for free.
+//
+// Breaking change for downstream crates: this blanket impl conflicts with
+// any external `impl Clifford for MyWord where MyWord: PauliWordTrait`.
+// Downstreams that need custom Clifford semantics must not implement
+// `PauliWordTrait` on that type — see `PauliWordTrait`'s docs and the
+// `PhasedPauliWord` impl in `crate::phase::clifford` for the pattern.
+
+impl<T: PauliWordTrait> Clifford for T {
+    #[inline]
+    fn x(&mut self, _index: usize) {
+        // X * I * X = I    00 -> 00, 0
+        // X * X * X = X    10 -> 10, 0
+        // X * Z * X = -Z   01 -> 01, 1
+        // X * Y * X = -Y   11 -> 11, 1
+        // word-level no-op: phase tracked at PhasedPauliWord level
+    }
+
+    #[inline]
+    fn y(&mut self, _index: usize) {
+        // word-level no-op
+    }
+
+    #[inline]
+    fn z(&mut self, _index: usize) {
+        // word-level no-op
+    }
+
+    #[inline]
+    fn h(&mut self, index: usize) {
+        // H * I * H = I, H * X * H = Z, H * Z * H = X, H * Y * H = -Y
+        if self.get_lbit(index) {
+            return;
+        }
+        let ix = self.get_xbit(index);
+        let iz = self.get_zbit(index);
+        self.set_xbit(index, iz);
+        self.set_zbit(index, ix);
+        self.rehash();
+    }
+
+    #[inline]
+    fn s(&mut self, index: usize) {
+        // S * I * S = I, S * X * S = Y, S * Z * S = Z, S * Y * S = -X
+        if self.get_lbit(index) {
+            return;
+        }
+        let z = self.get_xbit(index) ^ self.get_zbit(index);
+        self.set_zbit(index, z);
+        self.rehash();
+    }
+
+    #[inline]
+    fn cnot(&mut self, control: usize, target: usize) {
+        if self.get_lbit(control) || self.get_lbit(target) {
+            return;
+        }
+        let control_z = self.get_zbit(target) ^ self.get_zbit(control);
+        let target_x = self.get_xbit(control) ^ self.get_xbit(target);
+        self.set_zbit(control, control_z);
+        self.set_xbit(target, target_x);
+        self.rehash();
+    }
+
+    #[inline]
+    fn cz(&mut self, control: usize, target: usize) {
+        if self.get_lbit(control) || self.get_lbit(target) {
+            return;
+        }
+        // flip the control z if target x is 1
+        let control_z = self.get_zbit(control) ^ self.get_xbit(target);
+        self.set_zbit(control, control_z);
+        // flip the target z if control x is 1
+        let target_z = self.get_zbit(target) ^ self.get_xbit(control);
+        self.set_zbit(target, target_z);
+        self.rehash();
+    }
+}
+
+impl<T: PauliWordTrait> CliffordExtensions for T {
+    // |    Gate    |  X  |  Y  |  Z  |
+    // |:----------:|:---:|:---:|:---:|
+    // |     s      | -Y  |  X  |  Z  |
+    // |   s_adj    |  Y  | -X  |  Z  |
+    // |   sqrt_x   |  X  | -Z  |  Y  |
+    // | sqrt*x*adj |  X  |  Z  | -Y  |
+    // |   sqrt_y   |  Z  |  Y  | -X  |
+    // | sqrt*y*adj | -Z  |  Y  |  X  |
+
+    #[inline]
+    fn s_adj(&mut self, addr0: usize) {
+        // s_adj has the same bit mapping as s (only phases differ)
+        self.s(addr0);
+    }
+
+    #[inline]
+    fn sqrt_x(&mut self, addr0: usize) {
+        if self.get_lbit(addr0) {
+            return;
+        }
+        let x = self.get_xbit(addr0);
+        let z = self.get_zbit(addr0);
+        self.set_xbit(addr0, x ^ z);
+        self.rehash();
+    }
+
+    #[inline]
+    fn sqrt_x_adj(&mut self, addr0: usize) {
+        if self.get_lbit(addr0) {
+            return;
+        }
+        let x = self.get_xbit(addr0);
+        let z = self.get_zbit(addr0);
+        self.set_xbit(addr0, x ^ z);
+        self.rehash();
+    }
+
+    #[inline]
+    fn sqrt_y(&mut self, addr0: usize) {
+        if self.get_lbit(addr0) {
+            return;
+        }
+        let x = self.get_xbit(addr0);
+        let z = self.get_zbit(addr0);
+        self.set_xbit(addr0, z);
+        self.set_zbit(addr0, x);
+        self.rehash();
+    }
+
+    #[inline]
+    fn sqrt_y_adj(&mut self, addr0: usize) {
+        if self.get_lbit(addr0) {
+            return;
+        }
+        let x = self.get_xbit(addr0);
+        let z = self.get_zbit(addr0);
+        self.set_xbit(addr0, z);
+        self.set_zbit(addr0, x);
+        self.rehash();
+    }
+
+    // | CY  |  I  |  X  |  Y  |  Z  |
+    // |:---:|:---:|:---:|:---:|:---:|
+    // |  I  | II  | ZX  | IY  | ZZ  |
+    // |  X  | XY  | -YZ | XI  | YX  |
+    // |  Y  | YY  | XZ  | YI  | -XX |
+    // |  Z  | ZI  | IX  | ZY  | IZ  |
+    #[inline]
+    fn cy(&mut self, addr0: usize, addr1: usize) {
+        if self.get_lbit(addr0) || self.get_lbit(addr1) {
+            return;
+        }
+        let xc = self.get_xbit(addr0);
+        let zc = self.get_zbit(addr0);
+        let xt = self.get_xbit(addr1);
+        let zt = self.get_zbit(addr1);
+        self.set_zbit(addr0, zc ^ xt ^ zt);
+        self.set_xbit(addr1, xt ^ xc);
+        self.set_zbit(addr1, zt ^ xc);
+        self.rehash();
+    }
 }

--- a/crates/ppvm-runtime/src/traits/word_trait.rs
+++ b/crates/ppvm-runtime/src/traits/word_trait.rs
@@ -1,5 +1,5 @@
 use crate::char::Pauli;
-use crate::traits::{Clifford, PauliStorage};
+use crate::traits::PauliStorage;
 use std::fmt::Display;
 use std::hash::Hash;
 
@@ -7,9 +7,28 @@ pub trait PauliIter {
     fn iter(&self) -> impl Iterator<Item = Pauli>;
 }
 
-pub trait PauliWordTrait:
-    Clone + Hash + Eq + PauliIter + From<String> + Clifford + Display
-{
+/// Word-level Pauli operations. Types implementing this trait automatically
+/// gain [`crate::traits::Clifford`] and [`crate::traits::CliffordExtensions`]
+/// behavior via blanket impls in [`crate::traits::clifford`], using
+/// `get_lbit` / `get_xbit` / `set_xbit` / `set_zbit` / `rehash` to transform
+/// Pauli words.
+///
+/// # Word-level vs. state-level gate semantics
+///
+/// The blanket `Clifford` impl applies gates at the *bit* level of a single
+/// Pauli word. X / Y / Z are bit-level no-ops on a Pauli word — they affect
+/// phase, not the X/Z bits — so `word.x(i)`, `word.y(i)`, `word.z(i)` are
+/// deliberately silent. Phase is tracked separately by
+/// [`crate::phase::PhasedPauliWord`], which implements `Clifford` manually.
+///
+/// If you need a word representation whose gate behavior is *not* pure
+/// bit manipulation (phase tracking, fused multi-qubit updates, alternative
+/// loss semantics), do **not** implement `PauliWordTrait` on it — define a
+/// specialized `Clifford` impl instead, the way `PhasedPauliWord` does.
+/// Implementing both `PauliWordTrait` and a custom `impl Clifford for ...`
+/// for the same type will not compile: the blanket impl overlaps with your
+/// custom impl (coherence error), not silently shadows it.
+pub trait PauliWordTrait: Clone + Hash + Eq + PauliIter + From<String> + Display {
     fn new(nqubits: usize) -> Self;
 
     fn n_qubits(&self) -> usize;

--- a/crates/ppvm-runtime/src/word/clifford.rs
+++ b/crates/ppvm-runtime/src/word/clifford.rs
@@ -1,206 +1,10 @@
-use std::hash::BuildHasher;
-
-use super::data::PauliWord;
-use crate::traits::{Clifford, CliffordExtensions, PauliStorage, PauliWordTrait};
-
-impl<A, H, const REHASH: bool> Clifford for PauliWord<A, H, REHASH>
-where
-    A: PauliStorage,
-    H: BuildHasher + Clone + Default,
-{
-    #[inline]
-    fn x(&mut self, _index: usize) {
-        // X * I * X = I    00 -> 00, 0
-        // X * X * X = X    10 -> 10, 0
-        // X * Z * X = -Z   01 -> 01, 1
-        // X * Y * X = -Y.  11 -> 11, 1
-    }
-
-    #[inline]
-    fn y(&mut self, _index: usize) {
-        // Y * I * Y = I    00 -> 00, 0
-        // Y * X * Y = -X   10 -> 10, 1
-        // Y * Z * Y = -Z   01 -> 01, 1
-        // Y * Y * Y = Y    11 -> 11, 0
-    }
-
-    #[inline]
-    fn z(&mut self, _index: usize) {
-        // Z * I * Z = I    00 -> 00, 0
-        // Z * X * Z = -X   10 -> 10, 1
-        // Z * Z * Z = Z    01 -> 01, 0
-        // Z * Y * Z = -Y   11 -> 11, 1
-    }
-
-    #[inline]
-    fn h(&mut self, index: usize) {
-        // H * I * H = I    00 -> 00, 0
-        // H * X * H = Z    10 -> 01, 0
-        // H * Z * H = X    01 -> 10, 0
-        // H * Y * H = -Y   11 -> 11, 1
-        let index_x = self.xbits[index];
-        let index_z = self.zbits[index];
-        self.xbits.set(index, index_z);
-        self.zbits.set(index, index_x);
-        self.rehash();
-    }
-
-    #[inline]
-    fn s(&mut self, index: usize) {
-        // S * I * S = I    00 -> 00, 0
-        // S * X * S = Y    10 -> 11, 0
-        // S * Z * S = Z    01 -> 01, 0
-        // S * Y * S = -X   11 -> 10, 1
-        let z = self.xbits[index] ^ self.zbits[index];
-        self.zbits.set(index, z);
-        self.rehash();
-    }
-
-    #[inline]
-    fn cnot(&mut self, control: usize, target: usize) {
-        //                          xx zz    xx zz  phase
-        // CNOT * II * CNOT == II,  00 00 -> 00 00, 0
-        // CNOT * IX * CNOT == IX,  01 00 -> 01 00, 0
-        // CNOT * IZ * CNOT == ZZ,  00 01 -> 00 11, 0
-        // CNOT * IY * CNOT == ZY,  01 01 -> 01 11, 0
-
-        // CNOT * XI * CNOT == XX,  10 00 -> 11 00, 0
-        // CNOT * XX * CNOT == XI,  11 00 -> 10 00, 0
-        // CNOT * XY * CNOT == YZ,  11 01 -> 10 11, 0
-        // CNOT * XZ * CNOT == -YY, 10 01 -> 11 11, 1
-
-        // CNOT * ZI * CNOT == ZI,  00 10 -> 00 10, 0
-        // CNOT * ZX * CNOT == ZX,  01 10 -> 01 10, 0
-        // CNOT * ZY * CNOT == IY,  01 11 -> 01 01, 0
-        // CNOT * ZZ * CNOT == IZ,  00 11 -> 00 01, 0
-
-        // CNOT * YI * CNOT == YX,  10 10 -> 11 10, 0
-        // CNOT * YX * CNOT == YI,  11 10 -> 10 10, 0
-        // CNOT * YY * CNOT == -XZ, 11 11 -> 10 01, 1
-        // CNOT * YZ * CNOT == XY,  10 11 -> 11 01, 0
-        let control_z = self.zbits[target] ^ self.zbits[control];
-        let target_x = self.xbits[control] ^ self.xbits[target];
-        self.zbits.set(control, control_z);
-        self.xbits.set(target, target_x);
-        self.rehash();
-    }
-
-    #[inline]
-    fn cz(&mut self, control: usize, target: usize) {
-        // CZ = |0><0| I + |1><1| Z
-        // CZ * II * CZ = II,   00 00 -> 00 00, 0
-        // CZ * IX * CZ = ZX,   01 00 -> 01 10, 0
-        // CZ * IY * CZ = ZY,   01 01 -> 01 11, 0
-        // CZ * IZ * CZ = ZZ,   00 01 -> 00 01, 0
-
-        // CZ * XI * CZ = XZ,   10 00 -> 10 01, 0
-        // CZ * XX * CZ = YY,   11 00 -> 11 11, 0
-        // CZ * XY * CZ = -YX,  11 01 -> 11 10, 1
-        // CZ * XZ * CZ = XI,   10 01 -> 10 00, 0
-
-        // CZ * ZI * CZ == ZI,  00 10 -> 00 10, 0
-        // CZ * ZX * CZ == IX,  01 10 -> 01 00, 0
-        // CZ * ZY * CZ == IY,  01 11 -> 01 01, 0
-        // CZ * ZZ * CZ == ZZ,  00 11 -> 00 11, 0
-
-        // CZ * YI * CZ == YZ,  10 10 -> 10 11, 0
-        // CZ * YX * CZ == -XY, 11 10 -> 11 01, 1
-        // CZ * YY * CZ == XX,  11 11 -> 11 00, 0
-        // CZ * YZ * CZ == YI,  10 11 -> 10 10, 0
-
-        // xx: identity
-        // zz:
-        // xx: 00, identity
-        // xx: 01, 00 -> 10, 01 -> 11, 10 -> 00, 11 -> 01
-        // xx: 10, 00 -> 01, 01 -> 00, 10 -> 11, 11 -> 10
-        // xx: 11, 00 -> 11, 01 -> 10, 10 -> 01, 11 -> 00
-
-        // flip the control z if target x is 1
-        let control_z = self.zbits[control] ^ self.xbits[target];
-        self.zbits.set(control, control_z);
-        // flip the target z if control x is 1
-        let target_z = self.zbits[target] ^ self.xbits[control];
-        self.zbits.set(target, target_z);
-        self.rehash();
-    }
-}
-
-impl<A, H, const REHASH: bool> CliffordExtensions for PauliWord<A, H, REHASH>
-where
-    A: PauliStorage,
-    H: BuildHasher + Clone + Default,
-{
-    // |    Gate    |  X  |  Y  |  Z  |
-    // |:----------:|:---:|:---:|:---:|
-    // |     s      | -Y  |  X  |  Z  |
-    // |   s_adj    |  Y  | -X  |  Z  |
-    // |   sqrt_x   |  X  | -Z  |  Y  |
-    // | sqrt*x*adj |  X  |  Z  | -Y  |
-    // |   sqrt_y   |  Z  |  Y  | -X  |
-    // | sqrt*y*adj | -Z  |  Y  |  X  |
-
-    #[inline]
-    fn s_adj(&mut self, addr0: usize) {
-        self.s(addr0);
-    }
-
-    #[inline]
-    fn sqrt_x(&mut self, addr0: usize) {
-        let x = self.xbits[addr0];
-        let z = self.zbits[addr0];
-        self.set_xbit(addr0, x ^ z);
-        self.rehash();
-    }
-
-    #[inline]
-    fn sqrt_y(&mut self, addr0: usize) {
-        let x = self.xbits[addr0];
-        let z = self.zbits[addr0];
-        self.set_xbit(addr0, z);
-        self.set_zbit(addr0, x);
-        self.rehash();
-    }
-
-    #[inline]
-    fn sqrt_x_adj(&mut self, addr0: usize) {
-        let x = self.xbits[addr0];
-        let z = self.zbits[addr0];
-        self.set_xbit(addr0, x ^ z);
-        self.rehash();
-    }
-
-    #[inline]
-    fn sqrt_y_adj(&mut self, addr0: usize) {
-        let x = self.xbits[addr0];
-        let z = self.zbits[addr0];
-        self.set_xbit(addr0, z);
-        self.set_zbit(addr0, x);
-        self.rehash();
-    }
-
-    // | CY  |  I  |  X  |  Y  |  Z  |
-    // |:---:|:---:|:---:|:---:|:---:|
-    // |  I  | II  | ZX  | IY  | ZZ  |
-    // |  X  | XY  | -YZ | XI  | YX  |
-    // |  Y  | YY  | XZ  | YI  | -XX |
-    // |  Z  | ZI  | IX  | ZY  | IZ  |
-
-    #[inline]
-    fn cy(&mut self, addr0: usize, addr1: usize) {
-        let xc = self.xbits[addr0];
-        let zc = self.zbits[addr0];
-        let xt = self.xbits[addr1];
-        let zt = self.zbits[addr1];
-        self.set_zbit(addr0, zc ^ xt ^ zt);
-        self.set_xbit(addr1, xt ^ xc);
-        self.set_zbit(addr1, zt ^ xc);
-        self.rehash();
-    }
-}
+// Clifford behavior for `PauliWord` is provided by the blanket impl
+// `impl<T: PauliWordTrait> Clifford for T` in `crate::traits::clifford`.
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::super::data::PauliWord;
+    use crate::traits::{Clifford, CliffordExtensions};
 
     #[test]
     fn test_x() {
@@ -228,26 +32,6 @@ mod tests {
             assert_eq!((input, output.to_string()), (input, target.to_string()));
         }
     }
-
-    // CNOT * II * CNOT == II,  00 00 -> 00 00, 0
-    // CNOT * IX * CNOT == IX,  01 00 -> 01 00, 0
-    // CNOT * IZ * CNOT == ZZ,  00 01 -> 00 11, 0
-    // CNOT * IY * CNOT == ZY,  01 01 -> 01 11, 0
-
-    // CNOT * XI * CNOT == XX,  10 00 -> 11 00, 0
-    // CNOT * XX * CNOT == XI,  11 00 -> 10 00, 0
-    // CNOT * XY * CNOT == YZ,  11 01 -> 10 11, 0
-    // CNOT * XZ * CNOT == -YY, 10 01 -> 11 11, 1
-
-    // CNOT * ZI * CNOT == ZI,  00 10 -> 00 10, 0
-    // CNOT * ZX * CNOT == ZX,  01 10 -> 01 10, 0
-    // CNOT * ZY * CNOT == IY,  01 11 -> 01 01, 0
-    // CNOT * ZZ * CNOT == IZ,  00 11 -> 00 01, 0
-
-    // CNOT * YI * CNOT == YX,  10 10 -> 11 10, 0
-    // CNOT * YX * CNOT == YI,  11 10 -> 10 10, 0
-    // CNOT * YY * CNOT == -XZ, 11 11 -> 10 01, 1
-    // CNOT * YZ * CNOT == XY,  10 11 -> 11 01, 0
 
     #[test]
     fn test_cnot() {
@@ -277,7 +61,6 @@ mod tests {
 
     #[test]
     fn test_h() {
-        // NOTE: phase on "Y" not added in words
         for (input, target) in [("I", "I"), ("X", "Z"), ("Y", "Y"), ("Z", "X")] {
             let mut output: PauliWord<u64> = PauliWord::from(input);
             output.h(0);
@@ -287,8 +70,6 @@ mod tests {
 
     #[test]
     fn test_s() {
-        // S' * P * S (backward propagation)
-        // X -> Y, Z -> Z, Y -> X (ignoring phase)
         for (input, target) in [("I", "I"), ("X", "Y"), ("Z", "Z"), ("Y", "X")] {
             let mut output: PauliWord<u64> = PauliWord::from(input);
             output.s(0);
@@ -298,7 +79,6 @@ mod tests {
 
     #[test]
     fn test_s_adj() {
-        // Same bit mapping as s (only phases differ)
         for (input, target) in [("I", "I"), ("X", "Y"), ("Z", "Z"), ("Y", "X")] {
             let mut output: PauliWord<u64> = PauliWord::from(input);
             output.s_adj(0);
@@ -308,7 +88,6 @@ mod tests {
 
     #[test]
     fn test_sqrt_x() {
-        // SqrtX' * P * SqrtX: X -> X, Y -> Z, Z -> Y (ignoring phase)
         for (input, target) in [("I", "I"), ("X", "X"), ("Y", "Z"), ("Z", "Y")] {
             let mut output: PauliWord<u64> = PauliWord::from(input);
             output.sqrt_x(0);
@@ -318,7 +97,6 @@ mod tests {
 
     #[test]
     fn test_sqrt_x_adj() {
-        // Same bit mapping as sqrt_x (only phases differ)
         for (input, target) in [("I", "I"), ("X", "X"), ("Y", "Z"), ("Z", "Y")] {
             let mut output: PauliWord<u64> = PauliWord::from(input);
             output.sqrt_x_adj(0);
@@ -328,7 +106,6 @@ mod tests {
 
     #[test]
     fn test_sqrt_y() {
-        // SqrtY' * P * SqrtY: X -> Z, Y -> Y, Z -> X (ignoring phase)
         for (input, target) in [("I", "I"), ("X", "Z"), ("Y", "Y"), ("Z", "X")] {
             let mut output: PauliWord<u64> = PauliWord::from(input);
             output.sqrt_y(0);
@@ -338,7 +115,6 @@ mod tests {
 
     #[test]
     fn test_sqrt_y_adj() {
-        // Same bit mapping as sqrt_y (only phases differ)
         for (input, target) in [("I", "I"), ("X", "Z"), ("Y", "Y"), ("Z", "X")] {
             let mut output: PauliWord<u64> = PauliWord::from(input);
             output.sqrt_y_adj(0);
@@ -348,7 +124,6 @@ mod tests {
 
     #[test]
     fn test_cy() {
-        // CY' * P * CY (backward propagation, CY is Hermitian)
         for (input, target) in [
             ("II", "II"),
             ("IX", "ZX"),

--- a/crates/ppvm-tableau/src/lib.rs
+++ b/crates/ppvm-tableau/src/lib.rs
@@ -6,11 +6,13 @@ pub mod noise;
 pub mod sparsevec;
 pub mod stim;
 pub mod tableau_index;
+pub mod tableau_like;
 
 pub mod prelude {
     pub use crate::data::{GeneralizedTableau, Tableau};
     pub use crate::sparsevec::SparseVector;
     pub use crate::stim::RunStim;
     pub use crate::tableau_index::TableauIndex;
+    pub use crate::tableau_like::TableauLike;
     pub use ppvm_runtime::prelude::*;
 }

--- a/crates/ppvm-tableau/src/noise.rs
+++ b/crates/ppvm-tableau/src/noise.rs
@@ -7,208 +7,104 @@ use num::traits::{One, ToPrimitive, Zero};
 
 use crate::prelude::*;
 use rand::RngExt;
+use rand::rngs::SmallRng;
 
-/// Check that a value is a valid probability (in [0, 1]).
-/// Extracted to avoid triggering `clippy::manual_range_contains` when
-/// the generic `T::Coeff` does not implement `PartialOrd` in both directions.
-#[inline]
-fn is_probability(p: &impl PartialOrd<f64>) -> bool {
-    *p >= 0.0 && *p <= 1.0
-}
+// === TableauLike impls ===
+//
+// Implementing TableauLike grants automatic implementations of all
+// single- and two-qubit Pauli noise channels via default methods.
 
-impl<T: Config> Depolarizing<T> for Tableau<T>
+impl<T: Config> TableauLike for Tableau<T>
 where
     T::Coeff: PartialOrd<f64>,
 {
-    fn depolarize(&mut self, addr0: usize, p: T::Coeff) {
-        debug_assert!(is_probability(&p));
-        let r = self.rng.random::<f64>();
-        if p <= r {
-            return;
-        }
-        if p > r * 3.0 {
-            // p / 3 > r >= 0
-            self.x(addr0);
-        } else if p > r * 1.5 {
-            // 2p/3 > r >= p / 3
-            self.y(addr0);
-        } else {
-            // p > r >= 2p/3
-            self.z(addr0);
-        }
+    type Coeff = T::Coeff;
+    type Rng = SmallRng;
+
+    #[inline]
+    fn rng_mut(&mut self) -> &mut Self::Rng {
+        &mut self.rng
     }
 }
 
-impl<T: Config, I: TableauIndex, C: SparseVector<Complex<T::Coeff>, I>> Depolarizing<T>
+impl<T: Config, I: TableauIndex, C: SparseVector<Complex<T::Coeff>, I>> TableauLike
     for GeneralizedTableau<T, I, C>
 where
     T::Coeff: PartialOrd<f64>,
-    Complex<<T as Config>::Coeff>: From<Complex<f64>>,
+    Complex<T::Coeff>: From<Complex<f64>>,
 {
-    fn depolarize(&mut self, addr0: usize, p: T::Coeff) {
-        debug_assert!(is_probability(&p));
-        let r = self.tableau.rng.random::<f64>();
-        if p <= r {
-            return;
-        }
-        if p > r * 3.0 {
-            // p / 3 > r >= 0
-            self.x(addr0);
-        } else if p > r * 1.5 {
-            // 2p/3 > r >= p / 3
-            self.y(addr0);
-        } else {
-            // p > r >= 2p/3
-            self.z(addr0);
-        }
+    type Coeff = T::Coeff;
+    type Rng = SmallRng;
+
+    #[inline]
+    fn rng_mut(&mut self) -> &mut Self::Rng {
+        &mut self.tableau.rng
+    }
+
+    #[inline]
+    fn is_qubit_lost(&self, addr: usize) -> bool {
+        self.is_lost[addr]
     }
 }
 
-impl<T: Config> PauliError<T> for Tableau<T>
-where
-    T::Coeff: PartialOrd<f64> + Zero,
-{
-    fn pauli_error(&mut self, addr0: usize, p: [<T as Config>::Coeff; 3]) {
-        let r = self.rng.random::<f64>();
-        let mut cumulative = T::Coeff::zero();
-        for (i, p_) in p.iter().enumerate() {
-            cumulative += p_.clone();
-            if cumulative > r {
-                match i {
-                    0 => self.x(addr0),
-                    1 => self.y(addr0),
-                    _ => self.z(addr0),
-                }
-                return;
+// === Noise trait impls ===
+//
+// Orphan rules (E0210) forbid `impl<X: TableauLike<Coeff = T::Coeff>> Depolarizing<T> for X`,
+// so we expand the four noise traits per backend via a macro. Each backend only
+// has to list its generics + where-clause once.
+
+macro_rules! impl_tableau_noise {
+    (generics: [$($gen:tt)*], ty: $ty:ty, where: [$($bound:tt)*] $(,)?) => {
+        impl<T: Config $($gen)*> Depolarizing<T> for $ty
+        where $($bound)*
+        {
+            fn depolarize(&mut self, addr0: usize, p: T::Coeff) {
+                self.depolarize_impl(addr0, p);
             }
         }
-    }
-}
 
-impl<T: Config, I: TableauIndex, C: SparseVector<Complex<T::Coeff>, I>> PauliError<T>
-    for GeneralizedTableau<T, I, C>
-where
-    T::Coeff: PartialOrd<f64> + Zero,
-    Complex<<T as Config>::Coeff>: From<Complex<f64>>,
-{
-    fn pauli_error(&mut self, addr0: usize, p: [<T as Config>::Coeff; 3]) {
-        debug_assert!(p.iter().all(|p_| *p_ >= 0.0 && *p_ <= 1.0));
-        debug_assert!(p[0].clone() + p[1].clone() + p[2].clone() - 1.0 < 1e-7);
-        let r = self.tableau.rng.random::<f64>();
-        let mut cumulative = T::Coeff::zero();
-        for (i, p_) in p.iter().enumerate() {
-            cumulative += p_.clone();
-            if cumulative > r {
-                match i {
-                    0 => self.x(addr0),
-                    1 => self.y(addr0),
-                    _ => self.z(addr0),
-                }
-                return;
+        impl<T: Config $($gen)*> PauliError<T> for $ty
+        where $($bound)*
+        {
+            fn pauli_error(&mut self, addr0: usize, p: [T::Coeff; 3]) {
+                self.pauli_error_impl(addr0, p);
             }
         }
-    }
-}
 
-fn two_qubit_pauli_error_impl<T: Config>(
-    this: &mut impl Clifford,
-    addr0: usize,
-    addr1: usize,
-    p: [T::Coeff; 15],
-    r: f64,
-) where
-    T::Coeff: PartialOrd<f64> + Zero,
-{
-    debug_assert!(p.iter().all(|p_| *p_ >= 0.0 && *p_ <= 1.0));
-    // debug_assert!(p.iter().sum() - 1.0 < 1e-7);
-    let sum = T::Coeff::zero();
-    let idx = p
-        .iter()
-        .scan(sum, |acc, p_| {
-            *acc += p_.clone();
-            Some(acc.clone())
-        })
-        .position(|cum_prob| cum_prob > r);
-
-    if let Some(i) = idx {
-        #[rustfmt::skip]
-        const PAULI_PAIRS: [(u8, u8); 16] = [
-            (0,0),(0,1),(0,2),(0,3),
-            (1,0),(1,1),(1,2),(1,3),
-            (2,0),(2,1),(2,2),(2,3),
-            (3,0),(3,1),(3,2),(3,3),
-        ];
-        let cartesian_index = PAULI_PAIRS[i + 1]; // skip II entry
-
-        match cartesian_index.0 {
-            0 => {}
-            1 => this.x(addr0),
-            2 => this.y(addr0),
-            _ => this.z(addr0),
+        impl<T: Config $($gen)*> TwoQubitPauliError<T> for $ty
+        where $($bound)*
+        {
+            fn two_qubit_pauli_error(&mut self, addr0: usize, addr1: usize, p: [T::Coeff; 15]) {
+                self.two_qubit_pauli_error_impl(addr0, addr1, p);
+            }
         }
 
-        match cartesian_index.1 {
-            0 => {}
-            1 => this.x(addr1),
-            2 => this.y(addr1),
-            _ => this.z(addr1),
+        impl<T: Config $($gen)*> Depolarizing2<T> for $ty
+        where $($bound)*
+        {
+            fn depolarize2(&mut self, addr0: usize, addr1: usize, p: T::Coeff) {
+                self.depolarize2_impl(addr0, addr1, p);
+            }
         }
-    }
+    };
 }
 
-impl<T: Config> TwoQubitPauliError<T> for Tableau<T>
-where
-    T::Coeff: PartialOrd<f64> + Zero,
-{
-    fn two_qubit_pauli_error(&mut self, addr0: usize, addr1: usize, p: [<T as Config>::Coeff; 15]) {
-        let r = self.rng.random::<f64>();
-        two_qubit_pauli_error_impl::<T>(self, addr0, addr1, p, r);
-    }
+impl_tableau_noise! {
+    generics: [],
+    ty: Tableau<T>,
+    where: [T::Coeff: PartialOrd<f64>],
 }
 
-impl<T: Config, I: TableauIndex, C: SparseVector<Complex<T::Coeff>, I>> TwoQubitPauliError<T>
-    for GeneralizedTableau<T, I, C>
-where
-    T::Coeff: PartialOrd<f64> + Zero,
-    Complex<<T as Config>::Coeff>: From<Complex<f64>>,
-{
-    fn two_qubit_pauli_error(&mut self, addr0: usize, addr1: usize, p: [<T as Config>::Coeff; 15]) {
-        if self.is_lost[addr0] || self.is_lost[addr1] {
-            return;
-        }
-
-        let r = self.tableau.rng.random::<f64>();
-        two_qubit_pauli_error_impl::<T>(self, addr0, addr1, p, r);
-    }
+impl_tableau_noise! {
+    generics: [, I: TableauIndex, C: SparseVector<Complex<T::Coeff>, I>],
+    ty: GeneralizedTableau<T, I, C>,
+    where: [
+        T::Coeff: PartialOrd<f64>,
+        Complex<T::Coeff>: From<Complex<f64>>,
+    ],
 }
 
-impl<T: Config> Depolarizing2<T> for Tableau<T>
-where
-    T::Coeff: PartialOrd<f64> + Zero,
-{
-    fn depolarize2(&mut self, addr0: usize, addr1: usize, p: <T as Config>::Coeff) {
-        let r = self.rng.random::<f64>();
-        let p_arr: [T::Coeff; 15] = core::array::from_fn(|_| p.clone() * (1.0 / 15.0));
-        two_qubit_pauli_error_impl::<T>(self, addr0, addr1, p_arr, r);
-    }
-}
-
-impl<T: Config, I: TableauIndex, C: SparseVector<Complex<T::Coeff>, I>> Depolarizing2<T>
-    for GeneralizedTableau<T, I, C>
-where
-    T::Coeff: PartialOrd<f64> + Zero,
-    Complex<<T as Config>::Coeff>: From<Complex<f64>>,
-{
-    fn depolarize2(&mut self, addr0: usize, addr1: usize, p: <T as Config>::Coeff) {
-        if self.is_lost[addr0] || self.is_lost[addr1] {
-            return;
-        }
-
-        let r = self.tableau.rng.random::<f64>();
-        let p_arr: [T::Coeff; 15] = core::array::from_fn(|_| p.clone() * (1.0 / 15.0));
-        two_qubit_pauli_error_impl::<T>(self, addr0, addr1, p_arr, r);
-    }
-}
+// === GeneralizedTableau-specific loss channels (no Tableau equivalent) ===
 
 impl<T: Config, I: TableauIndex + Send + Sync, C: SparseVector<Complex<T::Coeff>, I>> LossChannel<T>
     for GeneralizedTableau<T, I, C>
@@ -583,6 +479,46 @@ mod tests {
         t.reset_loss_channel(0);
         t.x(0); // should no longer be a no-op
         assert!(t.measure(0).unwrap());
+    }
+
+    // === Seeded RNG ordering ===
+    //
+    // `Depolarizing` and `PauliError` must consume RNG unconditionally so
+    // that seeded traces are reproducible regardless of loss events. The
+    // selected Clifford gate no-ops on lost qubits (see gates/clifford.rs).
+
+    #[test]
+    fn depolarize_rng_consumed_on_lost_qubit() {
+        let seed = 42u64;
+        let mut t_active = tab(1);
+        t_active.tableau.rng = rand::SeedableRng::seed_from_u64(seed);
+        t_active.depolarize(0, 0.3);
+        let next_active: f64 = t_active.tableau.rng.random();
+
+        let mut t_lost = tab(1);
+        t_lost.tableau.rng = rand::SeedableRng::seed_from_u64(seed);
+        t_lost.is_lost[0] = true;
+        t_lost.depolarize(0, 0.3);
+        let next_lost: f64 = t_lost.tableau.rng.random();
+
+        assert_eq!(next_active, next_lost);
+    }
+
+    #[test]
+    fn pauli_error_rng_consumed_on_lost_qubit() {
+        let seed = 42u64;
+        let mut t_active = tab(1);
+        t_active.tableau.rng = rand::SeedableRng::seed_from_u64(seed);
+        t_active.pauli_error(0, [0.1, 0.1, 0.1]);
+        let next_active: f64 = t_active.tableau.rng.random();
+
+        let mut t_lost = tab(1);
+        t_lost.tableau.rng = rand::SeedableRng::seed_from_u64(seed);
+        t_lost.is_lost[0] = true;
+        t_lost.pauli_error(0, [0.1, 0.1, 0.1]);
+        let next_lost: f64 = t_lost.tableau.rng.random();
+
+        assert_eq!(next_active, next_lost);
     }
 
     // === Statistical tests ===

--- a/crates/ppvm-tableau/src/tableau_like.rs
+++ b/crates/ppvm-tableau/src/tableau_like.rs
@@ -1,0 +1,154 @@
+//! [`TableauLike`] trait: shared interface for stabilizer-tableau backends.
+//!
+//! Any type implementing [`TableauLike`] gets default implementations of
+//! single- and two-qubit Pauli noise channels (Depolarizing, PauliError,
+//! Depolarizing2, TwoQubitPauliError). New tableau backends only need to
+//! provide [`TableauLike::rng_mut`] and (optionally) override
+//! [`TableauLike::is_qubit_lost`].
+
+use num::Zero;
+use rand::{Rng, RngExt};
+
+use ppvm_runtime::traits::{Clifford, Coefficient};
+
+// `Zero` is used for `Self::Coeff::zero()` inside default method bodies; the
+// bound itself is redundant on `Self::Coeff` because `Coefficient: num::Zero`.
+
+/// A stabilizer-tableau-like backend that supports Clifford gates and an RNG.
+///
+/// Implementing this trait grants default implementations of the Pauli noise
+/// channels via [`TableauLike::depolarize_impl`] and friends. The associated
+/// `Rng` type lets each backend choose its own RNG; nothing in this trait
+/// depends on `SmallRng`.
+pub trait TableauLike: Clifford {
+    /// Coefficient type used for probabilities.
+    type Coeff: Coefficient + PartialOrd<f64>;
+
+    /// RNG type backing the stochastic channels.
+    type Rng: Rng + RngExt;
+
+    /// Mutable access to the backend's RNG.
+    fn rng_mut(&mut self) -> &mut Self::Rng;
+
+    /// Whether the qubit at `addr` is lost. Default: never lost.
+    #[inline]
+    fn is_qubit_lost(&self, _addr: usize) -> bool {
+        false
+    }
+
+    /// Single-qubit depolarizing channel.
+    ///
+    /// RNG is consumed unconditionally; the selected Clifford gate is expected
+    /// to no-op on lost qubits. This preserves seeded RNG sequences across
+    /// loss events.
+    #[inline]
+    fn depolarize_impl(&mut self, addr0: usize, p: Self::Coeff) {
+        #[allow(clippy::manual_range_contains)]
+        // Can't use RangeInclusive::contains: it requires PartialOrd<Self>,
+        // but Self::Coeff only provides PartialOrd<f64>.
+        {
+            debug_assert!(p >= 0.0 && p <= 1.0);
+        }
+        let r = self.rng_mut().random::<f64>();
+        if p <= r {
+            return;
+        }
+        if p > r * 3.0 {
+            // p / 3 > r >= 0
+            self.x(addr0);
+        } else if p > r * 1.5 {
+            // 2p/3 > r >= p / 3
+            self.y(addr0);
+        } else {
+            // p > r >= 2p/3
+            self.z(addr0);
+        }
+    }
+
+    /// Single-qubit Pauli-error channel (X, Y, Z with given probabilities).
+    ///
+    /// RNG is consumed unconditionally; the selected Clifford gate is expected
+    /// to no-op on lost qubits. This preserves seeded RNG sequences across
+    /// loss events.
+    #[inline]
+    fn pauli_error_impl(&mut self, addr0: usize, p: [Self::Coeff; 3]) {
+        #[allow(clippy::manual_range_contains)]
+        {
+            debug_assert!(p.iter().all(|p_| *p_ >= 0.0 && *p_ <= 1.0));
+        }
+        let r = self.rng_mut().random::<f64>();
+        let mut cumulative = Self::Coeff::zero();
+        for (i, p_) in p.iter().enumerate() {
+            cumulative += p_.clone();
+            if cumulative > r {
+                match i {
+                    0 => self.x(addr0),
+                    1 => self.y(addr0),
+                    _ => self.z(addr0),
+                }
+                return;
+            }
+        }
+    }
+
+    /// Two-qubit Pauli-error channel (15 non-identity Pauli combinations).
+    #[inline]
+    fn two_qubit_pauli_error_impl(&mut self, addr0: usize, addr1: usize, p: [Self::Coeff; 15]) {
+        if self.is_qubit_lost(addr0) || self.is_qubit_lost(addr1) {
+            return;
+        }
+        #[allow(clippy::manual_range_contains)]
+        {
+            debug_assert!(p.iter().all(|p_| *p_ >= 0.0 && *p_ <= 1.0));
+        }
+        let r = self.rng_mut().random::<f64>();
+        let sum = Self::Coeff::zero();
+        let idx = p
+            .iter()
+            .scan(sum, |acc, p_| {
+                *acc += p_.clone();
+                Some(acc.clone())
+            })
+            .position(|cum_prob| cum_prob > r);
+
+        if let Some(i) = idx {
+            #[rustfmt::skip]
+            const PAULI_PAIRS: [(u8, u8); 16] = [
+                (0,0),(0,1),(0,2),(0,3),
+                (1,0),(1,1),(1,2),(1,3),
+                (2,0),(2,1),(2,2),(2,3),
+                (3,0),(3,1),(3,2),(3,3),
+            ];
+            let cartesian_index = PAULI_PAIRS[i + 1]; // skip II entry
+
+            match cartesian_index.0 {
+                0 => {}
+                1 => self.x(addr0),
+                2 => self.y(addr0),
+                _ => self.z(addr0),
+            }
+
+            match cartesian_index.1 {
+                0 => {}
+                1 => self.x(addr1),
+                2 => self.y(addr1),
+                _ => self.z(addr1),
+            }
+        }
+    }
+
+    /// Two-qubit depolarizing channel: spreads `p` over the 15 non-identity
+    /// two-qubit Pauli errors.
+    #[inline]
+    fn depolarize2_impl(&mut self, addr0: usize, addr1: usize, p: Self::Coeff) {
+        if self.is_qubit_lost(addr0) || self.is_qubit_lost(addr1) {
+            return;
+        }
+        #[allow(clippy::manual_range_contains)]
+        {
+            debug_assert!(p >= 0.0 && p <= 1.0);
+        }
+        let p_arr: [Self::Coeff; 15] = core::array::from_fn(|_| p.clone() * (1.0 / 15.0));
+        self.two_qubit_pauli_error_impl(addr0, addr1, p_arr);
+    }
+}


### PR DESCRIPTION
## Summary

Four independent trait-system improvements, net **-402 lines**. All 199 library tests pass; Python bindings still compile.

1. **`sum/noise.rs` arithmetic:** rewrote `f64 op T::Coeff` as `T::Coeff op f64`, eliminating `f64: Mul/Add/Sub<T::Coeff>` bounds from 7 impl blocks. The 15-arm `TwoQubitPauliError` match now uses a small `one_minus_two_sum` helper instead of 8-line repeated expressions.

2. **`TableauLike` trait (new, in `ppvm-tableau`):** carries default implementations of `depolarize_impl`, `pauli_error_impl`, `two_qubit_pauli_error_impl`, `depolarize2_impl`. `Tableau` and `GeneralizedTableau` implement it with just `rng_mut` (and, for GT, `is_qubit_lost`); their noise trait impls collapse to one-line delegations. **Extensibility:** new tableau-like backends inherit all Pauli noise channels for free.

3. **Blanket `Clifford` for `PauliWordTrait`:** removed `Clifford` from `PauliWordTrait`'s supertraits and added `impl<T: PauliWordTrait> Clifford for T` plus a matching `CliffordExtensions` blanket. Loss guards use `get_lbit()` — which returns `false` for `PauliWord` and the actual bit for `LossyPauliWord` — so the guard is optimized away on the non-lossy type. This deletes ~380 lines of duplicated gate logic across `word/clifford.rs` and `loss/clifford.rs` (tests retained). **Extensibility:** new `PauliWordTrait` types automatically get correct Clifford behavior.

4. **`PauliSum` where-clause cleanup:** `impl<S, H, T> ... where T: Config<Storage = S, BuildHasher = H>` collapses to `impl<T: Config>` using `T::Storage` / `T::BuildHasher` directly in the `Clifford`, `RotationOne`, `RotationTwo` impls.

Two planned phases were dropped after investigation:
- Adding `PartialOrd<f64>` to `Coefficient`: blocked because `Complex<f64>` doesn't (and can't) implement ordering.
- Consolidating `ACMap` sub-traits: current granularity is load-bearing — `sum/rot1.rs`/`rot2.rs` depend only on `ACMapInsert + ACMapConsume`, which is the interface-segregation principle at work.

Plan file: `~/.claude/plans/generic-hopping-kay.md` (local, not committed).

## Test plan

- [x] `cargo test --workspace --lib --exclude ppvm-python-native` passes (199 tests)
- [x] `cargo test --workspace --lib --exclude ppvm-python-native --all-features` passes
- [x] `cargo build -p ppvm-python-native` succeeds
- [x] `cargo clippy --workspace --exclude ppvm-python-native` clean
- [ ] CI green
- [ ] `cargo bench -p ppvm-tableau --bench micro` shows no regression (noise channels are now one extra indirection via trait default method — should inline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)