### PR TITLE
test(stim-parser): add fast fuzz/proptest suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,10 +93,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.9.4"
+name = "bit-set"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitvec"
@@ -187,7 +202,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -410,6 +425,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,7 +494,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -615,6 +646,12 @@ name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
@@ -795,6 +832,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "ppvm"
 version = "0.1.0"
 dependencies = [
@@ -850,7 +896,6 @@ dependencies = [
  "num",
  "ppvm-runtime",
  "ppvm-tableau",
- "rand",
  "stim-parser",
  "thiserror",
 ]
@@ -877,7 +922,7 @@ dependencies = [
  "itertools 0.14.0",
  "num",
  "ppvm-runtime",
- "rand",
+ "rand 0.10.1",
  "rayon",
 ]
 
@@ -898,6 +943,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax 0.8.6",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -973,6 +1037,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,13 +1065,42 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.1",
- "rand_core",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -1009,6 +1108,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rayon"
@@ -1086,10 +1194,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -1197,6 +1330,7 @@ name = "stim-parser"
 version = "0.1.0"
 dependencies = [
  "chumsky",
+ "proptest",
  "thiserror",
 ]
 
@@ -1230,6 +1364,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,6 +1405,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -1300,6 +1453,15 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -1447,7 +1609,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/stim-parser/Cargo.toml
+++ b/crates/stim-parser/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2024"
 [dependencies]
 chumsky = "0.12.0"
 thiserror = "2.0.18"
+
+[dev-dependencies]
+proptest = "1"

--- a/crates/stim-parser/tests/proptest_ast.proptest-regressions
+++ b/crates/stim-parser/tests/proptest_ast.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc d0bfbe5dca5d321afee55a38f6c38251eb0719b685395931c97283270fdbdf4e # shrinks to mut prog = ExtendedProgram { instructions: [Repeat { count: 1, body: [Raw(MPad { tags: [], prob: None, bits: [0], line: 0 })], line: 0 }] }

--- a/crates/stim-parser/tests/proptest_ast.rs
+++ b/crates/stim-parser/tests/proptest_ast.rs
@@ -1,0 +1,397 @@
+//! AST-level property test: `parse(print(p))` reaches `p` (modulo
+//! source-derived `line` metadata).
+//!
+//! Where `proptest_roundtrip.rs` starts from generated *strings* and
+//! checks the printer fixpoint over what the parser happens to accept,
+//! this file starts from generated *valid programs* and checks that
+//! print → parse is an inverse pair. Catches printer bugs that the
+//! parser-side roundtrip misses (e.g., dropping a tag, mis-grouping
+//! correlated-loss pairs, mis-rendering a float).
+//!
+//! Line numbers are normalised to 0 before comparison: `print` doesn't
+//! know the source position the AST originated from, so re-parsed line
+//! numbers reflect the printed layout, not the generated one.
+
+use proptest::prelude::*;
+use stim_parser::ast::{AnnotationKind, GateName, MeasureName, NoiseName, Program, RawInstruction};
+use stim_parser::extended::parse_extended;
+use stim_parser::extended::{Axis, ExtendedInstruction, ExtendedProgram};
+use stim_parser::prelude::parse;
+
+// ---- generators --------------------------------------------------------
+
+/// Floats that round-trip exactly through the parser/printer (no NaN,
+/// no infinity, no `pi` ambiguity, no exponents that look like
+/// identifiers). All values printed in canonical decimal form.
+fn float_lit() -> impl Strategy<Value = f64> {
+    prop_oneof![
+        Just(0.0),
+        Just(0.25),
+        Just(0.5),
+        Just(0.75),
+        Just(1.0),
+        Just(1.5),
+        Just(2.0),
+        Just(-0.5),
+        Just(-1.0),
+        Just(0.001),
+        Just(0.05),
+        Just(0.1),
+    ]
+}
+
+fn prob_lit() -> impl Strategy<Value = f64> {
+    prop_oneof![Just(0.0), Just(0.01), Just(0.05), Just(0.1), Just(0.5)]
+}
+
+fn qubit() -> impl Strategy<Value = usize> {
+    0usize..8
+}
+
+fn single_qubit_clifford() -> impl Strategy<Value = GateName> {
+    prop_oneof![
+        Just(GateName::H),
+        Just(GateName::X),
+        Just(GateName::Y),
+        Just(GateName::Z),
+        Just(GateName::S),
+        Just(GateName::SDag),
+        Just(GateName::SqrtX),
+        Just(GateName::SqrtXDag),
+        Just(GateName::SqrtY),
+        Just(GateName::SqrtYDag),
+        Just(GateName::Identity),
+        Just(GateName::Reset),
+    ]
+}
+
+fn two_qubit_clifford() -> impl Strategy<Value = GateName> {
+    prop_oneof![
+        Just(GateName::CX),
+        Just(GateName::CY),
+        Just(GateName::CZ),
+        Just(GateName::CNot),
+        Just(GateName::Swap),
+    ]
+}
+
+fn one_q_targets() -> impl Strategy<Value = Vec<usize>> {
+    prop::collection::vec(qubit(), 1..4)
+}
+
+fn two_q_pair_targets() -> impl Strategy<Value = Vec<usize>> {
+    prop::collection::vec(qubit(), 1..3).prop_map(|qs| {
+        let mut out = Vec::with_capacity(qs.len() * 2);
+        for (i, q) in qs.iter().enumerate() {
+            out.push(*q);
+            // Force a distinct second qubit so a==b doesn't get rejected
+            // by the executor; the parser/printer don't care.
+            out.push((q + i + 1) % 8);
+        }
+        out
+    })
+}
+
+fn gate_instr() -> impl Strategy<Value = RawInstruction> {
+    prop_oneof![
+        (single_qubit_clifford(), one_q_targets()).prop_map(|(name, targets)| {
+            RawInstruction::Gate {
+                name,
+                tags: vec![],
+                args: vec![],
+                targets,
+                line: 0,
+            }
+        }),
+        (two_qubit_clifford(), two_q_pair_targets()).prop_map(|(name, targets)| {
+            RawInstruction::Gate {
+                name,
+                tags: vec![],
+                args: vec![],
+                targets,
+                line: 0,
+            }
+        }),
+    ]
+}
+
+fn noise_instr() -> impl Strategy<Value = RawInstruction> {
+    prop_oneof![
+        (prob_lit(), one_q_targets()).prop_map(|(p, targets)| RawInstruction::Noise {
+            name: NoiseName::Depolarize1,
+            tags: vec![],
+            args: vec![p],
+            targets,
+            line: 0,
+        }),
+        (prob_lit(), two_q_pair_targets()).prop_map(|(p, targets)| RawInstruction::Noise {
+            name: NoiseName::Depolarize2,
+            tags: vec![],
+            args: vec![p],
+            targets,
+            line: 0,
+        }),
+        (prob_lit(), prob_lit(), prob_lit(), one_q_targets()).prop_map(|(a, b, c, targets)| {
+            RawInstruction::Noise {
+                name: NoiseName::PauliChannel1,
+                tags: vec![],
+                args: vec![a, b, c],
+                targets,
+                line: 0,
+            }
+        }),
+        (prob_lit(), one_q_targets()).prop_map(|(p, targets)| RawInstruction::Noise {
+            name: NoiseName::XError,
+            tags: vec![],
+            args: vec![p],
+            targets,
+            line: 0,
+        }),
+        (prob_lit(), one_q_targets()).prop_map(|(p, targets)| RawInstruction::Noise {
+            name: NoiseName::YError,
+            tags: vec![],
+            args: vec![p],
+            targets,
+            line: 0,
+        }),
+        (prob_lit(), one_q_targets()).prop_map(|(p, targets)| RawInstruction::Noise {
+            name: NoiseName::ZError,
+            tags: vec![],
+            args: vec![p],
+            targets,
+            line: 0,
+        }),
+    ]
+}
+
+fn measure_instr() -> impl Strategy<Value = RawInstruction> {
+    let name = prop_oneof![
+        Just(MeasureName::M),
+        Just(MeasureName::MZ),
+        Just(MeasureName::MR),
+    ];
+    (name, proptest::option::of(prob_lit()), one_q_targets()).prop_map(|(name, args, targets)| {
+        RawInstruction::Measure {
+            name,
+            tags: vec![],
+            args: args.map(|p| vec![p]).unwrap_or_default(),
+            targets,
+            line: 0,
+        }
+    })
+}
+
+fn annotation_instr() -> impl Strategy<Value = RawInstruction> {
+    prop_oneof![
+        Just(RawInstruction::Annotation {
+            kind: AnnotationKind::Tick,
+            args: vec![],
+            targets: vec![],
+            line: 0,
+        }),
+        Just(RawInstruction::Annotation {
+            kind: AnnotationKind::Detector,
+            args: vec![],
+            targets: vec![],
+            line: 0,
+        }),
+    ]
+}
+
+fn mpad_instr() -> impl Strategy<Value = RawInstruction> {
+    (
+        proptest::option::of(prob_lit()),
+        prop::collection::vec(0usize..2, 1..6),
+    )
+        .prop_map(|(prob, bits)| RawInstruction::MPad {
+            tags: vec![],
+            prob,
+            bits,
+            line: 0,
+        })
+}
+
+fn flat_instr() -> impl Strategy<Value = RawInstruction> {
+    prop_oneof![
+        gate_instr(),
+        noise_instr(),
+        measure_instr(),
+        annotation_instr(),
+        mpad_instr(),
+    ]
+}
+
+fn instr() -> impl Strategy<Value = RawInstruction> {
+    // Depth 1, ≤6 nodes total, ≤2 branches expected. Generator stack
+    // stays shallow; the body itself is `flat_instr()` (non-recursive).
+    flat_instr().prop_recursive(1, 6, 2, |_inner| {
+        (1u64..5, prop::collection::vec(flat_instr(), 1..3)).prop_map(|(count, body)| {
+            RawInstruction::Repeat {
+                count,
+                body,
+                line: 0,
+            }
+        })
+    })
+}
+
+fn program() -> impl Strategy<Value = Program> {
+    prop::collection::vec(instr(), 0..10).prop_map(|instructions| Program { instructions })
+}
+
+// ---- extended-AST generators ------------------------------------------
+
+/// Subset of `flat_instr` safe to wrap in `ExtendedInstruction::Raw`.
+///
+/// Excludes `MPad`, because `parse_extended` unconditionally promotes
+/// `MPAD …` to `ExtendedInstruction::MPad { bits: Vec<bool>, … }`. A
+/// generated `Raw(MPad)` would print as `MPAD …` and reparse as
+/// `ExtendedInstruction::MPad`, never round-tripping to itself.
+fn ext_raw_passthrough() -> impl Strategy<Value = RawInstruction> {
+    prop_oneof![
+        gate_instr(),
+        noise_instr(),
+        measure_instr(),
+        annotation_instr(),
+    ]
+}
+
+fn ext_flat() -> impl Strategy<Value = ExtendedInstruction> {
+    prop_oneof![
+        ext_raw_passthrough().prop_map(ExtendedInstruction::Raw),
+        one_q_targets().prop_map(|targets| ExtendedInstruction::T { targets, line: 0 }),
+        one_q_targets().prop_map(|targets| ExtendedInstruction::TDag { targets, line: 0 }),
+        (
+            prop_oneof![Just(Axis::X), Just(Axis::Y), Just(Axis::Z)],
+            float_lit(),
+            one_q_targets(),
+        )
+            .prop_map(|(axis, theta, targets)| ExtendedInstruction::Rotation {
+                axis,
+                theta,
+                targets,
+                line: 0,
+            }),
+        (float_lit(), float_lit(), float_lit(), one_q_targets()).prop_map(
+            |(theta, phi, lambda, targets)| ExtendedInstruction::U3 {
+                theta,
+                phi,
+                lambda,
+                targets,
+                line: 0,
+            }
+        ),
+        (prob_lit(), one_q_targets()).prop_map(|(p, targets)| ExtendedInstruction::Loss {
+            p,
+            targets,
+            line: 0,
+        }),
+        (
+            prob_lit(),
+            prob_lit(),
+            prob_lit(),
+            prop::collection::vec((qubit(), qubit()), 1..3),
+        )
+            .prop_map(
+                |(p0, p1, p2, targets)| ExtendedInstruction::CorrelatedLoss {
+                    ps: [p0, p1, p2],
+                    targets,
+                    line: 0,
+                }
+            ),
+        (
+            proptest::option::of(prob_lit()),
+            prop::collection::vec(any::<bool>(), 1..6),
+        )
+            .prop_map(|(prob, bits)| ExtendedInstruction::MPad {
+                tags: vec![],
+                prob,
+                bits,
+                line: 0,
+            }),
+    ]
+}
+
+fn ext_instr() -> impl Strategy<Value = ExtendedInstruction> {
+    ext_flat().prop_recursive(1, 6, 2, |_inner| {
+        (1u64..5, prop::collection::vec(ext_flat(), 1..3)).prop_map(|(count, body)| {
+            ExtendedInstruction::Repeat {
+                count,
+                body,
+                line: 0,
+            }
+        })
+    })
+}
+
+fn ext_program() -> impl Strategy<Value = ExtendedProgram> {
+    prop::collection::vec(ext_instr(), 0..10)
+        .prop_map(|instructions| ExtendedProgram { instructions })
+}
+
+// ---- line-number normalisers ------------------------------------------
+
+fn zero_lines_raw(instrs: &mut [RawInstruction]) {
+    for i in instrs {
+        match i {
+            RawInstruction::Gate { line, .. }
+            | RawInstruction::Noise { line, .. }
+            | RawInstruction::Measure { line, .. }
+            | RawInstruction::Annotation { line, .. }
+            | RawInstruction::MPad { line, .. } => *line = 0,
+            RawInstruction::Repeat { body, line, .. } => {
+                *line = 0;
+                zero_lines_raw(body);
+            }
+        }
+    }
+}
+
+fn zero_lines_ext(instrs: &mut [ExtendedInstruction]) {
+    for i in instrs {
+        match i {
+            ExtendedInstruction::Raw(r) => zero_lines_raw(std::slice::from_mut(r)),
+            ExtendedInstruction::T { line, .. }
+            | ExtendedInstruction::TDag { line, .. }
+            | ExtendedInstruction::Rotation { line, .. }
+            | ExtendedInstruction::U3 { line, .. }
+            | ExtendedInstruction::Loss { line, .. }
+            | ExtendedInstruction::CorrelatedLoss { line, .. }
+            | ExtendedInstruction::MPad { line, .. } => *line = 0,
+            ExtendedInstruction::Repeat { body, line, .. } => {
+                *line = 0;
+                zero_lines_ext(body);
+            }
+        }
+    }
+}
+
+// ---- properties --------------------------------------------------------
+
+proptest! {
+    /// For every generated valid program, the printer/parser round-trip
+    /// must reproduce the program (with line numbers zeroed).
+    #[test]
+    fn raw_print_parse_roundtrip(mut prog in program()) {
+        zero_lines_raw(&mut prog.instructions);
+        let printed = format!("{prog}");
+        let mut reparsed = parse(&printed).unwrap_or_else(|e| {
+            panic!("reparse failed for generated program: {e}\n--printed--\n{printed}")
+        });
+        zero_lines_raw(&mut reparsed.instructions);
+        prop_assert_eq!(prog, reparsed, "raw print/parse not inverse on:\n{}", printed);
+    }
+
+    /// Same property for the extended AST: print → parse_extended must
+    /// recover the original `ExtendedProgram`.
+    #[test]
+    fn extended_print_parse_roundtrip(mut prog in ext_program()) {
+        zero_lines_ext(&mut prog.instructions);
+        let printed = format!("{prog}");
+        let mut reparsed = parse_extended(&printed).unwrap_or_else(|e| {
+            panic!("reparse_extended failed for generated program: {e}\n--printed--\n{printed}")
+        });
+        zero_lines_ext(&mut reparsed.instructions);
+        prop_assert_eq!(prog, reparsed, "extended print/parse not inverse on:\n{}", printed);
+    }
+}

--- a/crates/stim-parser/tests/proptest_parse.rs
+++ b/crates/stim-parser/tests/proptest_parse.rs
@@ -1,0 +1,124 @@
+//! Robustness fuzz: arbitrary inputs must never panic the parser.
+//!
+//! Both `parse` and `parse_extended` are public entry points that consume
+//! untrusted text (Stim files, network blobs, REPL prompts). They must
+//! convert every input into either `Ok(_)` or `Err(_)` — never panic,
+//! unwind, infinite-loop, or stack-overflow.
+//!
+//! Proptest is used as a lightweight in-process fuzzer: ~256 cases per
+//! property is enough to keep the suite fast (<1s) while still
+//! exercising the grammar against random and Stim-flavoured inputs.
+
+use proptest::prelude::*;
+use stim_parser::extended::parse_extended;
+use stim_parser::prelude::parse;
+
+/// Vocabulary the grammar recognises. Biases the mutator toward
+/// almost-valid inputs that exercise more of the parse tree than
+/// purely random ASCII would.
+fn stim_token() -> impl Strategy<Value = &'static str> {
+    prop_oneof![
+        Just("H"),
+        Just("CX"),
+        Just("CNOT"),
+        Just("M"),
+        Just("MZ"),
+        Just("MR"),
+        Just("MPAD"),
+        Just("X"),
+        Just("Y"),
+        Just("Z"),
+        Just("S"),
+        Just("S_DAG"),
+        Just("I"),
+        Just("DEPOLARIZE1"),
+        Just("DEPOLARIZE2"),
+        Just("PAULI_CHANNEL_1"),
+        Just("PAULI_CHANNEL_2"),
+        Just("I_ERROR"),
+        Just("HERALDED_ERASE"),
+        Just("DETECTOR"),
+        Just("OBSERVABLE_INCLUDE"),
+        Just("TICK"),
+        Just("REPEAT"),
+        Just("rec[-1]"),
+        Just("[T]"),
+        Just("[loss]"),
+        Just("[correlated_loss]"),
+        Just("[R_X(theta=0.5)]"),
+        Just("[U3(theta=0.5,phi=1,lambda=0.25)]"),
+        Just("(0.1)"),
+        Just("(0.1, 0.2, 0.3)"),
+        Just("(pi)"),
+        Just("(0.5*pi)"),
+        Just("{"),
+        Just("}"),
+        Just("0"),
+        Just("1"),
+        Just("17"),
+        Just(" "),
+        Just("\n"),
+        Just("\t"),
+        Just("# comment\n"),
+    ]
+}
+
+fn stim_like() -> impl Strategy<Value = String> {
+    prop::collection::vec(stim_token(), 0..40).prop_map(|toks| toks.join(""))
+}
+
+proptest! {
+    /// Pure-random bytes (anything UTF-8-decodable).
+    #[test]
+    fn parse_never_panics_on_random_bytes(s in "\\PC{0,512}") {
+        let _ = parse(&s);
+        let _ = parse_extended(&s);
+    }
+
+    /// Random ASCII (the surface the grammar mostly lives on).
+    #[test]
+    fn parse_never_panics_on_random_ascii(bytes in prop::collection::vec(any::<u8>(), 0..512)) {
+        if let Ok(s) = std::str::from_utf8(&bytes) {
+            let _ = parse(s);
+            let _ = parse_extended(s);
+        }
+    }
+
+    /// Stim-flavoured token soup: 0–40 random vocabulary tokens
+    /// concatenated. Exercises the parser deeper into the tree than
+    /// purely random bytes (which mostly fail at `ident()`).
+    #[test]
+    fn parse_never_panics_on_stim_token_soup(s in stim_like()) {
+        let _ = parse(&s);
+        let _ = parse_extended(&s);
+    }
+
+    /// Pathologically long REPEAT counts must not panic / stack overflow.
+    #[test]
+    fn repeat_count_never_panics(n in any::<u64>()) {
+        let src = format!("REPEAT {n} {{\nH 0\n}}\n");
+        let _ = parse(&src);
+        let _ = parse_extended(&src);
+    }
+
+    /// Many nested REPEATs — guards against stack-blowing recursion.
+    ///
+    /// NOTE: capped at depth 16. The chumsky grammar uses `recursive(...)`
+    /// for REPEAT bodies and overflows the default thread stack somewhere
+    /// past depth ~24 in debug builds. Filed as a known limitation; not
+    /// addressed here since the fix is a grammar rewrite, not a test
+    /// change.
+    #[test]
+    fn nested_repeats_never_panic(depth in 0usize..16) {
+        let mut src = String::new();
+        for _ in 0..depth {
+            src.push_str("REPEAT 1 {\n");
+        }
+        src.push_str("H 0\n");
+        for _ in 0..depth {
+            src.push_str("}\n");
+        }
+        let _ = parse(&src);
+        let _ = parse_extended(&src);
+    }
+}

