### PR TITLE
docs: import old Python docs as Astro tutorials + executed notebooks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,10 +23,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      # Site sources. Other paths (crates/, ppvm-python/) don't affect
-      # the build because the API JSON consumed by /api/ is committed
-      # under docs/src/data/ and regenerated manually.
+      # Site sources, the Rust workspace (consumed by the API JSON
+      # extractor), and the Python package (consumed by the notebook
+      # build step + the Python API extractor).
       - "docs/**"
+      - "crates/**"
+      - "ppvm-python/**"
       - ".github/workflows/docs.yml"
   pull_request_target:
     types: [closed]
@@ -94,6 +96,19 @@ jobs:
         run: |
           node scripts/extract-rust.mjs
           node scripts/extract-python.mjs
+
+      - name: Build Jupyter notebooks
+        # `docs/scripts/build-notebooks.py` executes every Jupytext
+        # `.py` under `docs/notebooks/` and writes HTML fragments to
+        # `docs/src/generated/notebooks/`, where the dynamic
+        # `examples/[slug].astro` route picks them up. Uses the
+        # ppvm-python venv so the notebooks can `import ppvm`, plus
+        # the jupyter stack via `uv run --with`.
+        run: |
+          uv run --project ppvm-python \
+            --with jupytext --with nbconvert --with nbclient \
+            --with ipykernel --with matplotlib --with numpy \
+            python docs/scripts/build-notebooks.py
 
       - name: Build site
         working-directory: docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -85,6 +85,19 @@ jobs:
             echo "base=/" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Compute git ref for source links
+        id: compute-ref
+        # "Source" links on the Examples pages resolve against this ref.
+        # PR previews use the PR head SHA so new files (that aren't on
+        # main yet) still link correctly; main deploys use the merge
+        # commit SHA so the link is stable forever.
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build site
         # `npm run build` aggregates the three extraction steps
         # (`extract:rust`, `extract:python`, `extract:notebooks`) plus
@@ -95,6 +108,7 @@ jobs:
         env:
           PPVM_SITE: https://congenial-bassoon-l436wp3.pages.github.io
           PPVM_BASE: ${{ steps.compute-base.outputs.base }}
+          PPVM_GIT_REF: ${{ steps.compute-ref.outputs.ref }}
           RUSTFLAGS: "-C target-feature=+aes,+sse2"
         run: npm run build
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -85,37 +85,18 @@ jobs:
             echo "base=/" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Generate API JSON
-        # The /api/ page reads docs/src/data/{rust,python}-api.json,
-        # which are .gitignore'd and produced by docs/scripts/. The
-        # Rust extractor needs nightly for `--output-format json`;
-        # the Python extractor uses griffe via `uv run --with griffe`.
-        working-directory: docs
-        env:
-          RUSTFLAGS: "-C target-feature=+aes,+sse2"
-        run: |
-          node scripts/extract-rust.mjs
-          node scripts/extract-python.mjs
-
-      - name: Build Jupyter notebooks
-        # `docs/scripts/build-notebooks.py` executes every Jupytext
-        # `.py` under `docs/notebooks/` and writes HTML fragments to
-        # `docs/src/generated/notebooks/`, where the dynamic
-        # `examples/[slug].astro` route picks them up. Uses the
-        # ppvm-python venv so the notebooks can `import ppvm`, plus
-        # the jupyter stack via `uv run --with`.
-        run: |
-          uv run --project ppvm-python \
-            --with jupytext --with nbconvert --with nbclient \
-            --with ipykernel --with matplotlib --with numpy \
-            python docs/scripts/build-notebooks.py
-
       - name: Build site
+        # `npm run build` aggregates the three extraction steps
+        # (`extract:rust`, `extract:python`, `extract:notebooks`) plus
+        # `astro build` into a single command. See `docs/README.md`
+        # for the per-step breakdown and the per-component escape
+        # hatches a developer would use locally.
         working-directory: docs
         env:
           PPVM_SITE: https://congenial-bassoon-l436wp3.pages.github.io
           PPVM_BASE: ${{ steps.compute-base.outputs.base }}
-        run: npx astro build
+          RUSTFLAGS: "-C target-feature=+aes,+sse2"
+        run: npm run build
 
       - name: Upload built site
         uses: actions/upload-artifact@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,9 +33,13 @@ on:
   pull_request_target:
     types: [closed]
 
+# No workflow-wide write privileges. Each job declares the narrowest
+# token scope it actually needs. The `build` job executes user-controlled
+# notebooks via `npm run extract:notebooks`, so its token must not be
+# able to push to `gh-pages` (or anything else). Deploys run on
+# separately-scoped jobs that don't see the notebook execution context.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   # Serialise per-PR (and main); a fresh build cancels any in-flight one
@@ -50,6 +54,11 @@ jobs:
     if: github.event.action != 'closed'
     name: Build Astro site
     runs-on: ubuntu-latest
+    # Notebook execution runs arbitrary repo-controlled Python here;
+    # the token in this job stays read-only so a malicious PR can't
+    # exfiltrate it into a gh-pages write.
+    permissions:
+      contents: read
     outputs:
       base: ${{ steps.compute-base.outputs.base }}
     steps:
@@ -125,6 +134,10 @@ jobs:
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    # Only this job writes to gh-pages; it doesn't run any
+    # repo-controlled scripts (the artifact is already built).
+    permissions:
+      contents: write
     concurrency:
       group: deploy-gh-pages
       cancel-in-progress: false
@@ -151,6 +164,11 @@ jobs:
     needs: build
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
     runs-on: ubuntu-latest
+    # Writes the pre-built artifact to gh-pages/pr-preview/pr-<N>/
+    # and comments back on the PR.
+    permissions:
+      contents: write
+      pull-requests: write
     concurrency:
       group: deploy-gh-pages
       cancel-in-progress: false
@@ -173,6 +191,11 @@ jobs:
     name: Clean up PR preview
     if: github.event_name == 'pull_request_target' && github.event.action == 'closed'
     runs-on: ubuntu-latest
+    # Removes the gh-pages/pr-preview/pr-<N>/ subtree and edits the
+    # PR's preview comment; nothing else.
+    permissions:
+      contents: write
+      pull-requests: write
     concurrency:
       group: deploy-gh-pages
       cancel-in-progress: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,17 @@
 # AGENTS.md
 
 > **Read the Developer Guide first.** The canonical contributor reference for
-> this repository — for both human and AI contributors — lives in the docs
-> site at `docs/src/pages/develop.astro` (rendered at `/develop/`). It covers
-> project layout, build/test commands, architecture, conventions, the Python
-> binding pipeline, and where to look for each subsystem.
+> this repository — for both human and AI contributors — is the Astro page
+> at [`docs/src/pages/develop.astro`](docs/src/pages/develop.astro) (rendered
+> at `/develop/` on the live site). It covers project layout, build/test
+> commands for the Rust workspace, the Python package, **and the docs site
+> itself** (`§ 2 Build & test`), architecture, conventions, the Python
+> binding pipeline, extension recipes, and the file-by-file "where to look
+> for X" table.
 >
-> This file is a short pointer so agents can find that guide quickly. Do not
-> add content here that belongs in the Developer Guide — keep the guide as
-> the single source of truth.
+> This file is a short pointer so agents can find that guide quickly. Do
+> not add content here that belongs in the Developer Guide — keep the
+> guide as the single source of truth.
 
 ## Install the ppvm-usage skill
 
@@ -29,13 +32,19 @@ internals.
 
 If you are an AI agent picking up a task in this repository:
 
-1. Open `docs/src/pages/develop.astro` and read the sections relevant to your
-   task. The "For AI agents" callout at the top tells you which sections are
-   load-bearing.
+1. Open [`docs/src/pages/develop.astro`](docs/src/pages/develop.astro) and
+   read the sections relevant to your task. The "For AI agents" callout at
+   the top tells you which sections are load-bearing.
 2. Use `uv` for anything Python; never `pip`.
 3. Use Conventional Commits: `<type>(<scope>): <description>`.
-4. Build & test with the commands documented in the guide
-   (`cargo test --workspace`, `uv run --project ppvm-python --group dev pytest …`).
+4. Build & test the relevant target:
+   - **Rust workspace**: `cargo test --workspace`
+   - **Python package**: `uv run --project ppvm-python --group dev pytest …`
+   - **Docs site**: `cd docs && npm run build` (chains `extract:rust`,
+     `extract:python`, `extract:notebooks`, then `astro build`).
+     Per-step commands and the `astro:dev` / `astro:build` escape
+     hatches are documented under `§ 2 → "This docs site"` in the
+     Developer Guide and in [`docs/README.md`](docs/README.md).
 5. Respect the `Config`-trait generics in `ppvm-runtime`; do not introduce
    runtime dispatch where a compile-time bound suffices.
 6. Pauli propagation runs **backwards** (Heisenberg picture). Reverse the

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,3 +3,7 @@ dist/
 .astro/
 src/data/rust-api.json
 src/data/python-api.json
+# Outputs from `docs/scripts/build-notebooks.py`. The Jupytext sources
+# under `docs/notebooks/` are tracked; the executed HTML fragments,
+# their metadata, and the index are regenerated on every build.
+src/generated/

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,74 @@
+# ppvm docs site
+
+Astro site for the ppvm documentation. Deployed to gh-pages root by
+`.github/workflows/docs.yml`; PRs that touch this directory get a
+per-PR preview deploy.
+
+## Quick reference
+
+From this directory:
+
+```bash
+npm install                 # one-time
+npm run dev                 # extract + astro dev → http://127.0.0.1:4321
+npm run build               # extract + astro build → ./dist/
+```
+
+`npm run dev` and `npm run build` run every prerequisite extraction
+step first, so a fresh clone has one command to remember. Each
+extraction step is also available on its own when you're iterating on
+a specific layer:
+
+| Command                       | What it does |
+|-------------------------------|-----|
+| `npm run extract:rust`        | Re-run `cargo +nightly rustdoc -- --output-format json` for the three Rust crates and reshape into `src/data/rust-api.json`. Source: `scripts/extract-rust.mjs`. |
+| `npm run extract:python`      | Re-run `griffe dump ppvm` and reshape into `src/data/python-api.json`. Source: `scripts/extract-python.mjs`. |
+| `npm run extract:notebooks`   | Execute every Jupytext `.py` under `notebooks/` and emit HTML fragments + metadata to `src/generated/notebooks/`. Source: `scripts/build-notebooks.py`. |
+| `npm run extract`             | All three of the above, in order. |
+| `npm run astro:dev`           | `astro dev` without extracting anything — handy when you're editing only the Astro layer and trust the existing inputs. |
+| `npm run astro:build`         | `astro build` without extracting anything. |
+
+## Workflow patterns
+
+- **First clone / fresh checkout:** `npm install && npm run dev`.
+- **Iterating on the homepage / layout:** keep `npm run astro:dev` running; re-run `npm run extract:*` only when you change the underlying source.
+- **Changed a Rust public API:** `npm run extract:rust` then refresh the browser. The site picks up the regenerated `src/data/rust-api.json` automatically.
+- **Edited a notebook under `notebooks/`:** `npm run extract:notebooks`.
+- **Added a *new* notebook:** drop it into `notebooks/<name>.py` as a Jupytext-percent file, then `npm run extract:notebooks`. The Examples landing page picks it up from the regenerated `src/generated/notebooks/index.json`.
+
+## Layout
+
+```
+docs/
+├── notebooks/                       # Jupytext .py — executed at build time
+├── scripts/
+│   ├── extract-rust.mjs
+│   ├── extract-python.mjs
+│   └── build-notebooks.py
+├── src/
+│   ├── data/                        # *.json from extract:rust / extract:python  (gitignored)
+│   ├── generated/                   # notebooks/*.html + meta + index           (gitignored)
+│   ├── components/, layouts/, pages/, styles/
+│   └── ...
+├── package.json
+└── astro.config.mjs
+```
+
+`src/data/` and `src/generated/` are `.gitignore`'d; they're rebuilt on
+every CI run via `npm run extract`.
+
+## CI
+
+`.github/workflows/docs.yml` builds the site via `npm run build` on
+every PR that touches `docs/`, `crates/`, `ppvm-python/`, or itself.
+PR previews land at `gh-pages/pr-preview/pr-<N>/`; the main deploy
+publishes to `gh-pages` root on every push to `main`.
+
+## Prerequisites
+
+- Node ≥ 20 (Astro 5 requirement).
+- `uv` (https://docs.astral.sh/uv/) — used to drive the Python
+  notebook executor and the griffe-based Python extractor.
+- Rust nightly — `extract-rust.mjs` invokes `cargo +nightly rustdoc
+  --output-format json`. Install with `rustup toolchain install
+  nightly`.

--- a/docs/notebooks/msd.py
+++ b/docs/notebooks/msd.py
@@ -135,10 +135,22 @@ print(f"Simulated {n_shots} shots of the {n_qubits}-qubit MSD circuit")
 print(f"Total time: {elapsed:.2f} s ({elapsed / n_shots * 1e3:.2f} ms per shot)")
 
 # %% [markdown]
-# Let's look at the measurement outcomes.
+# Let's look at the measurement outcomes. Each shot produces an
+# 85-bit string (one bit per measured qubit). We summarise rather
+# than dump every shot — printing all `n_shots` strings would balloon
+# the rendered notebook page without telling the reader anything
+# new.
 
 # %%
+from collections import Counter
+
 bitstrings = [
     "".join("1" if r == MeasurementResult.ONE else "0" for r in shot)
     for shot in results
 ]
+counts = Counter(bitstrings)
+
+print(f"Distinct outcomes: {len(counts)} / {n_shots}")
+print("Most common 5 patterns:")
+for pattern, count in counts.most_common(5):
+    print(f"  {count:>4}×  {pattern}")

--- a/docs/notebooks/msd.py
+++ b/docs/notebooks/msd.py
@@ -1,0 +1,144 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.19.1
+#   kernelspec:
+#     display_name: ppvm (3.12.12)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Magic State Distillation with the Generalized Stabilizer Tableau
+#
+# Here we simulate an 85-qubit MSD circuit (5 code blocks of 17 qubits each) using ppvm's
+# `GeneralizedTableau`. It is loosely based on [the TSIM example](https://bloqade.quera.com/latest/digital/examples/tsim/magic_state_distillation/),
+# but with fewer details.
+
+# %%
+import time
+
+from ppvm import GeneralizedTableau, MeasurementResult
+
+QUBITS_PER_CODE_BLOCK = 17
+
+
+def encode(tab: GeneralizedTableau, qubits: list[int]) -> None:
+    """Apply the 17-qubit surface code encoding circuit."""
+    for i in [0, 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16]:
+        tab.sqrt_y(qubits[i])
+
+    for i, j in [[1, 3], [7, 10], [12, 14], [13, 16]]:
+        tab.cz(qubits[i], qubits[j])
+    for i in [7, 16]:
+        tab.sqrt_y_adj(qubits[i])
+    for i, j in [[4, 7], [8, 10], [11, 14], [15, 16]]:
+        tab.cz(qubits[i], qubits[j])
+    for i in [4, 10, 14, 16]:
+        tab.sqrt_y_adj(qubits[i])
+    for i, j in [[2, 4], [6, 8], [7, 9], [10, 13], [14, 16]]:
+        tab.cz(qubits[i], qubits[j])
+    for i in [3, 6, 9, 10, 12, 13]:
+        tab.sqrt_y(qubits[i])
+    for i, j in [[0, 2], [3, 6], [5, 8], [10, 12], [11, 13]]:
+        tab.cz(qubits[i], qubits[j])
+    for i in [1, 2, 3, 4, 6, 7, 8, 9, 11, 12, 14]:
+        tab.sqrt_y(qubits[i])
+    for i, j in [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9], [12, 15]]:
+        tab.cz(qubits[i], qubits[j])
+    for i in [0, 2, 5, 6, 8, 10, 12]:
+        tab.sqrt_y_adj(qubits[i])
+
+
+def msd_circuit(tab: GeneralizedTableau) -> list[MeasurementResult]:
+    """Build and measure the full 85-qubit MSD circuit."""
+    n_qubits = QUBITS_PER_CODE_BLOCK * 5
+    qubit_addrs = list(range(n_qubits))
+
+    # Split into 5 code blocks
+    ql = [
+        qubit_addrs[i * QUBITS_PER_CODE_BLOCK : (i + 1) * QUBITS_PER_CODE_BLOCK]
+        for i in range(5)
+    ]
+
+    # Prepare magic state in each block: H + T on encoding qubit, then encode
+    for q in ql:
+        encoding_qubit = q[7]
+        tab.h(encoding_qubit)
+        tab.t(encoding_qubit)
+        encode(tab, q)
+
+    # Cross-block entangling operations
+    for i in [0, 1, 4]:
+        for q in ql[i]:
+            tab.sqrt_x(q)
+
+    for control, target in zip(ql[0], ql[1]):
+        tab.cz(control, target)
+    for control, target in zip(ql[2], ql[3]):
+        tab.cz(control, target)
+
+    for q in ql[0]:
+        tab.sqrt_y(q)
+    for q in ql[3]:
+        tab.sqrt_y(q)
+
+    for control, target in zip(ql[0], ql[2]):
+        tab.cz(control, target)
+    for control, target in zip(ql[3], ql[4]):
+        tab.cz(control, target)
+
+    for q in ql[0]:
+        tab.sqrt_x_adj(q)
+
+    for control, target in zip(ql[0], ql[4]):
+        tab.cz(control, target)
+    for control, target in zip(ql[1], ql[3]):
+        tab.cz(control, target)
+
+    for i in range(5):
+        for q in ql[i]:
+            tab.sqrt_x_adj(q)
+
+    # Measure all qubits
+    return [tab.measure(i) for i in range(n_qubits)]
+
+
+# %% [markdown]
+# ## Running the circuit
+#
+# Each shot requires its own copy of the initial tableau since measurement mutates the state.
+# We use `fork()` to create independent copies with separate RNG streams.
+
+# %%
+n_qubits = QUBITS_PER_CODE_BLOCK * 5
+n_shots = 1000
+
+tab = GeneralizedTableau(n_qubits)
+
+start = time.perf_counter()
+
+results = []
+for shot in range(n_shots):
+    tab_shot = tab.fork(seed=shot)
+    results.append(msd_circuit(tab_shot))
+
+elapsed = time.perf_counter() - start
+
+print(f"Simulated {n_shots} shots of the {n_qubits}-qubit MSD circuit")
+print(f"Total time: {elapsed:.2f} s ({elapsed / n_shots * 1e3:.2f} ms per shot)")
+
+# %% [markdown]
+# Let's look at the measurement outcomes.
+
+# %%
+bitstrings = [
+    "".join("1" if r == MeasurementResult.ONE else "0" for r in shot)
+    for shot in results
+]