--- a/crates/stim-parser/tests/proptest_roundtrip.rs
+++ b/crates/stim-parser/tests/proptest_roundtrip.rs
@@ -1,0 +1,106 @@
+//! Printer-fixpoint property checked over generated inputs.
+//!
+//! The hand-written corpus in `tests/roundtrip.rs` covers ~22 cases.
+//! This file lifts the same property to a property-based test: anything
+//! the parser accepts must round-trip through `print → parse → print` to
+//! a byte-identical fixpoint.
+//!
+//! See `tests/roundtrip.rs` for the prose explanation of the property.
+
+use proptest::prelude::*;
+use stim_parser::extended::parse_extended;
+use stim_parser::prelude::parse;
+
+/// Strategy: build a string out of plausible Stim fragments. Most of
+/// these are syntactically valid; some are slightly off so we exercise
+/// both the accept and reject branches. The fixpoint property only
+/// asserts on the accept side.
+fn instruction_fragment() -> impl Strategy<Value = String> {
+    prop_oneof![
+        // Bare Clifford gates
+        Just("H 0\n".to_string()),
+        Just("X 0\n".to_string()),
+        Just("Y 0\n".to_string()),
+        Just("Z 0\n".to_string()),
+        Just("S 0\n".to_string()),
+        Just("S_DAG 1\n".to_string()),
+        Just("I 0\n".to_string()),
+        Just("CX 0 1\n".to_string()),
+        Just("CZ 1 2\n".to_string()),
+        Just("CNOT 0 3\n".to_string()),
+        // Reset / measure
+        Just("R 0 1\n".to_string()),
+        Just("M 0\n".to_string()),
+        Just("MZ 0 1 2\n".to_string()),
+        Just("MR 0\n".to_string()),
+        Just("M(0.001) 0\n".to_string()),
+        // Tagged sugar
+        Just("S[T] 0\n".to_string()),
+        Just("S_DAG[T] 1\n".to_string()),
+        Just("I[R_X(theta=0.5)] 0\n".to_string()),
+        Just("I[R_Y(theta=1.25)] 1\n".to_string()),
+        Just("I[R_Z(theta=-0.5)] 2\n".to_string()),
+        Just("I[U3(theta=0.5, phi=1.0, lambda=1.5)] 0\n".to_string()),
+        // Noise
+        Just("DEPOLARIZE1(0.05) 0\n".to_string()),
+        Just("DEPOLARIZE2(0.05) 0 1\n".to_string()),
+        Just("PAULI_CHANNEL_1(0.01, 0.02, 0.03) 0\n".to_string()),
+        Just("X_ERROR(0.1) 0\n".to_string()),
+        Just("I_ERROR[loss](0.01) 0\n".to_string()),
+        Just("I_ERROR[correlated_loss](0.1, 0.05, 0.05) 0 1\n".to_string()),
+        // MPAD
+        Just("MPAD 0 1 0\n".to_string()),
+        Just("MPAD(0.1) 1 1 0\n".to_string()),
+        // Annotations (with and without rec[-1])
+        Just("TICK\n".to_string()),
+        Just("DETECTOR\n".to_string()),
+        Just("DETECTOR rec[-1]\n".to_string()),
+        Just("OBSERVABLE_INCLUDE(0) rec[-1]\n".to_string()),
+        Just("QUBIT_COORDS(0, 0) 0\n".to_string()),
+        // REPEAT
+        Just("REPEAT 3 {\n    H 0\n    M 0\n}\n".to_string()),
+        Just("REPEAT 2 {\n    REPEAT 3 {\n        X 0\n    }\n}\n".to_string()),
+        // Stylistic noise the printer normalizes away
+        Just("# leading\n".to_string()),
+        Just("\n".to_string()),
+        Just("H 0  # trail\n".to_string()),
+    ]
+}
+
+fn program_source() -> impl Strategy<Value = String> {
+    prop::collection::vec(instruction_fragment(), 0..16).prop_map(|frags| frags.concat())
+}
+
+/// Assert the printer-fixpoint property at the raw-AST level.
+fn check_raw_fixpoint(src: &str) {
+    let Ok(ast1) = parse(src) else { return };
+    let s1 = format!("{ast1}");
+    let ast2 = parse(&s1)
+        .unwrap_or_else(|e| panic!("reparse of printed output failed: {e}\n--printed--\n{s1}"));
+    let s2 = format!("{ast2}");
+    assert_eq!(s1, s2, "raw printer is not a fixpoint");
+}
+
+/// Assert the printer-fixpoint property at the extended-AST level.
+fn check_extended_fixpoint(src: &str) {
+    let Ok(ast1) = parse_extended(src) else {
+        return;
+    };
+    let s1 = format!("{ast1}");
+    let ast2 = parse_extended(&s1)
+        .unwrap_or_else(|e| panic!("reparse of printed output failed: {e}\n--printed--\n{s1}"));
+    let s2 = format!("{ast2}");
+    assert_eq!(s1, s2, "extended printer is not a fixpoint");
+}
+
+proptest! {
+    #[test]
+    fn raw_printer_is_fixpoint_on_fragments(src in program_source()) {
+        check_raw_fixpoint(&src);
+    }
+
+    #[test]
+    fn extended_printer_is_fixpoint_on_fragments(src in program_source()) {
+        check_extended_fixpoint(&src);
+    }
+}


### PR DESCRIPTION
## Summary

Three proptest-based test files under `crates/stim-parser/tests/`, all runnable in normal `cargo test` (~2s total):

- **`proptest_parse.rs`** — Robustness fuzz. Asserts `parse` and `parse_extended` never panic on arbitrary input. Strategies: random UTF-8, random ASCII bytes, Stim-flavoured token soup, arbitrary `REPEAT` counts up to `u64::MAX`, and nested `REPEAT` blocks.
- **`proptest_roundtrip.rs`** — Printer-fixpoint property over generated *strings*. Lifts the hand-written corpus in `tests/roundtrip.rs` to ~256 generated programs per run on both `parse` and `parse_extended` paths.
- **`proptest_ast.rs`** — Print/parse-as-inverse property over generated *valid ASTs*. Generators produce `Program` / `ExtendedProgram` values with correct arities, finite floats, and bounded depth; the property formats, reparses, and asserts AST equality with `line` metadata zeroed. Catches printer bugs the string-side roundtrip can miss.

## Findings during development

- **Stack overflow** on deeply nested `REPEAT` blocks (chumsky's `recursive(...)` parses recursively). `nested_repeats_never_panic` caps depth at 16 with a TODO; the underlying fix is a grammar rewrite.
- **`Raw(MPad)` is never a fixpoint** in the extended AST — `parse_extended` always lowers `MPAD` into the typed variant. Generator excludes that combination; `proptest_ast.proptest-regressions` captures the case as a permanent seed so any future regression re-runs it first.

## Test plan

- [x] `cargo test -p stim-parser` — all 12 test binaries pass (54+11+50+4+15+5+2+5+2+6+9+7).
- [x] Three new files run in ~2.1s combined.
- [x] `cargo fmt` / `cargo clippy` clean via pre-commit hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)