--- a/docs/notebooks/trotter.py
+++ b/docs/notebooks/trotter.py
@@ -1,0 +1,191 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.19.1
+#   kernelspec:
+#     display_name: ppvm (3.12.12)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Trotterized Time Evolution of the XZZ Ising Chain
+#
+# In this example we simulate the time evolution of the **XZZ Ising chain Hamiltonian**
+#
+# $$H = h \sum_i X_i + J \sum_i Z_i Z_{i+1}$$
+#
+# using first-order Trotterized time evolution and **Heisenberg-picture Pauli propagation**.
+#
+# In the Heisenberg picture we propagate *observables* backwards through the circuit rather
+# than evolving a state vector forwards. ppvm represents the observable as a weighted sum of
+# Pauli strings and applies each gate layer analytically.
+#
+# One Trotter step of duration $\delta t$ decomposes the unitary as
+#
+# $$U(\delta t) \approx \prod_i e^{-i h \delta t X_i} \prod_i e^{-i J \delta t Z_i Z_{i+1}}$$
+#
+# We run two simulations: a noiseless baseline and a noisy version with qubit loss,
+# using ppvm's `LossyPauliSum`. Note that the noiseless simulation is still subject
+# to truncation and therefore an approximate solution.
+
+# %%
+import matplotlib.pyplot as plt
+
+from ppvm import LossyPauliSum, PauliSum
+
+# %% [markdown]
+# ## Parameters
+
+# %%
+n = 6
+h = 1.0
+j = 1.5 * h
+dt = 0.1 / h
+time = 3.0 / h
+
+# %% [markdown]
+# ## Noiseless simulation
+#
+# We want to compute $\langle \sum_i Z_i \rangle$ on the all-zeros state.
+# In the Heisenberg picture, we initialise the observable as
+#
+# $$O = \sum_{i=0}^{n-1} Z_i$$
+#
+# using ppvm's compact notation where `"Z3"` means $Z$ on qubit 3 and $I$ everywhere else.
+#
+# Each call to `trotter_step` applies one Trotter step in reverse (Heisenberg picture):
+#
+# 1. **RX** on every qubit — implements $e^{-i h \delta t X_i}$
+# 2. **RZZ** on every neighbouring pair — implements $e^{-i J \delta t Z_i Z_{i+1}}$
+#
+# Truncation applies automatically after every gate and channel.
+# There are currently two possible ways to truncate in a loss-less simulation:
+# * Coefficient truncation: every Pauli string with a leading coefficient, whose absolute value is smaller than `min_abs_coeff` is truncated.
+# * Max Pauli Weight truncation: every Pauli string with more than `max_pauli_weight` non-identity Paulis gets truncated.
+
+# %%
+state = PauliSum.new(
+    n_qubits=n,
+    terms=[f"Z{i}" for i in range(n)],
+    min_abs_coeff=1e-6,
+    max_pauli_weight=8,
+)
+
+theta_x = dt * h
+theta_zz = dt * j
+
+
+def trotter_step(state, n, theta_x, theta_zz):
+    for i in range(n):
+        state.rx(i, theta_x)
+    for i in range(n - 1):
+        state.rzz(i, i + 1, theta_zz)
+
+
+# %% [markdown]
+# ## Noiseless time evolution
+
+# %%
+steps = int(time / dt)
+times = [i * dt for i in range(steps + 1)]
+ev_noiseless = []
+
+for _ in range(steps):
+    ev_noiseless.append(state.overlap_with_zero())
+    trotter_step(state, n, theta_x, theta_zz)
+
+ev_noiseless.append(state.overlap_with_zero())
+print(f"Max Pauli weight (noiseless): {state.current_max_weight()}")
+
+# %% [markdown]
+# ## Noisy simulation with qubit loss
+#
+# We repeat the simulation using `LossyPauliSum`, which extends the Pauli basis with a
+# loss operator $L$ to track qubits that have left the computational subspace.
+#
+# After each gate layer we apply:
+# - a **single-qubit depolarising channel** (`pauli_error`) or
+#   **two-qubit depolarising channel** (`two_qubit_pauli_error`) to model gate errors
+# - a **loss channel** (`loss_channel`) to model qubit loss at the same locations
+#
+# In addition to the two truncation strategies, we can now also truncate using
+# `max_loss_weight`, which removes any Pauli String which has more `L`s than
+# that thresholds. This is justified since these Pauli strings only contribute
+# little to the final average value.
+
+# %%
+noise_1q = [
+    1e-3,
+    1e-3,
+    1e-3,
+]  # symmetric single-qubit depolarising: equal p for X, Y, Z
+noise_2q = [
+    1e-3 / 15.0
+] * 15  # symmetric two-qubit depolarising over all 15 non-identity Paulis
+p_loss = 1e-3  # loss probability per gate location
+
+noisy_state = LossyPauliSum.new(
+    n_qubits=n,
+    terms=[f"Z{i}" for i in range(n)],
+    min_abs_coeff=1e-6,
+    max_pauli_weight=8,
+    max_loss_weight=2,
+)
+
+# Reset the loss register on every qubit before propagation: this ensures that qubits
+# which become lost during the circuit are counted as |0⟩ when computing overlap_with_zero.
+# **NOTE**: without truncation, this scales exponentially
+for i in range(n):
+    noisy_state.reset_loss_channel(i)
+
+
+def noisy_trotter_step(state, n, theta_x, theta_zz):
+    for i in range(n):
+        state.rx(i, theta_x)
+        state.pauli_error(i, noise_1q)
+        state.loss_channel(i, p_loss)
+
+    for i in range(n - 1):
+        state.rzz(i, i + 1, theta_zz)
+        state.two_qubit_pauli_error(i, i + 1, noise_2q)
+        state.loss_channel(i, p_loss)
+        state.loss_channel(i + 1, p_loss)
+
+
+# %% [markdown]
+# ## Noisy time evolution
+
+# %%
+ev_noisy = []
+
+for _ in range(steps):
+    ev_noisy.append(noisy_state.overlap_with_zero())
+    noisy_trotter_step(noisy_state, n, theta_x, theta_zz)
+
+ev_noisy.append(noisy_state.overlap_with_zero())
+print(f"Max Pauli weight (noisy): {noisy_state.current_max_weight()}")
+
+# %% [markdown]
+# ## Results
+#
+# Both curves start at 1 (all qubits in $|0\rangle$). In the interaction-dominated regime
+# ($J > h$) the magnetisation oscillates before decaying. The noisy simulation decays
+# faster due to depolarisation and qubit loss.
+
+# %%
+fig, ax = plt.subplots()
+ax.plot(times, [ev / n for ev in ev_noiseless], label="noiseless")
+ax.plot(times, [ev / n for ev in ev_noisy], label="noisy + loss")
+ax.set_xlabel("Time $t$")
+ax.set_ylabel(r"$\langle \sum_i Z_i \rangle / n$")
+ax.set_title("XZZ Ising chain — Trotterized evolution")
+ax.legend()
+plt.tight_layout()
+plt.show()

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "//extract": "Build steps that produce inputs the Astro pages depend on.",
     "extract:rust": "node scripts/extract-rust.mjs",
     "extract:python": "node scripts/extract-python.mjs",
-    "extract:notebooks": "uv run --project ../ppvm-python --with jupytext --with nbconvert --with nbclient --with ipykernel --with matplotlib --with numpy python scripts/build-notebooks.py",
+    "extract:notebooks": "uv run --project ../ppvm-python --with jupytext --with nbconvert --with nbclient --with ipykernel --with matplotlib --with numpy --with bleach python scripts/build-notebooks.py",
     "extract": "npm run extract:rust && npm run extract:python && npm run extract:notebooks",
     "//astro": "Raw Astro commands — use these only if you've extracted the inputs yourself.",
     "astro:dev": "astro dev --host 127.0.0.1 --port 4321",

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,11 +4,17 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "//extract": "Build steps that produce inputs the Astro pages depend on.",
     "extract:rust": "node scripts/extract-rust.mjs",
     "extract:python": "node scripts/extract-python.mjs",
-    "extract": "npm run extract:rust && npm run extract:python",
-    "dev": "astro dev --host 127.0.0.1 --port 4321",
-    "build": "npm run extract && astro build",
+    "extract:notebooks": "uv run --project ../ppvm-python --with jupytext --with nbconvert --with nbclient --with ipykernel --with matplotlib --with numpy python scripts/build-notebooks.py",
+    "extract": "npm run extract:rust && npm run extract:python && npm run extract:notebooks",
+    "//astro": "Raw Astro commands — use these only if you've extracted the inputs yourself.",
+    "astro:dev": "astro dev --host 127.0.0.1 --port 4321",
+    "astro:build": "astro build",
+    "//run": "Default entry points: extract everything first, then start the server / produce dist/.",
+    "dev": "npm run extract && npm run astro:dev",
+    "build": "npm run extract && npm run astro:build",
     "preview": "astro preview"
   },
   "dependencies": {

--- a/docs/scripts/build-notebooks.py
+++ b/docs/scripts/build-notebooks.py
@@ -39,10 +39,11 @@ OUTPUT_DIR = DOCS / "src" / "generated" / "notebooks"
 
 # Force a non-interactive matplotlib backend before any cell runs so
 # inline ``plt.show()`` calls produce embedded PNGs rather than trying
-# to open a window. This is appended as the first code cell of every
-# notebook before execution; it never appears in the rendered output
-# because the cell is tagged ``remove-input`` (and we filter outputs
-# from it below).
+# to open a window. We prepend this as the first code cell of every
+# notebook with the ``ppvm-hidden-setup`` tag, execute the notebook,
+# and then drop the tagged cell entirely via ``drop_hidden_setup_cells``
+# before rendering — so neither the input nor any output of this cell
+# survives into the HTML fragment that the site embeds.
 MATPLOTLIB_SETUP = (
     "import matplotlib\n"
     "matplotlib.use('Agg')\n"
@@ -108,6 +109,25 @@ def execute(nb: nbformat.NotebookNode, source_label: str) -> None:
 
 
 _BODY_PATTERN = re.compile(r"<body[^>]*>(.*)</body>", re.DOTALL)
+_MAIN_PATTERN = re.compile(r"</?main[^>]*>", re.IGNORECASE)
+_SCRIPT_PATTERN = re.compile(r"<script\b[^>]*>.*?</script>", re.DOTALL | re.IGNORECASE)
+_EVENT_HANDLER_PATTERN = re.compile(r"\s+on[a-z]+\s*=\s*(?:\"[^\"]*\"|'[^']*'|[^\s>]+)", re.IGNORECASE)
+
+
+def sanitise(fragment: str) -> str:
+    """Defense-in-depth scrub of the rendered notebook HTML before we
+    embed it via ``set:html``. Notebook authors are trusted (the source
+    .py files live in this repo and run during CI), but nbconvert's
+    ``basic`` template will faithfully include any HTML a cell emits as
+    rich output — including ``<script>`` and inline event handlers.
+    Drop both, plus the ``<main>`` wrapper nbconvert adds (the page
+    already has its own ``<main>`` from ``Base.astro``; nesting two is
+    invalid HTML).
+    """
+    fragment = _SCRIPT_PATTERN.sub("", fragment)
+    fragment = _EVENT_HANDLER_PATTERN.sub("", fragment)
+    fragment = _MAIN_PATTERN.sub("", fragment)
+    return fragment.strip()
 
 
 def render_html(nb: nbformat.NotebookNode) -> str:
@@ -121,7 +141,8 @@ def render_html(nb: nbformat.NotebookNode) -> str:
     exporter.exclude_output_prompt = True
     body, _ = exporter.from_notebook_node(nb)
     match = _BODY_PATTERN.search(body)
-    return match.group(1).strip() if match else body
+    inner = match.group(1) if match else body
+    return sanitise(inner)
 
 
 def detect_language(nb: nbformat.NotebookNode) -> str:

--- a/docs/scripts/build-notebooks.py
+++ b/docs/scripts/build-notebooks.py
@@ -27,6 +27,7 @@ import re
 import sys
 from pathlib import Path
 
+import bleach
 import jupytext
 import nbformat
 from nbclient import NotebookClient
@@ -37,18 +38,22 @@ DOCS = HERE.parent
 SOURCE_DIR = DOCS / "notebooks"
 OUTPUT_DIR = DOCS / "src" / "generated" / "notebooks"
 
-# Force a non-interactive matplotlib backend before any cell runs so
-# inline ``plt.show()`` calls produce embedded PNGs rather than trying
-# to open a window. We prepend this as the first code cell of every
-# notebook with the ``ppvm-hidden-setup`` tag, execute the notebook,
-# and then drop the tagged cell entirely via ``drop_hidden_setup_cells``
-# before rendering — so neither the input nor any output of this cell
-# survives into the HTML fragment that the site embeds.
+# Switch matplotlib to the IPython "inline" backend before any cell
+# runs so ``plt.show()`` triggers Jupyter's display hook and embeds
+# the figure as a base64 PNG inside the cell's output. The plain
+# ``Agg`` backend renders to a buffer but never reaches the
+# notebook output stream, which is why an early version of this
+# pipeline silently dropped every plot.
+#
+# We prepend this as the first code cell of every notebook with the
+# ``ppvm-hidden-setup`` tag, execute the notebook, and then drop the
+# tagged cell entirely via ``drop_hidden_setup_cells`` before
+# rendering — so neither the input nor any output of this cell
+# survives into the HTML fragment the site embeds.
 MATPLOTLIB_SETUP = (
+    "%matplotlib inline\n"
     "import matplotlib\n"
-    "matplotlib.use('Agg')\n"
-    "from matplotlib import pyplot as _ppvm_plt\n"
-    "_ppvm_plt.rcParams['figure.dpi'] = 110\n"
+    "matplotlib.rcParams['figure.dpi'] = 110\n"
 )
 
 
@@ -110,24 +115,74 @@ def execute(nb: nbformat.NotebookNode, source_label: str) -> None:
 
 _BODY_PATTERN = re.compile(r"<body[^>]*>(.*)</body>", re.DOTALL)
 _MAIN_PATTERN = re.compile(r"</?main[^>]*>", re.IGNORECASE)
-_SCRIPT_PATTERN = re.compile(r"<script\b[^>]*>.*?</script>", re.DOTALL | re.IGNORECASE)
-_EVENT_HANDLER_PATTERN = re.compile(r"\s+on[a-z]+\s*=\s*(?:\"[^\"]*\"|'[^']*'|[^\s>]+)", re.IGNORECASE)
+
+# Tag and attribute allow-lists for the rendered notebook HTML
+# fragment. Notebook authors live in this repo and we trust their
+# .py source, but nbconvert's ``basic`` template will faithfully
+# emit any HTML a cell produces as rich output. We hand the
+# fragment to ``bleach`` (html5lib-based, parses to a real DOM
+# rather than string-matching) so a future notebook that prints
+# an ``<iframe>`` or a ``javascript:`` URL can't smuggle active
+# content into the page.
+ALLOWED_TAGS = frozenset({
+    # Block structure used by nbconvert's `basic` template
+    "div", "section", "article", "header", "footer", "main",
+    "p", "br", "hr",
+    "h1", "h2", "h3", "h4", "h5", "h6",
+    "ul", "ol", "li", "dl", "dt", "dd",
+    "blockquote",
+    "table", "thead", "tbody", "tfoot", "tr", "th", "td", "caption",
+    # Inline prose
+    "a", "em", "strong", "i", "b", "u", "s", "sub", "sup", "small", "mark", "code", "kbd", "samp",
+    "span", "abbr", "cite", "q", "del", "ins",
+    # Code rendering (Pygments wraps tokens in nested spans)
+    "pre",
+    # Images: matplotlib figures embed as `data:image/png;base64,...`
+    "img",
+    # Math from notebook LaTeX (rare, but `nbconvert` may pass through)
+    "math", "mrow", "mi", "mn", "mo", "ms", "mtext", "mfrac", "msup", "msub",
+    "msubsup", "msqrt", "mroot", "mfenced", "mtable", "mtr", "mtd",
+    "annotation", "annotation-xml", "semantics",
+})
+
+ALLOWED_ATTRS = {
+    "*": ["class", "id", "title", "aria-hidden", "aria-label", "role",
+          "tabindex", "data-mime-type", "lang"],
+    "a": ["href", "rel", "target"],
+    "img": ["src", "alt", "width", "height"],
+    "td": ["colspan", "rowspan", "headers", "scope"],
+    "th": ["colspan", "rowspan", "headers", "scope"],
+    "ol": ["start", "type"],
+    "li": ["value"],
+}
+
+# Permitted URL schemes for `<a href>` and `<img src>`. `data:` is
+# allowed so matplotlib figures (which arrive as
+# `data:image/png;base64,...`) can survive — `bleach` enforces this
+# at the attribute level.
+ALLOWED_PROTOCOLS = frozenset({"http", "https", "mailto", "data"})
 
 
 def sanitise(fragment: str) -> str:
-    """Defense-in-depth scrub of the rendered notebook HTML before we
-    embed it via ``set:html``. Notebook authors are trusted (the source
-    .py files live in this repo and run during CI), but nbconvert's
-    ``basic`` template will faithfully include any HTML a cell emits as
-    rich output — including ``<script>`` and inline event handlers.
-    Drop both, plus the ``<main>`` wrapper nbconvert adds (the page
-    already has its own ``<main>`` from ``Base.astro``; nesting two is
-    invalid HTML).
+    """Parse the rendered notebook HTML with bleach and re-serialise
+    with only tags/attrs/URL schemes on the allow-list above.
+    Anything else — `<script>`, `<iframe>`, inline event handlers,
+    `javascript:` hrefs — is stripped at the DOM level, so we
+    don't accidentally delete legitimate text that happens to
+    mention `onload="…"` in prose or a code block.
+
+    Drop nbconvert's `<main>` wrapper first because the surrounding
+    page layout already provides its own `<main>` (one per page).
     """
-    fragment = _SCRIPT_PATTERN.sub("", fragment)
-    fragment = _EVENT_HANDLER_PATTERN.sub("", fragment)
     fragment = _MAIN_PATTERN.sub("", fragment)
-    return fragment.strip()
+    return bleach.clean(
+        fragment,
+        tags=ALLOWED_TAGS,
+        attributes=ALLOWED_ATTRS,
+        protocols=ALLOWED_PROTOCOLS,
+        strip=True,
+        strip_comments=False,
+    ).strip()
 
 
 def render_html(nb: nbformat.NotebookNode) -> str:

--- a/docs/scripts/build-notebooks.py
+++ b/docs/scripts/build-notebooks.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Convert Jupytext notebooks under ``docs/notebooks/`` into executed HTML
+fragments that the Astro site can embed.
+
+Pipeline per notebook (``foo.py``):
+
+1. Read the Jupytext ``percent`` script and turn it into an in-memory
+   ``ipynb`` via the Jupytext Python API.
+2. Run every code cell via ``nbclient.NotebookClient`` so that text
+   outputs, tracebacks, and matplotlib figures are captured inline. We
+   force inline matplotlib so plots get embedded as base64 PNGs.
+3. Render to an HTML fragment with ``nbconvert.HTMLExporter`` using the
+   ``basic`` template — no page chrome, no toolbar, just the cell
+   stream. The site's stylesheet (`global.css`) carries our own theme
+   for the ``.jp-*`` classes.
+4. Write ``docs/src/generated/notebooks/<name>.html`` and a sidecar
+   ``<name>.json`` with metadata (title, ordered headings) that the
+   Astro index page can render without parsing HTML.
+
+Designed to be invoked from CI as the step before ``npx astro build``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import jupytext
+import nbformat
+from nbclient import NotebookClient
+from nbconvert import HTMLExporter
+
+HERE = Path(__file__).resolve().parent
+DOCS = HERE.parent
+SOURCE_DIR = DOCS / "notebooks"
+OUTPUT_DIR = DOCS / "src" / "generated" / "notebooks"
+
+# Force a non-interactive matplotlib backend before any cell runs so
+# inline ``plt.show()`` calls produce embedded PNGs rather than trying
+# to open a window. This is appended as the first code cell of every
+# notebook before execution; it never appears in the rendered output
+# because the cell is tagged ``remove-input`` (and we filter outputs
+# from it below).
+MATPLOTLIB_SETUP = (
+    "import matplotlib\n"
+    "matplotlib.use('Agg')\n"
+    "from matplotlib import pyplot as _ppvm_plt\n"
+    "_ppvm_plt.rcParams['figure.dpi'] = 110\n"
+)
+
+
+def slug_for(path: Path) -> str:
+    return path.stem.lower().replace("_", "-")
+
+
+def extract_title_and_headings(nb: nbformat.NotebookNode) -> tuple[str, list[str]]:
+    """Pull the document title (first H1) and the rest of the headings
+    out of the markdown cells. We only walk markdown cells; output
+    cells from executed code aren't part of the document structure.
+    """
+    title: str | None = None
+    headings: list[str] = []
+    pattern = re.compile(r"^(#{1,3})\s+(.+?)\s*$", re.MULTILINE)
+    for cell in nb.cells:
+        if cell.cell_type != "markdown":
+            continue
+        for match in pattern.finditer(cell.source):
+            level, text = match.group(1), match.group(2).strip()
+            if level == "#" and title is None:
+                title = text
+            else:
+                headings.append(text)
+    return title or "Untitled", headings
+
+
+def prepend_setup_cell(nb: nbformat.NotebookNode) -> None:
+    cell = nbformat.v4.new_code_cell(MATPLOTLIB_SETUP)
+    cell["metadata"] = {"tags": ["ppvm-hidden-setup"]}
+    nb.cells.insert(0, cell)
+
+
+def drop_hidden_setup_cells(nb: nbformat.NotebookNode) -> None:
+    nb.cells = [
+        c
+        for c in nb.cells
+        if "ppvm-hidden-setup" not in (c.get("metadata", {}) or {}).get("tags", [])
+    ]
+
+
+def execute(nb: nbformat.NotebookNode, source_label: str) -> None:
+    client = NotebookClient(
+        nb,
+        timeout=600,
+        kernel_name="python3",
+        # Plain text/HTML outputs only; we don't want stale `In [N]`
+        # prompts cluttering the rendered fragment.
+        allow_errors=False,
+        record_timing=False,
+        resources={"metadata": {"path": str(SOURCE_DIR)}},
+    )
+    try:
+        client.execute()
+    except Exception as exc:  # noqa: BLE001
+        sys.stderr.write(f"notebook execution failed for {source_label}: {exc}\n")
+        raise
+
+
+_BODY_PATTERN = re.compile(r"<body[^>]*>(.*)</body>", re.DOTALL)
+
+
+def render_html(nb: nbformat.NotebookNode) -> str:
+    """Render the notebook to an HTML *fragment* — just the cell stream,
+    none of the surrounding JupyterLab stylesheet. The site's own CSS
+    in ``global.css`` handles the visual treatment.
+    """
+    exporter = HTMLExporter()
+    exporter.template_name = "basic"
+    exporter.exclude_input_prompt = True
+    exporter.exclude_output_prompt = True
+    body, _ = exporter.from_notebook_node(nb)
+    match = _BODY_PATTERN.search(body)
+    return match.group(1).strip() if match else body
+
+
+def build_one(source: Path) -> dict:
+    sys.stderr.write(f"[notebooks] building {source.name}\n")
+    nb = jupytext.read(source, fmt="py:percent")
+    title, headings = extract_title_and_headings(nb)
+    slug = slug_for(source)
+
+    prepend_setup_cell(nb)
+    execute(nb, source.name)
+    drop_hidden_setup_cells(nb)
+
+    html = render_html(nb)
+    (OUTPUT_DIR / f"{slug}.html").write_text(html, encoding="utf-8")
+    meta = {
+        "slug": slug,
+        "title": title,
+        "headings": headings,
+        "source": f"docs/notebooks/{source.name}",
+    }
+    (OUTPUT_DIR / f"{slug}.json").write_text(
+        json.dumps(meta, indent=2), encoding="utf-8"
+    )
+    return meta
+
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    sources = sorted(SOURCE_DIR.glob("*.py"))
+    if not sources:
+        sys.stderr.write(f"[notebooks] no .py files found under {SOURCE_DIR}\n")
+        return 0
+    index = [build_one(s) for s in sources]
+    (OUTPUT_DIR / "index.json").write_text(
+        json.dumps(index, indent=2), encoding="utf-8"
+    )
+    sys.stderr.write(f"[notebooks] built {len(index)} notebook(s)\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/scripts/build-notebooks.py
+++ b/docs/scripts/build-notebooks.py
@@ -124,11 +124,20 @@ def render_html(nb: nbformat.NotebookNode) -> str:
     return match.group(1).strip() if match else body
 
 
+def detect_language(nb: nbformat.NotebookNode) -> str:
+    kernelspec = (nb.metadata or {}).get("kernelspec", {}) or {}
+    lang = kernelspec.get("language") or (
+        (nb.metadata or {}).get("language_info", {}) or {}
+    ).get("name")
+    return (lang or "python").lower()
+
+
 def build_one(source: Path) -> dict:
     sys.stderr.write(f"[notebooks] building {source.name}\n")
     nb = jupytext.read(source, fmt="py:percent")
     title, headings = extract_title_and_headings(nb)
     slug = slug_for(source)
+    language = detect_language(nb)
 
     prepend_setup_cell(nb)
     execute(nb, source.name)
@@ -140,6 +149,7 @@ def build_one(source: Path) -> dict:
         "slug": slug,
         "title": title,
         "headings": headings,
+        "language": language,
         "source": f"docs/notebooks/{source.name}",
     }
     (OUTPUT_DIR / f"{slug}.json").write_text(

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -222,20 +222,40 @@ const nav = [
         carry `$ … $` and `$$ … $$` LaTeX in their markdown cells; KaTeX
         renders them after page load. Loaded on every page so the
         markup is consistent — the auto-renderer is cheap when there
-        is no math to find. */}
+        is no math to find.
+
+        The auto-render call is in a separate inline `<script>` (not
+        an `onload` attribute) because Astro re-encodes attribute
+        values and would collapse our `\\(` JS escape into `\(`,
+        which `auto-render` then treats as a literal `(` delimiter —
+        leading to every parenthesised phrase being rendered as math. */}
     <link rel="stylesheet"
           href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css"
           integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+"
           crossorigin="anonymous" />
-    <script defer
-            src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"
+    <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"
             integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg"
             crossorigin="anonymous"></script>
-    <script defer
-            src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"
+    <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"
             integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk"
-            crossorigin="anonymous"
-            onload="renderMathInElement(document.body, {delimiters: [{left: '$$', right: '$$', display: true}, {left: '$', right: '$', display: false}, {left: '\\(', right: '\\)', display: false}, {left: '\\[', right: '\\]', display: true}], throwOnError: false});"></script>
+            crossorigin="anonymous"></script>
+    <script is:inline>
+      document.addEventListener("DOMContentLoaded", () => {
+        if (typeof renderMathInElement !== "function") return;
+        renderMathInElement(document.body, {
+          delimiters: [
+            { left: "$$", right: "$$", display: true },
+            { left: "$",  right: "$",  display: false },
+            { left: "\\(", right: "\\)", display: false },
+            { left: "\\[", right: "\\]", display: true },
+          ],
+          // Skip code spans and code blocks — `[7, 16]` and friends
+          // shouldn't accidentally trigger as math delimiters.
+          ignoredTags: ["script", "noscript", "style", "textarea", "pre", "code"],
+          throwOnError: false,
+        });
+      });
+    </script>
 
     {/* Syntax highlighting — highlight.js, languages we use bundled in
         one UMD script. The colour theme is defined in global.css using

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -8,7 +8,7 @@ interface TocItem {
 interface Props {
   title: string;
   description?: string;
-  current?: "home" | "quickstart" | "develop" | "api";
+  current?: "home" | "quickstart" | "tutorials" | "examples" | "develop" | "api";
   toc?: TocItem[];
   tocTitle?: string;
 }
@@ -18,6 +18,8 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
 const nav = [
   { id: "home", label: "Overview", href: `${base}/` },
   { id: "quickstart", label: "Quick Start", href: `${base}/quickstart` },
+  { id: "tutorials", label: "Tutorials", href: `${base}/tutorials` },
+  { id: "examples", label: "Examples", href: `${base}/examples` },
   { id: "develop", label: "Develop", href: `${base}/develop` },
   { id: "api", label: "Reference", href: `${base}/api` },
 ];
@@ -215,6 +217,25 @@ const nav = [
         </span>
       </div>
     </footer>
+
+    {/* Math rendering for executed notebook content. The notebooks
+        carry `$ … $` and `$$ … $$` LaTeX in their markdown cells; KaTeX
+        renders them after page load. Loaded on every page so the
+        markup is consistent — the auto-renderer is cheap when there
+        is no math to find. */}
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css"
+          integrity="sha384-nB0miv6/jRmo5UMMR1wu3Gz6NLsoTkbqJghGIsx//Rlm+ZU03BU6SQNC66uf4l5+"
+          crossorigin="anonymous" />
+    <script defer
+            src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"
+            integrity="sha384-7zkQWkzuo3B5mTepMUcHkMB5jZaolc2xDwL6VFqjFALcbeS9Ggm/Yr2r3Dy4lfFg"
+            crossorigin="anonymous"></script>
+    <script defer
+            src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"
+            integrity="sha384-43gviWU0YVjaDtb/GhzOouOXtZMP/7XUzwPTstBeZFe/+rCMvRwr4yROQP43s0Xk"
+            crossorigin="anonymous"
+            onload="renderMathInElement(document.body, {delimiters: [{left: '$$', right: '$$', display: true}, {left: '$', right: '$', display: false}, {left: '\\(', right: '\\)', display: false}, {left: '\\[', right: '\\]', display: true}], throwOnError: false});"></script>
 
     {/* Syntax highlighting — highlight.js, languages we use bundled in
         one UMD script. The colour theme is defined in global.css using

--- a/docs/src/pages/develop.astro
+++ b/docs/src/pages/develop.astro
@@ -179,6 +179,81 @@ uv run --project ppvm-python --group dev pytest ppvm-python/test/ -k test_ghz</c
       ppvm-python-native</code>.
     </p>
 
+    <h3>This docs site</h3>
+
+    <p>
+      The Astro site you're reading lives under <code>docs/</code>. Every
+      build step (rustdoc-JSON extraction, griffe-based Python API
+      extraction, notebook execution, Astro build) is wired into
+      <code>docs/package.json</code>, so a fresh checkout has one command
+      to remember:
+    </p>
+
+<pre><code class="language-bash">cd docs
+npm install            # one-time
+npm run dev            # extract everything, then `astro dev` (port 4321)
+npm run build          # extract everything, then `astro build` → dist/</code></pre>
+
+    <p>
+      <code>npm run dev</code> / <code>npm run build</code> chain the
+      three extraction steps in order so the rendered site picks up
+      every public API change automatically. When you're iterating on a
+      single layer, run that step on its own and refresh the
+      already-running <code>astro dev</code>:
+    </p>
+
+    <table class="dev-cmd-table">
+      <thead>
+        <tr><th>Command</th><th>Rebuilds</th><th>When to use</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>npm run extract:rust</code></td>
+          <td><code>src/data/rust-api.json</code></td>
+          <td>You changed a public Rust item — trait, struct, doc comment — and want it surfaced on <code>/api/</code>. Needs <code>cargo +nightly</code>.</td>
+        </tr>
+        <tr>
+          <td><code>npm run extract:python</code></td>
+          <td><code>src/data/python-api.json</code></td>
+          <td>You changed a public Python item under <code>ppvm-python/src/ppvm/</code> and want it surfaced on <code>/api/</code>. Uses <code>griffe</code> via <code>uv</code>.</td>
+        </tr>
+        <tr>
+          <td><code>npm run extract:notebooks</code></td>
+          <td><code>src/generated/notebooks/*</code></td>
+          <td>You edited or added a Jupytext file under <code>docs/notebooks/</code>. Re-executes the notebooks against the current ppvm-python build and embeds outputs.</td>
+        </tr>
+        <tr>
+          <td><code>npm run extract</code></td>
+          <td>All of the above, in order.</td>
+          <td>Touched several layers at once.</td>
+        </tr>
+        <tr>
+          <td><code>npm run astro:dev</code> / <code>npm run astro:build</code></td>
+          <td>Just Astro.</td>
+          <td>You're only editing <code>.astro</code> / <code>.css</code> files and trust the existing extractor outputs — fastest loop.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>
+      <code>docs/src/data/</code> and <code>docs/src/generated/</code> are
+      both <code>.gitignore</code>'d; the only sources of truth for those
+      files are the extractor scripts, which CI re-runs on every build.
+      Adding a notebook is a single drop-in:
+      <code>docs/notebooks/my_notebook.py</code> (Jupytext-percent
+      format) → <code>npm run extract:notebooks</code> → the Examples
+      landing page picks it up from
+      <code>src/generated/notebooks/index.json</code>.
+    </p>
+
+    <p>
+      Local prerequisites the scripts assume: <code>node ≥ 20</code>
+      (Astro 5), <code>uv</code>, Rust nightly
+      (<code>rustup toolchain install nightly</code>). The full layout
+      and rationale live in
+      <code><a href="https://github.com/QuEraComputing/ppvm/blob/main/docs/README.md">docs/README.md</a></code>.
+    </p>
+
     <h2 id="architecture"><span class="sec-num">§ 3</span>Architecture</h2>
 
     <p>

--- a/docs/src/pages/examples/[slug].astro
+++ b/docs/src/pages/examples/[slug].astro
@@ -1,6 +1,5 @@
 ---
 import Base from "../../layouts/Base.astro";
-import index from "../../generated/notebooks/index.json";
 
 interface Meta {
   slug: string;
@@ -9,7 +8,6 @@ interface Meta {
   language: string;
   source: string;
 }
-const notebooks = index as Meta[];
 
 export async function getStaticPaths() {
   const idx = (await import("../../generated/notebooks/index.json")).default as Meta[];
@@ -23,12 +21,19 @@ export async function getStaticPaths() {
   return idx.map((nb) => {
     // Vite glob keys look like "../../generated/notebooks/trotter.html".
     const key = Object.keys(htmls).find((k) => k.endsWith(`/${nb.slug}.html`));
+    if (!key) {
+      // Fail the build loudly rather than silently producing an
+      // empty Examples page — a missing fragment usually means
+      // `npm run extract:notebooks` wasn't run after a rename.
+      throw new Error(
+        `notebook fragment missing for slug "${nb.slug}". ` +
+        `Expected docs/src/generated/notebooks/${nb.slug}.html. ` +
+        `Run \`npm run extract:notebooks\` to regenerate it.`
+      );
+    }
     return {
       params: { slug: nb.slug },
-      props: {
-        meta: nb,
-        html: key ? htmls[key] : "",
-      },
+      props: { meta: nb, html: htmls[key] },
     };
   });
 }

--- a/docs/src/pages/examples/[slug].astro
+++ b/docs/src/pages/examples/[slug].astro
@@ -1,0 +1,58 @@
+---
+import Base from "../../layouts/Base.astro";
+import index from "../../generated/notebooks/index.json";
+
+interface Meta {
+  slug: string;
+  title: string;
+  headings: string[];
+  source: string;
+}
+const notebooks = index as Meta[];
+
+export async function getStaticPaths() {
+  const idx = (await import("../../generated/notebooks/index.json")).default as Meta[];
+  // Pull the HTML fragment for each slug at build time so the page is
+  // a single static document — no runtime fetch.
+  const htmls = import.meta.glob("../../generated/notebooks/*.html", {
+    eager: true,
+    query: "?raw",
+    import: "default",
+  }) as Record<string, string>;
+  return idx.map((nb) => {
+    // Vite glob keys look like "../../generated/notebooks/trotter.html".
+    const key = Object.keys(htmls).find((k) => k.endsWith(`/${nb.slug}.html`));
+    return {
+      params: { slug: nb.slug },
+      props: {
+        meta: nb,
+        html: key ? htmls[key] : "",
+      },
+    };
+  });
+}
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+const { meta, html } = Astro.props as { meta: Meta; html: string };
+
+const toc = meta.headings.map((h) => ({
+  label: h,
+  href: `#${h.replace(/[^a-zA-Z0-9]+/g, "-")}`,
+}));
+---
+<Base title={meta.title} current="examples" toc={toc}>
+  <article class="shell narrow notebook">
+    <div class="titleblock">
+      <div class="eyebrow">
+        <a href={`${base}/examples`}>Examples</a> &middot; executed during build
+      </div>
+      <h1>{meta.title}</h1>
+      <p class="byline">
+        Source:
+        <code><a href={`https://github.com/QuEraComputing/ppvm/blob/main/${meta.source}`}>{meta.source}</a></code>
+      </p>
+    </div>
+
+    <div class="notebook-body" set:html={html}></div>
+  </article>
+</Base>

--- a/docs/src/pages/examples/[slug].astro
+++ b/docs/src/pages/examples/[slug].astro
@@ -6,6 +6,7 @@ interface Meta {
   slug: string;
   title: string;
   headings: string[];
+  language: string;
   source: string;
 }
 const notebooks = index as Meta[];
@@ -33,6 +34,7 @@ export async function getStaticPaths() {
 }
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+const gitRef = process.env.PPVM_GIT_REF || "main";
 const { meta, html } = Astro.props as { meta: Meta; html: string };
 
 const toc = meta.headings.map((h) => ({
@@ -48,11 +50,15 @@ const toc = meta.headings.map((h) => ({
       </div>
       <h1>{meta.title}</h1>
       <p class="byline">
-        Source:
-        <code><a href={`https://github.com/QuEraComputing/ppvm/blob/main/${meta.source}`}>{meta.source}</a></code>
+        <span class="examples-lang">{meta.language}</span>
+        <span class="examples-source-label">Source</span>
+        <a
+          class="examples-source"
+          href={`https://github.com/QuEraComputing/ppvm/blob/${gitRef}/${meta.source}`}
+        >{meta.source}</a>
       </p>
     </div>
 
-    <div class="notebook-body" set:html={html}></div>
+    <div class="notebook-body" data-language={meta.language} set:html={html}></div>
   </article>
 </Base>

--- a/docs/src/pages/examples/index.astro
+++ b/docs/src/pages/examples/index.astro
@@ -1,0 +1,45 @@
+---
+import Base from "../../layouts/Base.astro";
+import index from "../../generated/notebooks/index.json";
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+
+interface Meta {
+  slug: string;
+  title: string;
+  headings: string[];
+  source: string;
+}
+const notebooks = index as Meta[];
+---
+<Base title="Examples" current="examples">
+  <article class="shell narrow">
+    <div class="titleblock">
+      <div class="eyebrow">End-to-end notebooks</div>
+      <h1>Examples</h1>
+      <p class="byline">
+        Jupyter notebooks (authored as Jupytext <code>.py</code> scripts under
+        <code>docs/notebooks/</code>) executed during the site build, with
+        outputs and plots embedded inline. The source for each notebook is
+        a runnable Python file — open the link beside the title to read or
+        adapt it.
+      </p>
+    </div>
+
+    <ul class="examples-list">
+      {notebooks.map((nb) => (
+        <li>
+          <a class="examples-title" href={`${base}/examples/${nb.slug}`}>{nb.title}</a>
+          <div class="examples-meta">
+            <code><a href={`https://github.com/QuEraComputing/ppvm/blob/main/${nb.source}`}>{nb.source}</a></code>
+          </div>
+          {nb.headings.length > 0 && (
+            <ul class="examples-headings">
+              {nb.headings.map((h) => <li>{h}</li>)}
+            </ul>
+          )}
+        </li>
+      ))}
+    </ul>
+  </article>
+</Base>

--- a/docs/src/pages/examples/index.astro
+++ b/docs/src/pages/examples/index.astro
@@ -4,10 +4,17 @@ import index from "../../generated/notebooks/index.json";
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, "");
 
+// The git ref the "Source" links resolve against. CI sets PPVM_GIT_REF
+// per build target (PR head SHA for PR previews, push SHA on main).
+// Local dev falls back to `main`, which is fine for read-only browsing
+// once the PR has merged.
+const gitRef = process.env.PPVM_GIT_REF || "main";
+
 interface Meta {
   slug: string;
   title: string;
   headings: string[];
+  language: string;
   source: string;
 }
 const notebooks = index as Meta[];
@@ -15,14 +22,14 @@ const notebooks = index as Meta[];
 <Base title="Examples" current="examples">
   <article class="shell narrow">
     <div class="titleblock">
-      <div class="eyebrow">End-to-end notebooks</div>
+      <div class="eyebrow">Executed notebooks</div>
       <h1>Examples</h1>
       <p class="byline">
-        Jupyter notebooks (authored as Jupytext <code>.py</code> scripts under
-        <code>docs/notebooks/</code>) executed during the site build, with
-        outputs and plots embedded inline. The source for each notebook is
-        a runnable Python file — open the link beside the title to read or
-        adapt it.
+        End-to-end Jupyter notebooks executed at build time, with stdout,
+        return values, and matplotlib plots embedded inline. Each notebook
+        is also a runnable Jupytext <code>.py</code> file in the repo —
+        the "Source" link below opens it on GitHub at the commit that
+        produced this page.
       </p>
     </div>
 
@@ -30,14 +37,14 @@ const notebooks = index as Meta[];
       {notebooks.map((nb) => (
         <li>
           <a class="examples-title" href={`${base}/examples/${nb.slug}`}>{nb.title}</a>
-          <div class="examples-meta">
-            <code><a href={`https://github.com/QuEraComputing/ppvm/blob/main/${nb.source}`}>{nb.source}</a></code>
-          </div>
-          {nb.headings.length > 0 && (
-            <ul class="examples-headings">
-              {nb.headings.map((h) => <li>{h}</li>)}
-            </ul>
-          )}
+          <p class="examples-meta">
+            <span class="examples-lang">{nb.language}</span>
+            <span class="examples-source-label">Source</span>
+            <a
+              class="examples-source"
+              href={`https://github.com/QuEraComputing/ppvm/blob/${gitRef}/${nb.source}`}
+            >{nb.source}</a>
+          </p>
         </li>
       ))}
     </ul>

--- a/docs/src/pages/tutorials/generalized-tableau.astro
+++ b/docs/src/pages/tutorials/generalized-tableau.astro
@@ -1,0 +1,140 @@
+---
+import Base from "../../layouts/Base.astro";
+const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+const toc = [
+  { label: "Overview",              href: "#overview" },
+  { label: "Basic usage",           href: "#basic-usage" },
+  { label: "Forking for multi-shot", href: "#forking" },
+  { label: "Stim circuit support",  href: "#stim" },
+  { label: "Noise and loss",        href: "#noise" },
+  { label: "Coefficient pruning",   href: "#pruning" },
+];
+---
+<Base title="Generalized Stabilizer Tableau" current="tutorials" toc={toc}>
+  <article class="shell narrow tutorial">
+    <div class="titleblock">
+      <div class="eyebrow"><a href={`${base}/tutorials`}>Tutorials</a></div>
+      <h1>Generalized Stabilizer Tableau</h1>
+      <p class="byline">
+        Schrödinger-picture state simulation: stabilizer tableau for the
+        Clifford fragment, sparse coefficient vector for the non-Clifford
+        part.
+      </p>
+    </div>
+
+    <section id="overview">
+      <h2>Overview</h2>
+      <p>
+        <a href={`${base}/api#py-ppvm-generalized_tableau-GeneralizedTableau`}><code>GeneralizedTableau</code></a>
+        simulates quantum circuits in the <strong>Schrödinger picture</strong>
+        using a generalized stabilizer decomposition.
+      </p>
+      <p>
+        Clifford operations are tracked efficiently in the stabilizer
+        tableau. Non-Clifford gates (T gates, arbitrary rotations) expand
+        the state into a superposition of stabilizer states, tracked via
+        a sparse coefficient vector. The cost scales exponentially only
+        in the number of non-Clifford gates, making it well-suited for
+        circuits with few T gates and many Clifford operations.
+      </p>
+    </section>
+
+    <section id="basic-usage">
+      <h2>Basic usage</h2>
+<pre><code class="language-python">from ppvm import GeneralizedTableau
+
+tab = GeneralizedTableau(n_qubits=2)
+tab.h(0)
+tab.cnot(0, 1)
+
+r0 = tab.measure(0)
+r1 = tab.measure(1)
+print(f"Qubit 0: {`{r0}`}, Qubit 1: {`{r1}`}")  # always correlated (Bell state)</code></pre>
+    </section>
+
+    <section id="forking">
+      <h2>Forking for multiple shots</h2>
+      <p>
+        Measurement mutates the tableau, so running multiple shots
+        requires creating independent copies. Use <code>fork()</code> to
+        clone the quantum state with a fresh RNG:
+      </p>
+<pre><code class="language-python">tab = GeneralizedTableau(n_qubits=2, seed=42)
+tab.h(0)
+tab.cnot(0, 1)
+
+for shot in range(100):
+    t = tab.fork(seed=shot)
+    print(t.measure(0), t.measure(1))</code></pre>
+      <p>
+        To preserve the RNG state exactly (e.g., for checkpointing),
+        use <code>copy.copy()</code> instead.
+      </p>
+    </section>
+
+    <section id="stim">
+      <h2>Stim circuit support</h2>
+      <p>
+        Circuits in <a href="https://github.com/quantumlib/Stim">STIM</a>
+        format are parsed and prepared once into a <code>StimProgram</code>,
+        then executed.
+      </p>
+<pre><code class="language-python">from ppvm import GeneralizedTableau, StimProgram, sample_stim
+
+prog = StimProgram.parse("""
+H 0
+CX 0 1
+M 0 1
+""")
+
+# Single shot:
+tab = GeneralizedTableau(n_qubits=2)
+results = tab.run(prog)
+print(f"Bell state measurement: {`{results}`}")
+
+# Many shots — fresh tableau per shot:
+shots = sample_stim(prog, n_qubits=2, num_shots=10_000, seed=0)
+
+# .stim file:
+prog = StimProgram.from_file("path/to/circuit.stim")
+shots = GeneralizedTableau.sample(prog, n_qubits=85, num_shots=100, seed=0)</code></pre>
+    </section>
+
+    <section id="noise">
+      <h2>Noise and loss</h2>
+      <p>
+        <code>GeneralizedTableau</code> supports the same noise channels as
+        <code>PauliSum</code>:
+      </p>
+      <ul>
+        <li><strong>Depolarizing:</strong> <code>depolarize(addr, p)</code> and <code>depolarize2(addr0, addr1, p)</code>.</li>
+        <li><strong>Pauli error:</strong> <code>pauli_error(addr, [p_x, p_y, p_z])</code>.</li>
+        <li><strong>Loss:</strong> <code>loss_channel(addr, p)</code> and <code>correlated_loss_channel(addr0, addr1, p)</code>.</li>
+      </ul>
+      <p>
+        When a qubit is lost, subsequent measurement returns
+        <a href={`${base}/api#py-ppvm-generalized_tableau-MeasurementResult`}><code>MeasurementResult.LOST</code></a>
+        instead of <code>ZERO</code> or <code>ONE</code>. You can check and
+        reset loss state:
+      </p>
+<pre><code class="language-python">tab = GeneralizedTableau(n_qubits=1, seed=0)
+tab.loss_channel(0, 1.0)  # deterministic loss
+
+print(tab.is_lost(0))   # True
+print(tab.measure(0))    # MeasurementResult.LOST
+
+tab.reset_loss_channel(0)
+print(tab.is_lost(0))   # False</code></pre>
+    </section>
+
+    <section id="pruning">
+      <h2>Coefficient pruning</h2>
+      <p>
+        Each non-Clifford gate doubles the number of terms in the internal
+        coefficient vector. The <code>min_abs_coeff</code> parameter
+        controls pruning of small coefficients:
+      </p>
+<pre><code class="language-python">tab = GeneralizedTableau(n_qubits=4, min_abs_coeff=1e-8)</code></pre>
+    </section>
+  </article>
+</Base>

--- a/docs/src/pages/tutorials/generalized-tableau.astro
+++ b/docs/src/pages/tutorials/generalized-tableau.astro
@@ -9,6 +9,58 @@ const toc = [
   { label: "Noise and loss",        href: "#noise" },
   { label: "Coefficient pruning",   href: "#pruning" },
 ];
+
+// Python snippets live in the frontmatter so f-string `{...}` braces
+// don't fight Astro's JSX parser. See the matching note in
+// `pauli-propagation.astro`.
+const basicUsage = `from ppvm import GeneralizedTableau
+
+tab = GeneralizedTableau(n_qubits=2)
+tab.h(0)
+tab.cnot(0, 1)
+
+r0 = tab.measure(0)
+r1 = tab.measure(1)
+print(f"Qubit 0: {r0}, Qubit 1: {r1}")  # always correlated (Bell state)`;
+
+const forking = `tab = GeneralizedTableau(n_qubits=2, seed=42)
+tab.h(0)
+tab.cnot(0, 1)
+
+for shot in range(100):
+    t = tab.fork(seed=shot)
+    print(t.measure(0), t.measure(1))`;
+
+const stimUsage = `from ppvm import GeneralizedTableau, StimProgram, sample_stim
+
+prog = StimProgram.parse("""
+H 0
+CX 0 1
+M 0 1
+""")
+
+# Single shot:
+tab = GeneralizedTableau(n_qubits=2)
+results = tab.run(prog)
+print(f"Bell state measurement: {results}")
+
+# Many shots — fresh tableau per shot:
+shots = sample_stim(prog, n_qubits=2, num_shots=10_000, seed=0)
+
+# .stim file:
+prog = StimProgram.from_file("path/to/circuit.stim")
+shots = GeneralizedTableau.sample(prog, n_qubits=85, num_shots=100, seed=0)`;
+
+const lossExample = `tab = GeneralizedTableau(n_qubits=1, seed=0)
+tab.loss_channel(0, 1.0)  # deterministic loss
+
+print(tab.is_lost(0))   # True
+print(tab.measure(0))    # MeasurementResult.LOST
+
+tab.reset_loss_channel(0)
+print(tab.is_lost(0))   # False`;
+
+const pruning = `tab = GeneralizedTableau(n_qubits=4, min_abs_coeff=1e-8)`;
 ---
 <Base title="Generalized Stabilizer Tableau" current="tutorials" toc={toc}>
   <article class="shell narrow tutorial">
@@ -41,15 +93,7 @@ const toc = [
 
     <section id="basic-usage">
       <h2>Basic usage</h2>
-<pre><code class="language-python">from ppvm import GeneralizedTableau
-
-tab = GeneralizedTableau(n_qubits=2)
-tab.h(0)
-tab.cnot(0, 1)
-
-r0 = tab.measure(0)
-r1 = tab.measure(1)
-print(f"Qubit 0: {`{r0}`}, Qubit 1: {`{r1}`}")  # always correlated (Bell state)</code></pre>
+<pre><code class="language-python">{basicUsage}</code></pre>
     </section>
 
     <section id="forking">
@@ -59,13 +103,7 @@ print(f"Qubit 0: {`{r0}`}, Qubit 1: {`{r1}`}")  # always correlated (Bell state)
         requires creating independent copies. Use <code>fork()</code> to
         clone the quantum state with a fresh RNG:
       </p>
-<pre><code class="language-python">tab = GeneralizedTableau(n_qubits=2, seed=42)
-tab.h(0)
-tab.cnot(0, 1)
-
-for shot in range(100):
-    t = tab.fork(seed=shot)
-    print(t.measure(0), t.measure(1))</code></pre>
+<pre><code class="language-python">{forking}</code></pre>
       <p>
         To preserve the RNG state exactly (e.g., for checkpointing),
         use <code>copy.copy()</code> instead.
@@ -79,25 +117,7 @@ for shot in range(100):
         format are parsed and prepared once into a <code>StimProgram</code>,
         then executed.
       </p>
-<pre><code class="language-python">from ppvm import GeneralizedTableau, StimProgram, sample_stim
-
-prog = StimProgram.parse("""
-H 0
-CX 0 1
-M 0 1
-""")
-
-# Single shot:
-tab = GeneralizedTableau(n_qubits=2)
-results = tab.run(prog)
-print(f"Bell state measurement: {`{results}`}")
-
-# Many shots — fresh tableau per shot:
-shots = sample_stim(prog, n_qubits=2, num_shots=10_000, seed=0)
-
-# .stim file:
-prog = StimProgram.from_file("path/to/circuit.stim")
-shots = GeneralizedTableau.sample(prog, n_qubits=85, num_shots=100, seed=0)</code></pre>
+<pre><code class="language-python">{stimUsage}</code></pre>
     </section>
 
     <section id="noise">
@@ -117,14 +137,7 @@ shots = GeneralizedTableau.sample(prog, n_qubits=85, num_shots=100, seed=0)</cod
         instead of <code>ZERO</code> or <code>ONE</code>. You can check and
         reset loss state:
       </p>
-<pre><code class="language-python">tab = GeneralizedTableau(n_qubits=1, seed=0)
-tab.loss_channel(0, 1.0)  # deterministic loss
-
-print(tab.is_lost(0))   # True
-print(tab.measure(0))    # MeasurementResult.LOST
-
-tab.reset_loss_channel(0)
-print(tab.is_lost(0))   # False</code></pre>
+<pre><code class="language-python">{lossExample}</code></pre>
     </section>
 
     <section id="pruning">
@@ -134,7 +147,7 @@ print(tab.is_lost(0))   # False</code></pre>
         coefficient vector. The <code>min_abs_coeff</code> parameter
         controls pruning of small coefficients:
       </p>
-<pre><code class="language-python">tab = GeneralizedTableau(n_qubits=4, min_abs_coeff=1e-8)</code></pre>
+<pre><code class="language-python">{pruning}</code></pre>
     </section>
   </article>
 </Base>

--- a/docs/src/pages/tutorials/index.astro
+++ b/docs/src/pages/tutorials/index.astro
@@ -1,0 +1,50 @@
+---
+import Base from "../../layouts/Base.astro";
+const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+---
+<Base title="Tutorials" current="tutorials">
+  <article class="shell narrow">
+    <div class="titleblock">
+      <div class="eyebrow">Conceptual guides</div>
+      <h1>Tutorials</h1>
+      <p class="byline">
+        Mid-length walkthroughs of ppvm's two simulation backends and the
+        loss-aware Pauli basis they use. Heavier on motivation and theory
+        than the <a href={`${base}/quickstart`}>Quick Start</a>; lighter on
+        end-to-end execution than the <a href={`${base}/examples`}>Examples</a>
+        notebooks.
+      </p>
+    </div>
+
+    <ul class="tutorials-list">
+      <li>
+        <a class="tutorials-title" href={`${base}/tutorials/pauli-propagation`}>Pauli Propagation</a>
+        <p>
+          Heisenberg-picture observable propagation with <code>PauliSum</code>:
+          basic usage, compact and full Pauli notation, the two truncation
+          knobs that control the approximation/performance trade-off, and
+          the loss-aware <code>LossyPauliSum</code> variant.
+        </p>
+      </li>
+      <li>
+        <a class="tutorials-title" href={`${base}/tutorials/loss-channel`}>Loss channel details</a>
+        <p>
+          The mathematical background for simulating qubit loss — the
+          extended five-symbol Pauli basis (<code>I</code>, <code>X</code>,
+          <code>Y</code>, <code>Z</code>, <code>L</code>), the Kraus
+          operators of the loss channel, and how it interacts with
+          downstream gates and measurement.
+        </p>
+      </li>
+      <li>
+        <a class="tutorials-title" href={`${base}/tutorials/generalized-tableau`}>Generalized Stabilizer Tableau</a>
+        <p>
+          The Schrödinger-picture backend: stabilizer tableau extended with a
+          sparse coefficient vector for non-Clifford gates, multi-shot
+          sampling via <code>fork()</code>, executing Stim programs, and the
+          noise channels available on top.
+        </p>
+      </li>
+    </ul>
+  </article>
+</Base>

--- a/docs/src/pages/tutorials/loss-channel.astro
+++ b/docs/src/pages/tutorials/loss-channel.astro
@@ -1,0 +1,208 @@
+---
+import Base from "../../layouts/Base.astro";
+const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+const toc = [
+  { label: "Updated Pauli basis", href: "#basis" },
+  { label: "Loss channel",        href: "#loss-channel" },
+  { label: "Reset channel",       href: "#reset-channel" },
+  { label: "Branching and scaling", href: "#scaling" },
+];
+
+// LaTeX expressions kept as raw strings in the frontmatter so JSX
+// never sees their `{ ... }` (curly braces inside `\begin{pmatrix}`
+// trip up the Astro/JSX parser).
+const matrixIX = String.raw`$$I = \begin{pmatrix} 1 & 0 & 0 \\ 0 & 1 & 0 \\ 0 & 0 & 0 \end{pmatrix}, ~~ X = \begin{pmatrix} 0 & 1 & 0 \\ 1 & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}, ~~ Y = \begin{pmatrix} 0 & -i & 0 \\ i & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix},$$`;
+const matrixZL = String.raw`$$Z = \begin{pmatrix} 1 & 0 & 0 \\ 0 & -1 & 0 \\ 0 & 0 & 0 \end{pmatrix}, ~~ L = \begin{pmatrix} 0 & 0 & 0 \\ 0 & 0 & 0 \\ 0 & 0 & 1 \end{pmatrix}.$$`;
+const krausLoss = String.raw`$$K_0 = \sqrt{1 - p_L}\, I + |L\rangle\langle L|, ~~ K_1 = \sqrt{p_L}\, |L\rangle\langle 0|, ~~ K_2 = \sqrt{p_L}\, |L\rangle\langle 1|,$$`;
+const chanPauli = String.raw`$$\mathcal{E}(P) = (1 - p_L)\, P, ~~ P \in \{I, X, Y, Z\},$$`;
+const chanLossL = String.raw`$$\mathcal{E}(L) = L + p_L\, I.$$`;
+const stateVec = String.raw`$$|\psi\rangle = \begin{pmatrix} c_0 \\ c_1 \\ 0 \end{pmatrix}.$$`;
+const stateLost = String.raw`$$|\psi\rangle = |L\rangle.$$`;
+const overlapZero = String.raw`$$\langle \psi| Q |\psi\rangle = 0.$$`;
+const krausReset = String.raw`$$K_0 = I, ~~~ K_1 = |0\rangle\langle L|.$$`;
+const resetXY = String.raw`$$\mathcal{E}(P) = P, ~ P \in \{X, Y\},$$`;
+const resetIZ = String.raw`$$\mathcal{E}(P) = P + L, ~ P \in \{I, Z\},$$`;
+const resetL = String.raw`$$\mathcal{E}(L) = 0.$$`;
+const factorize = String.raw`$$\langle P_1 L_2 P_3 P_4 L_5 P_6 \ldots \rangle = \langle L_2 \rangle \langle L_5 \rangle \langle P_1 P_3 P_4 P_6 \ldots \rangle.$$`;
+const basisSet = String.raw`$$\{I, X, Y, Z, L\}.$$`;
+const adjointInline = String.raw`$\langle A \rangle = \operatorname{tr}(A\, \mathcal{E}[\rho]) = \operatorname{tr}(\sum_i K_i^\dagger A K_i\, \rho)$`;
+---
+<Base title="Loss Channel Details" current="tutorials" toc={toc}>
+  <article class="shell narrow tutorial">
+    <div class="titleblock">
+      <div class="eyebrow"><a href={`${base}/tutorials`}>Tutorials</a></div>
+      <h1>Loss Channel Details</h1>
+      <p class="byline">
+        Mathematical background for simulating qubit loss with
+        <a href={`${base}/api#py-ppvm-paulisum-LossyPauliSum`}><code>LossyPauliSum</code></a>.
+        For usage, see
+        <a href={`${base}/tutorials/pauli-propagation#loss`}>Simulating loss</a>.
+      </p>
+    </div>
+
+    <section id="basis">
+      <h2>Updated Pauli basis</h2>
+      <p>
+        We can include loss in qubit simulation by adding a third state,
+        which we will call the leakage state $|L\rangle$. In order to
+        include this in Pauli Propagation, we extend the set of Pauli
+        basis operators by an additional operator
+        $L = |L\rangle\langle L|$, which is the projector on the leakage
+        state.
+      </p>
+      <p>The complete set of Pauli operators we use to describe any Pauli String is then</p>
+      <p>{basisSet}</p>
+      <p>
+        Neglecting coherences between the qubit subspace and the leakage
+        state, this basis fully describes the three-level system.
+      </p>
+      <p>For clarity, the corresponding matrix definitions are</p>
+      <p>{matrixIX}</p>
+      <p>{matrixZL}</p>
+      <aside class="callout">
+        In the basis above, gates <strong>no longer correspond to the
+        matrix</strong> definitions. The reason for this is simple:
+        applying e.g. an $X$ gate to a qubit in $|L\rangle$ will leave the
+        qubit invariant. However, it is obvious that multiplying any
+        Pauli $P \neq L$ from the basis with $L$ will give 0. This would
+        correspond to a zero-amplitude state. The implementation takes
+        that into account accordingly.
+      </aside>
+    </section>
+
+    <section id="loss-channel">
+      <h2>Loss channel</h2>
+      <p>
+        The action of an independent loss channel is to map part of the
+        population from the qubit subspace into the $|L\rangle$ state.
+        This corresponds to reducing the trace of the density operator.
+      </p>
+      <p>The Kraus operators for a loss channel are</p>
+      <p>{krausLoss}</p>
+      <p>where $p_L$ is the probability of losing a qubit.</p>
+      <p>The action of the channel on the Pauli basis is</p>
+      <p>{chanPauli}</p>
+      <p>{chanLossL}</p>
+      <p>
+        Note that this channel is not symmetric under forward and
+        backward propagation. The above action on Paulis corresponds to
+        the <strong>adjoint</strong> channel: {adjointInline}.
+      </p>
+      <p>
+        The action of the channel is clear from a physical perspective:
+        whenever a qubit undergoes a loss channel, we lose population out
+        of the qubit subspace.
+      </p>
+      <p>
+        However, if there is no loss present in the initial state, we
+        will never map any part of a Pauli string to $L$. This might seem
+        surprising, but is accurate. Under the loss channel described
+        here, we simply lose population out of the qubit subspace. Any
+        expectation value of a qubit-subspace operator will tend towards
+        $0$ with increasing loss.
+      </p>
+      <p>
+        An intuitive picture is also to consider a pure state which
+        describes a single probabilistic trajectory through the circuit.
+        Before loss, a state vector in the qubit subspace is just
+      </p>
+      <p>{stateVec}</p>
+      <p>Should the qubit be lost, the resulting state vector is</p>
+      <p>{stateLost}</p>
+      <p>
+        Since under the described dynamics there is no way to recover a
+        qubit once it has been lost, any trajectory where the qubit has
+        been lost will contribute a 0 overlap for any qubit-subspace
+        operator $Q$,
+      </p>
+      <p>{overlapZero}</p>
+      <p>
+        While this is conceptually accurate, the resulting loss does not
+        capture what happens on hardware. If there is no loss detection,
+        then a qubit that has been lost will be falsely counted as being
+        in the $|0\rangle$ state when measured. If there is loss
+        detection, we could either reject the trajectory via
+        post-selection (equivalent to having no loss in the system), or
+        reset the qubit to $|0\rangle$ during the circuit.
+      </p>
+    </section>
+
+    <section id="reset-channel">
+      <h2>Reset channel</h2>
+      <p>
+        To accurately model the hardware behaviour, we extend the above
+        description by a reset channel that incoherently resets a lost
+        qubit into the $|0\rangle$ state.
+      </p>
+      <p>
+        The underlying dynamics of this channel are equivalent to having
+        amplitude damping from $|L\rangle$ to the $|0\rangle$ state. The
+        Kraus operators are
+      </p>
+      <p>{krausReset}</p>
+      <p>The corresponding mappings of the Pauli basis are</p>
+      <p>{resetXY}</p>
+      <p>{resetIZ}</p>
+      <p>{resetL}</p>
+      <p>Intuitively, these mappings can be understood as:</p>
+      <ul>
+        <li>Coherences remain unchanged.</li>
+        <li>
+          Lost qubits are reset: lost population is removed ($L$ is set
+          to 0) and added to the $|0\rangle$ state, which is equivalent
+          to a positive contribution to both $Z$ and $I$.
+        </li>
+      </ul>
+      <p>
+        This reset channel is sufficient to model either actually
+        resetting a lost qubit, or the error that arises when falsely
+        counting a lost qubit as 0. For the latter, we simply apply the
+        loss channel to all qubits at the end of the circuit. This
+        ensures lost qubits don't partake in the dynamics of the
+        circuit, but are then counted as 0 in a measurement.
+      </p>
+      <p>
+        Note that since we are doing Pauli Propagation, we always have
+        to apply the adjoint circuit. Thus, resetting lost qubits at the
+        end of the circuit means we apply the reset channel at the very
+        beginning when propagating a Pauli string.
+      </p>
+    </section>
+
+    <section id="scaling">
+      <h2>Comment on branching and scaling</h2>
+      <p>
+        Both channels above branch, which without truncation would lead
+        to exponential scaling.
+      </p>
+      <p>
+        For the loss channel, it is easy to see that coefficient
+        truncation can deal with branching, since it only branches on
+        $L \to p_L I + L$. Branches therefore scale with $p_L$, which is
+        usually $\ll 1$.
+      </p>
+      <p>
+        The reset channel, on the other hand, branches on both $I$ and
+        $Z$ into $L$ without any leading coefficient. The probability of
+        having lost the $i$-th qubit at the end of the circuit is just
+        given by $\langle L_i \rangle$. Since there are no coherences
+        between $L$ and the qubit subspace, expectation values
+        factorize — for any Pauli string with $P_i \neq L_i$:
+      </p>
+      <p>{factorize}</p>
+      <p>
+        In a slight abuse of notation, we note that
+        $\langle L_i \rangle \propto p_L$; the contribution of Pauli
+        strings that have an $L$ on many positions is very small.
+        Therefore, we can truncate these to suppress exponential
+        branching.
+      </p>
+      <p>
+        In practice, this works similarly to large-weight truncation and
+        is achieved by a designated truncation strategy, configured
+        through <code>max_loss_weight</code> on
+        <a href={`${base}/api#py-ppvm-paulisum-LossyPauliSum`}><code>LossyPauliSum</code></a>.
+      </p>
+    </section>
+  </article>
+</Base>

--- a/docs/src/pages/tutorials/pauli-propagation.astro
+++ b/docs/src/pages/tutorials/pauli-propagation.astro
@@ -8,6 +8,47 @@ const toc = [
   { label: "Truncation",  href: "#truncation" },
   { label: "Simulating loss", href: "#loss" },
 ];
+
+// Code snippets live in the frontmatter as raw strings so the
+// `<pre><code>` body stays a plain `{snippet}` expression. Embedding
+// Python f-strings directly in Astro JSX would otherwise need awkward
+// brace escapes (`{`{i}`}`) that obscure the rendered code.
+const basicUsage = `from ppvm import PauliSum
+
+# Observable: Z on each qubit
+state = PauliSum.new(n_qubits=3, terms=[f"Z{i}" for i in range(3)])
+
+# Apply gates in reverse circuit order
+state.cnot(1, 2)
+state.cnot(0, 1)
+state.h(0)
+
+# Expectation value with respect to |0...0>
+print(state.overlap_with_zero())`;
+
+const termNotation = `ps = PauliSum.new(4, [("Z0Z1", 0.5), ("X2", 0.3)])`;
+
+const truncationKwargs = `ps = PauliSum.new(10, "Z0", min_abs_coeff=1e-8, max_pauli_weight=5)`;
+
+const lossExample = `from ppvm import LossyPauliSum
+
+ps = LossyPauliSum.new(n_qubits=1, terms=["Z"])
+
+# Reset at the end of the circuit
+ps.reset_loss_channel(0)
+
+# Loss after an X gate
+ps.loss_channel(0, 0.1)
+
+# Apply an X gate
+ps.x(0)
+
+z_exp = ps.overlap_with_zero()
+
+# This will be -0.8: in 10% of cases we have <Z> = 1 instead of -1.
+print(f"<Z>: {z_exp}")`;
+
+const lossWeight = `ps = LossyPauliSum.new(3, "ZZZ", max_loss_weight=2)`;
 ---
 <Base title="Pauli Propagation" current="tutorials" toc={toc}>
   <article class="shell narrow tutorial">
@@ -39,18 +80,7 @@ const toc = [
 
     <section id="basic-usage">
       <h2>Basic usage</h2>
-<pre><code class="language-python">from ppvm import PauliSum
-
-# Observable: Z on each qubit
-state = PauliSum.new(n_qubits=3, terms=[f"Z{`{i}`}" for i in range(3)])
-
-# Apply gates in reverse circuit order
-state.cnot(1, 2)
-state.cnot(0, 1)
-state.h(0)
-
-# Expectation value with respect to |0...0>
-print(state.overlap_with_zero())</code></pre>
+<pre><code class="language-python">{basicUsage}</code></pre>
       <aside class="callout">
         Because this is Heisenberg-picture propagation, gates must be
         applied in <strong>reverse circuit order</strong>.
@@ -64,7 +94,7 @@ print(state.overlap_with_zero())</code></pre>
         in compact notation (<code>"X0Z1"</code> — Pauli + qubit index).
         Coefficients default to <code>1.0</code> but can be set explicitly:
       </p>
-<pre><code class="language-python">ps = PauliSum.new(4, [("Z0Z1", 0.5), ("X2", 0.3)])</code></pre>
+<pre><code class="language-python">{termNotation}</code></pre>
     </section>
 
     <section id="truncation">
@@ -80,7 +110,7 @@ print(state.overlap_with_zero())</code></pre>
           drops terms with more non-identity Paulis than the cutoff.
         </li>
       </ul>
-<pre><code class="language-python">ps = PauliSum.new(10, "Z0", min_abs_coeff=1e-8, max_pauli_weight=5)</code></pre>
+<pre><code class="language-python">{truncationKwargs}</code></pre>
     </section>
 
     <section id="loss">
@@ -99,23 +129,7 @@ print(state.overlap_with_zero())</code></pre>
         need 3 bits to represent a character in a Pauli string rather than 2.
       </p>
       <p>Here is a small example:</p>
-<pre><code class="language-python">from ppvm import LossyPauliSum
-
-ps = LossyPauliSum.new(n_qubits=1, terms=["Z"])
-
-# Reset at the end of the circuit
-ps.reset_loss_channel(0)
-
-# Loss after an X gate
-ps.loss_channel(0, 0.1)
-
-# Apply an X gate
-ps.x(0)
-
-z_exp = ps.overlap_with_zero()
-
-# This will be -0.8: in 10% of cases we have &lt;Z&gt; = 1 instead of -1.
-print(f"&lt;Z&gt;: {`{z_exp}`}")</code></pre>
+<pre><code class="language-python">{lossExample}</code></pre>
       <p>A third truncation strategy is available for lossy simulations:</p>
       <ul>
         <li>
@@ -127,7 +141,7 @@ print(f"&lt;Z&gt;: {`{z_exp}`}")</code></pre>
           reset channels.
         </li>
       </ul>
-<pre><code class="language-python">ps = LossyPauliSum.new(3, "ZZZ", max_loss_weight=2)</code></pre>
+<pre><code class="language-python">{lossWeight}</code></pre>
     </section>
   </article>
 </Base>

--- a/docs/src/pages/tutorials/pauli-propagation.astro
+++ b/docs/src/pages/tutorials/pauli-propagation.astro
@@ -1,0 +1,133 @@
+---
+import Base from "../../layouts/Base.astro";
+const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+const toc = [
+  { label: "Overview",   href: "#overview" },
+  { label: "Basic usage", href: "#basic-usage" },
+  { label: "Term notation", href: "#term-notation" },
+  { label: "Truncation",  href: "#truncation" },
+  { label: "Simulating loss", href: "#loss" },
+];
+---
+<Base title="Pauli Propagation" current="tutorials" toc={toc}>
+  <article class="shell narrow tutorial">
+    <div class="titleblock">
+      <div class="eyebrow"><a href={`${base}/tutorials`}>Tutorials</a></div>
+      <h1>Pauli Propagation</h1>
+      <p class="byline">
+        Heisenberg-picture observable propagation through deep noisy
+        circuits, at a fraction of the cost of full state-vector
+        simulation.
+      </p>
+    </div>
+
+    <section id="overview">
+      <h2>Overview</h2>
+      <p>
+        <a href={`${base}/api#py-ppvm-paulisum-PauliSum`}><code>PauliSum</code></a>
+        simulates quantum circuits in the <strong>Heisenberg picture</strong>.
+        Instead of evolving a state vector forward through the circuit, it
+        propagates <em>observables</em> backward. The observable is
+        represented as a weighted sum of Pauli strings, and each gate is
+        applied analytically by conjugation.
+      </p>
+      <p>
+        This makes it possible to simulate large, deep circuits — including
+        noisy ones — at a fraction of the cost of full state-vector simulation.
+      </p>
+    </section>
+
+    <section id="basic-usage">
+      <h2>Basic usage</h2>
+<pre><code class="language-python">from ppvm import PauliSum
+
+# Observable: Z on each qubit
+state = PauliSum.new(n_qubits=3, terms=[f"Z{`{i}`}" for i in range(3)])
+
+# Apply gates in reverse circuit order
+state.cnot(1, 2)
+state.cnot(0, 1)
+state.h(0)
+
+# Expectation value with respect to |0...0>
+print(state.overlap_with_zero())</code></pre>
+      <aside class="callout">
+        Because this is Heisenberg-picture propagation, gates must be
+        applied in <strong>reverse circuit order</strong>.
+      </aside>
+    </section>
+
+    <section id="term-notation">
+      <h2>Term notation</h2>
+      <p>
+        Terms can be specified as full Pauli strings (<code>"XZI"</code>) or
+        in compact notation (<code>"X0Z1"</code> — Pauli + qubit index).
+        Coefficients default to <code>1.0</code> but can be set explicitly:
+      </p>
+<pre><code class="language-python">ps = PauliSum.new(4, [("Z0Z1", 0.5), ("X2", 0.3)])</code></pre>
+    </section>
+
+    <section id="truncation">
+      <h2>Truncation</h2>
+      <p>Two truncation strategies control the approximation/performance trade-off:</p>
+      <ul>
+        <li>
+          <strong>Coefficient truncation</strong> (<code>min_abs_coeff</code>):
+          drops terms with absolute coefficient below a threshold.
+        </li>
+        <li>
+          <strong>Weight truncation</strong> (<code>max_pauli_weight</code>):
+          drops terms with more non-identity Paulis than the cutoff.
+        </li>
+      </ul>
+<pre><code class="language-python">ps = PauliSum.new(10, "Z0", min_abs_coeff=1e-8, max_pauli_weight=5)</code></pre>
+    </section>
+
+    <section id="loss">
+      <h2>Simulating loss</h2>
+      <p>
+        To simulate qubit loss, ppvm offers
+        <a href={`${base}/api#py-ppvm-paulisum-LossyPauliSum`}><code>LossyPauliSum</code></a>.
+        This is a dedicated class that behaves just like a
+        <code>PauliSum</code>, but adds additional methods for the loss.
+      </p>
+      <p>
+        This separation exists because we need to extend the Pauli basis to
+        account for loss (see
+        <a href={`${base}/tutorials/loss-channel`}>Loss channel details</a>
+        for the full background). This comes at a storage overhead — we now
+        need 3 bits to represent a character in a Pauli string rather than 2.
+      </p>
+      <p>Here is a small example:</p>
+<pre><code class="language-python">from ppvm import LossyPauliSum
+
+ps = LossyPauliSum.new(n_qubits=1, terms=["Z"])
+
+# Reset at the end of the circuit
+ps.reset_loss_channel(0)
+
+# Loss after an X gate
+ps.loss_channel(0, 0.1)
+
+# Apply an X gate
+ps.x(0)
+
+z_exp = ps.overlap_with_zero()
+
+# This will be -0.8: in 10% of cases we have &lt;Z&gt; = 1 instead of -1.
+print(f"&lt;Z&gt;: {`{z_exp}`}")</code></pre>
+      <p>A third truncation strategy is available for lossy simulations:</p>
+      <ul>
+        <li>
+          <strong>Loss weight truncation</strong>
+          (<code>max_loss_weight</code>): drops terms with more than a given
+          number of <code>L</code> operators. Since the contribution of
+          strings with <code>L</code> on many positions scales as
+          $p_L^k$, this effectively controls the branching from loss and
+          reset channels.
+        </li>
+      </ul>
+<pre><code class="language-python">ps = LossyPauliSum.new(3, "ZZZ", max_loss_weight=2)</code></pre>
+    </section>
+  </article>
+</Base>

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -1945,6 +1945,56 @@ html[data-theme="dark"] .kind-module   { color: var(--ink); background: var(--bg
 .tut-toc a { border: 0; color: var(--ink); }
 .tut-toc a:hover { color: var(--accent); }
 
+/* Dev guide command tables. Plain hairline-row tables — Swiss
+   restraint, no zebra striping, no borders around the whole block. */
+.dev-cmd-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0 1.6rem;
+  font-size: 0.92rem;
+}
+.dev-cmd-table thead th {
+  text-align: left;
+  font-family: var(--sans-display);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-faint);
+  font-weight: 500;
+  padding: 0.4rem 0.7rem 0.4rem 0;
+  border-bottom: 1px solid var(--rule);
+}
+.dev-cmd-table tbody td {
+  vertical-align: top;
+  padding: 0.55rem 0.7rem 0.55rem 0;
+  border-bottom: 1px solid var(--rule-soft);
+  color: var(--ink-soft);
+  line-height: 1.5;
+}
+.dev-cmd-table tbody tr:last-child td { border-bottom: 0; }
+.dev-cmd-table td:first-child {
+  white-space: nowrap;
+  color: var(--ink);
+}
+.dev-cmd-table code {
+  font-family: var(--mono);
+  background: none;
+  border: 0;
+  padding: 0;
+  font-size: 0.85em;
+}
+@media (max-width: 720px) {
+  .dev-cmd-table, .dev-cmd-table thead, .dev-cmd-table tbody,
+  .dev-cmd-table tr, .dev-cmd-table th, .dev-cmd-table td { display: block; }
+  .dev-cmd-table thead { display: none; }
+  .dev-cmd-table tbody tr {
+    padding: 0.6rem 0;
+    border-bottom: 1px solid var(--rule-soft);
+  }
+  .dev-cmd-table tbody td { border-bottom: 0; padding: 0.15rem 0; }
+  .dev-cmd-table td:first-child { margin-bottom: 0.2rem; }
+}
+
 /* ──────────── Tutorials (long-form prose pages) ──────────── */
 
 .tutorial section { margin: 3rem 0; }

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -1945,6 +1945,233 @@ html[data-theme="dark"] .kind-module   { color: var(--ink); background: var(--bg
 .tut-toc a { border: 0; color: var(--ink); }
 .tut-toc a:hover { color: var(--accent); }
 
+/* ──────────── Tutorials (long-form prose pages) ──────────── */
+
+.tutorial section { margin: 3rem 0; }
+.tutorial section:first-of-type { margin-top: 1.6rem; }
+.tutorial h2 {
+  font-family: var(--sans-display);
+  font-size: 1.45rem;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  margin: 0 0 1rem;
+}
+.tutorial p { margin: 0.7rem 0; color: var(--ink-soft); line-height: 1.65; }
+.tutorial ul, .tutorial ol { color: var(--ink-soft); margin: 0.7rem 0 0.7rem 1.4rem; }
+.tutorial pre {
+  margin: 0.9rem 0;
+  background: var(--bg-elev);
+  border: 1px solid var(--rule-soft);
+  border-radius: 4px;
+  padding: 0.9rem 1.05rem;
+  font-size: 0.84rem;
+}
+
+.callout {
+  margin: 1rem 0;
+  padding: 0.85rem 1.1rem;
+  border: 1px solid var(--rule);
+  border-left: 3px solid var(--accent);
+  border-radius: 4px;
+  background: var(--bg-elev);
+  font-size: 0.95rem;
+  color: var(--ink-soft);
+  line-height: 1.55;
+}
+
+.tutorials-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.6rem 0 0;
+  display: grid;
+  gap: 1.6rem;
+}
+.tutorials-list > li {
+  padding-top: 1.4rem;
+  border-top: 1px solid var(--rule-soft);
+}
+.tutorials-list > li:first-child { border-top: 0; padding-top: 0; }
+.tutorials-title {
+  display: block;
+  font-family: var(--sans-display);
+  font-size: 1.25rem;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  text-decoration: none;
+  margin-bottom: 0.4rem;
+}
+.tutorials-title:hover { color: var(--accent); }
+.tutorials-list > li p { font-size: 0.95rem; color: var(--ink-soft); margin: 0; }
+
+/* ──────────── Examples (executed Jupyter notebooks) ──────────── */
+
+.examples-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.6rem 0 0;
+  display: grid;
+  gap: 1.8rem;
+}
+.examples-list > li {
+  padding-top: 1.4rem;
+  border-top: 1px solid var(--rule-soft);
+}
+.examples-list > li:first-child { border-top: 0; padding-top: 0; }
+.examples-title {
+  display: block;
+  font-family: var(--sans-display);
+  font-size: 1.25rem;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  text-decoration: none;
+  margin-bottom: 0.3rem;
+}
+.examples-title:hover { color: var(--accent); }
+.examples-meta { font-size: 0.82rem; color: var(--ink-faint); margin-bottom: 0.5rem; }
+.examples-meta code { background: none; border: 0; padding: 0; font-size: inherit; }
+.examples-meta a { color: var(--ink-soft); }
+.examples-meta a:hover { color: var(--accent); }
+.examples-headings {
+  margin: 0.2rem 0 0 1.2rem;
+  padding: 0;
+  font-size: 0.92rem;
+  color: var(--ink-soft);
+  columns: 2;
+  column-gap: 1.6rem;
+}
+.examples-headings li { break-inside: avoid; margin: 0.15rem 0; }
+@media (max-width: 720px) { .examples-headings { columns: 1; } }
+
+/* Notebook body: nbconvert's `basic` template wraps cells in
+   `.jp-Cell` containers with input + output regions. We translate
+   the JupyterLab look into the site's Swiss vocabulary — hairline
+   rules between cells, brand-tinted code blocks, plain prose for
+   markdown cells, plots embedded as their natural images. */
+.notebook { max-width: 50rem; }
+.notebook-body { margin-top: 2rem; }
+.notebook-body > main { display: contents; }
+.notebook-body .jp-Cell {
+  margin: 1.4rem 0;
+  padding: 0;
+  border: 0;
+}
+.notebook-body .jp-Cell + .jp-Cell { border-top: 1px solid var(--rule-soft); padding-top: 1.4rem; }
+.notebook-body .jp-MarkdownCell .jp-RenderedHTMLCommon {
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--ink);
+}
+.notebook-body .jp-MarkdownCell h1 {
+  font-family: var(--sans-display);
+  font-size: 1.65rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  margin: 0.6rem 0 1rem;
+}
+.notebook-body .jp-MarkdownCell h2 {
+  font-family: var(--sans-display);
+  font-size: 1.3rem;
+  font-weight: 500;
+  margin: 1.4rem 0 0.8rem;
+}
+.notebook-body .jp-MarkdownCell h3 { font-size: 1.05rem; font-weight: 500; margin: 1rem 0 0.5rem; }
+.notebook-body .jp-MarkdownCell .anchor-link { display: none; }
+.notebook-body .jp-MarkdownCell p { margin: 0.6rem 0; color: var(--ink-soft); }
+.notebook-body .jp-MarkdownCell code {
+  background: var(--bg-elev);
+  border: 1px solid var(--rule-soft);
+  border-radius: 3px;
+  padding: 1px 5px;
+}
+.notebook-body .jp-MarkdownCell ul,
+.notebook-body .jp-MarkdownCell ol { color: var(--ink-soft); margin: 0.6rem 0 0.6rem 1.4rem; }
+
+/* Input code cells. nbconvert wraps them in `.jp-CodeMirrorEditor`
+   with Pygments classes. Let the site's design tokens carry the
+   palette so we don't have to re-theme every Pygments class. */
+.notebook-body .jp-CodeCell .jp-InputArea {
+  margin: 0.4rem 0;
+}
+.notebook-body .jp-CodeCell .highlight,
+.notebook-body .jp-CodeCell pre {
+  background: var(--bg-elev);
+  border: 1px solid var(--rule-soft);
+  border-radius: 4px;
+  padding: 0.85rem 1rem;
+  font-size: 0.84rem;
+  line-height: 1.55;
+  overflow-x: auto;
+}
+.notebook-body .jp-CodeCell pre { margin: 0; border: 0; padding: 0; background: transparent; }
+/* Pygments token mapping (light + dark via var(--syntax-*) tokens
+   already defined for the highlight.js theme). */
+.notebook-body .highlight .k,  /* keyword */
+.notebook-body .highlight .kn,
+.notebook-body .highlight .kc,
+.notebook-body .highlight .o   /* operator (e.g. `import` rules) */ { color: var(--syntax-keyword); font-weight: 500; }
+.notebook-body .highlight .s,
+.notebook-body .highlight .s1,
+.notebook-body .highlight .s2,
+.notebook-body .highlight .sa  { color: var(--syntax-string); }
+.notebook-body .highlight .mi,
+.notebook-body .highlight .mf,
+.notebook-body .highlight .m   { color: var(--syntax-number); }
+.notebook-body .highlight .c,
+.notebook-body .highlight .c1,
+.notebook-body .highlight .cm  { color: var(--syntax-comment); font-style: italic; }
+.notebook-body .highlight .nn,
+.notebook-body .highlight .nc,
+.notebook-body .highlight .nb,
+.notebook-body .highlight .nf  { color: var(--syntax-ink); }
+.notebook-body .highlight .n,
+.notebook-body .highlight .p,
+.notebook-body .highlight .w   { color: var(--syntax-soft); }
+
+/* Output regions: text outputs (stdout/stderr) get a slight inset
+   so they read as the *result* of the cell above; images render
+   at their natural width inside the column. */
+.notebook-body .jp-OutputArea {
+  margin: 0.4rem 0 0;
+  padding-left: 0;
+}
+.notebook-body .jp-OutputArea-output {
+  padding: 0.5rem 0;
+}
+.notebook-body .jp-OutputArea pre {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font-size: 0.84rem;
+  line-height: 1.55;
+  color: var(--ink-soft);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.notebook-body .jp-OutputArea img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 0.6rem auto;
+  background: white;
+  border: 1px solid var(--rule-soft);
+  border-radius: 3px;
+}
+html[data-theme="dark"] .notebook-body .jp-OutputArea img {
+  /* matplotlib figures default to a white facecolor; soften the
+     contrast slightly on dark canvases so they sit better. */
+  filter: brightness(0.95);
+}
+
+/* Hide the JupyterLab gutter glyphs (collapse arrows, prompts)
+   that the `basic` template still emits — we want a clean read,
+   not an IDE recreation. */
+.notebook-body .jp-Collapser,
+.notebook-body .jp-InputPrompt,
+.notebook-body .jp-OutputPrompt { display: none !important; }
+
 /* ──────────── Footer ──────────── */
 .foot {
   margin-top: 5rem;

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -2061,7 +2061,7 @@ html[data-theme="dark"] .kind-module   { color: var(--ink); background: var(--bg
   padding: 0;
   margin: 1.6rem 0 0;
   display: grid;
-  gap: 1.8rem;
+  gap: 1.6rem;
 }
 .examples-list > li {
   padding-top: 1.4rem;
@@ -2076,23 +2076,48 @@ html[data-theme="dark"] .kind-module   { color: var(--ink); background: var(--bg
   letter-spacing: -0.005em;
   color: var(--ink);
   text-decoration: none;
-  margin-bottom: 0.3rem;
+  margin-bottom: 0.45rem;
 }
 .examples-title:hover { color: var(--accent); }
-.examples-meta { font-size: 0.82rem; color: var(--ink-faint); margin-bottom: 0.5rem; }
-.examples-meta code { background: none; border: 0; padding: 0; font-size: inherit; }
-.examples-meta a { color: var(--ink-soft); }
-.examples-meta a:hover { color: var(--accent); }
-.examples-headings {
-  margin: 0.2rem 0 0 1.2rem;
-  padding: 0;
-  font-size: 0.92rem;
-  color: var(--ink-soft);
-  columns: 2;
-  column-gap: 1.6rem;
+
+/* Source line: `<lang badge>  Source: <path>` on one row. The
+   "Source:" label is what makes the path obviously a link to the
+   file rather than a project-relative folder name. */
+.examples-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.55rem 0.7rem;
+  font-size: 0.85rem;
+  color: var(--ink-faint);
+  margin: 0;
 }
-.examples-headings li { break-inside: avoid; margin: 0.15rem 0; }
-@media (max-width: 720px) { .examples-headings { columns: 1; } }
+.examples-source-label {
+  font-family: var(--sans-display);
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.examples-source {
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  color: var(--ink-soft);
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 1px;
+}
+.examples-source:hover { color: var(--accent); border-bottom-color: var(--accent); }
+.examples-lang {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+  color: var(--accent);
+  border: 1px solid color-mix(in srgb, var(--accent) 38%, var(--rule));
+  border-radius: 3px;
+  padding: 0.1rem 0.45rem;
+  line-height: 1.3;
+}
 
 /* Notebook body: nbconvert's `basic` template wraps cells in
    `.jp-Cell` containers with input + output regions. We translate
@@ -2143,6 +2168,38 @@ html[data-theme="dark"] .kind-module   { color: var(--ink); background: var(--bg
    palette so we don't have to re-theme every Pygments class. */
 .notebook-body .jp-CodeCell .jp-InputArea {
   margin: 0.4rem 0;
+}
+.notebook-body .jp-CodeCell .jp-InputArea-editor,
+.notebook-body .jp-CodeCell > .jp-Cell-inputWrapper > .jp-InputArea {
+  /* Position the language badge relative to the cell. */
+  position: relative;
+}
+/* Tiny language label in the top-right of every input cell, sourced
+   from the wrapper's `data-language` attribute. Falls back to
+   "python" if the attribute is missing. */
+.notebook-body[data-language] .jp-CodeCell .jp-InputArea::after {
+  content: attr(data-cell-lang, "");
+}
+.notebook-body .jp-CodeCell .jp-InputArea::after {
+  content: "";
+}
+.notebook-body[data-language="python"] .jp-CodeCell .jp-InputArea::after { content: "python"; }
+.notebook-body[data-language="rust"]   .jp-CodeCell .jp-InputArea::after { content: "rust"; }
+.notebook-body[data-language="julia"]  .jp-CodeCell .jp-InputArea::after { content: "julia"; }
+.notebook-body[data-language] .jp-CodeCell .jp-InputArea::after {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.7rem;
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.04em;
+  color: var(--ink-faint);
+  background: var(--bg);
+  border: 1px solid var(--rule-soft);
+  border-radius: 2px;
+  padding: 0.05rem 0.4rem;
+  pointer-events: none;
+  z-index: 1;
 }
 .notebook-body .jp-CodeCell .highlight,
 .notebook-body .jp-CodeCell pre {

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -2126,7 +2126,6 @@ html[data-theme="dark"] .kind-module   { color: var(--ink); background: var(--bg
    markdown cells, plots embedded as their natural images. */
 .notebook { max-width: 50rem; }
 .notebook-body { margin-top: 2rem; }
-.notebook-body > main { display: contents; }
 .notebook-body .jp-Cell {
   margin: 1.4rem 0;
   padding: 0;
@@ -2174,15 +2173,12 @@ html[data-theme="dark"] .kind-module   { color: var(--ink); background: var(--bg
   /* Position the language badge relative to the cell. */
   position: relative;
 }
-/* Tiny language label in the top-right of every input cell, sourced
-   from the wrapper's `data-language` attribute. Falls back to
-   "python" if the attribute is missing. */
-.notebook-body[data-language] .jp-CodeCell .jp-InputArea::after {
-  content: attr(data-cell-lang, "");
-}
-.notebook-body .jp-CodeCell .jp-InputArea::after {
-  content: "";
-}
+/* Tiny language label in the top-right of every input cell. The
+   wrapper's `data-language` attribute selects which literal to emit
+   — we use literal `content:` per language rather than `attr()`
+   because the two-argument `attr(..., fallback)` form isn't yet
+   widely supported. Add a new language by appending a rule here
+   plus listing it in build-notebooks.py's `detect_language`. */
 .notebook-body[data-language="python"] .jp-CodeCell .jp-InputArea::after { content: "python"; }
 .notebook-body[data-language="rust"]   .jp-CodeCell .jp-InputArea::after { content: "rust"; }
 .notebook-body[data-language="julia"]  .jp-CodeCell .jp-InputArea::after { content: "julia"; }

--- a/ppvm-python/test/generalized_tableau/test_simulator_device.py
+++ b/ppvm-python/test/generalized_tableau/test_simulator_device.py
@@ -258,8 +258,8 @@ def test_correlated_qubit_loss_loses_both_qubits_in_pair():
     def main():
         q = squin.qalloc(4)
 
-        squin.correlated_qubit_loss(1.0, [q[0], q[1]])
-        squin.correlated_qubit_loss(0.0, [q[2], q[3]])
+        squin.correlated_qubit_loss(1.0, ilist.IList([q[0], q[1]]))
+        squin.correlated_qubit_loss(0.0, ilist.IList([q[2], q[3]]))
 
         return squin.broadcast.measure(q)
 


### PR DESCRIPTION
## Summary

Brings the content from the legacy `ppvm-python/docs/` mkdocs site into the new Astro docs in two paths, depending on what the source was. Headline ask was the Jupyter notebooks — those go through an **automated execute-and-embed pipeline** so adding a new notebook later is a single-file change. The static markdown tutorials are converted to Astro by hand (they don't execute, so no pipeline buys anything).

## Jupyter notebooks (automated pipeline)

`docs/scripts/build-notebooks.py` runs before `npx astro build`:

1. Reads every Jupytext `.py` file under `docs/notebooks/`.
2. Executes each via `nbclient.NotebookClient` so stdout, return values, and matplotlib figures get captured as embedded outputs.
3. Renders an HTML fragment via `nbconvert`'s `basic` template (stripping the `<body>` so JupyterLab's own stylesheet isn't pulled in — the site's CSS themes the `.jp-*` classes instead).
4. Writes `docs/src/generated/notebooks/<slug>.{html,json}` and an `index.json` listing.

The Astro side reads the generated files:

- `docs/src/pages/examples/index.astro` — listing.
- `docs/src/pages/examples/[slug].astro` — dynamic route that embeds the matching fragment via `set:html`.

Adding another notebook later is _just_ dropping another `.py` under `docs/notebooks/`. Two ship in this PR:

- `trotter.py` — XZZ Ising Trotter evolution + a noisy variant with loss
- `msd.py` — magic-state distillation on the generalized tableau

…both copied verbatim from `ppvm-python/docs/examples/`.

## Tutorials (markdown → Astro, hand-converted)

- `pauli-propagation.astro`, `loss-channel.astro`, `generalized-tableau.astro` under `src/pages/tutorials/` carry the three substantive markdown pages from the old mkdocs site. The conversion is manual since the source was static prose, not executable.
- `tutorials/index.astro` indexes them with one-sentence summaries.

## Site wiring

- `Base.astro` gains a **Tutorials** and **Examples** nav item.
- KaTeX loaded via CDN in `Base.astro` — the notebooks' LaTeX (`$$…$$`) and the loss-channel tutorial's matrix definitions actually render now.
- New CSS sections in `global.css`:
  - `.notebook-body .jp-*` maps JupyterLab's class names onto our design tokens (hairline rules, brand syntax theme, embedded plots in a tinted card).
  - `.tutorial`, `.callout`, `.tutorials-list` for the long-form pages.
- `.github/workflows/docs.yml` runs `build-notebooks.py` before `npx astro build`; the PR-paths filter expands to `crates/**` and `ppvm-python/**` so notebook execution re-runs when the upstream Python or Rust API changes.
- `docs/.gitignore` excludes `src/generated/` (everything in it is regenerated per build).

## Test plan

- [ ] CI's `Build Astro site` passes: notebook build runs, then `npx astro build` emits 13 pages including `examples/index`, `examples/trotter`, `examples/msd`, `tutorials/index`, `tutorials/pauli-propagation`, `tutorials/loss-channel`, `tutorials/generalized-tableau`.
- [ ] PR preview shows the executed notebooks with code, text outputs, and embedded plots (matplotlib figures).
- [ ] KaTeX renders the math in `tutorials/loss-channel` (the five-symbol basis, Kraus operators).
- [ ] Light + dark themes both look right on the notebook pages and on the tutorial pages.

## What this PR does **not** do

- Doesn't delete `ppvm-python/docs/` or `ppvm-python/mkdocs.yml`. A follow-up can do the cleanup once any external redirects are sorted.
- Doesn't drop the `[dependency-groups].doc` block in `ppvm-python/pyproject.toml`. Same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)