### PR TITLE
docs: improve mobile layout and small-screen readability

### DIFF
--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -238,10 +238,13 @@ const nav = [
             const open = toggle.getAttribute("aria-expanded") !== "true";
             setOpen(open);
           });
-          // Close after following an in-page link on mobile.
+          // Close after following an in-page link on mobile. Use
+          // closest("a") so this stays correct if a nav link ever
+          // wraps an icon or other inline element.
           nav.addEventListener("click", (e) => {
-            const target = e.target;
-            if (target && target.tagName === "A") setOpen(false);
+            if (e.target && e.target.closest && e.target.closest("a")) {
+              setOpen(false);
+            }
           });
           // Reset state when crossing the breakpoint.
           const mqNav = window.matchMedia("(min-width: 721px)");

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -23,6 +23,16 @@ interface Props {
 
 const { title, description = "ppvm — fast Pauli propagation and stabilizer-tableau quantum simulator.", current, toc, tocTitle = "On this page", sections, currentSection, sectionsTitle = "Sections" } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+
+// Compute prev/next links for the section pager when the page is part
+// of a multi-section walk-through (currently the Python Quick Start).
+let prevSection: SectionItem | undefined;
+let nextSection: SectionItem | undefined;
+if (sections && currentSection) {
+  const idx = sections.findIndex((s) => s.id === currentSection);
+  if (idx > 0) prevSection = sections[idx - 1];
+  if (idx >= 0 && idx < sections.length - 1) nextSection = sections[idx + 1];
+}
 const nav = [
   { id: "home", label: "Overview", href: `${base}/` },
   { id: "quickstart", label: "Quick Start", href: `${base}/quickstart` },
@@ -57,7 +67,10 @@ const nav = [
           <span class="brand-mono">ppvm</span>
           <span class="brand-sub">/ Pauli propagation &amp; tableau simulation</span>
         </a>
-        <nav class="nav-links">
+        <button type="button" class="nav-toggle" aria-expanded="false" aria-controls="primary-nav" aria-label="Open navigation menu">
+          <span class="nav-toggle-bars" aria-hidden="true"></span>
+        </button>
+        <nav class="nav-links" id="primary-nav">
           {nav.map((n) => (
             <a href={n.href} aria-current={current === n.id ? "page" : undefined}>{n.label}</a>
           ))}
@@ -86,8 +99,8 @@ const nav = [
     <main>
       {sections && sections.length > 0 ? (
         <div class="page-shell page-shell--3col">
-          <aside class="page-sections" aria-label={sectionsTitle}>
-            <div class="page-toc-label">{sectionsTitle}</div>
+          <details class="page-sections side-nav" aria-label={sectionsTitle}>
+            <summary class="page-toc-label">{sectionsTitle}</summary>
             <ol>
               {sections.map((s) => (
                 <li>
@@ -98,33 +111,49 @@ const nav = [
                 </li>
               ))}
             </ol>
-          </aside>
+          </details>
           <div class="page-toc-content">
             <slot />
+            {(prevSection || nextSection) && (
+              <nav class="section-pager" aria-label="Section navigation">
+                {prevSection ? (
+                  <a class="section-pager-link section-pager-prev" href={prevSection.href} rel="prev">
+                    <span class="section-pager-dir">← Previous</span>
+                    <span class="section-pager-label">{prevSection.label}</span>
+                  </a>
+                ) : <span class="section-pager-link section-pager-prev section-pager-empty" aria-hidden="true"></span>}
+                {nextSection ? (
+                  <a class="section-pager-link section-pager-next" href={nextSection.href} rel="next">
+                    <span class="section-pager-dir">Next →</span>
+                    <span class="section-pager-label">{nextSection.label}</span>
+                  </a>
+                ) : <span class="section-pager-link section-pager-next section-pager-empty" aria-hidden="true"></span>}
+              </nav>
+            )}
           </div>
           {toc && toc.length > 0 ? (
-            <aside class="page-toc page-toc--right" aria-label={tocTitle}>
-              <div class="page-toc-label">{tocTitle}</div>
+            <details class="page-toc page-toc--right side-nav" aria-label={tocTitle}>
+              <summary class="page-toc-label">{tocTitle}</summary>
               <ol>
                 {toc.map((t) => (
                   <li><a href={t.href} data-toc-link={t.href}>{t.label}</a></li>
                 ))}
               </ol>
-            </aside>
+            </details>
           ) : (
             <aside class="page-toc page-toc--right page-toc--empty" aria-hidden="true"></aside>
           )}
         </div>
       ) : toc && toc.length > 0 ? (
         <div class="page-shell">
-          <aside class="page-toc" aria-label={tocTitle}>
-            <div class="page-toc-label">{tocTitle}</div>
+          <details class="page-toc side-nav" aria-label={tocTitle}>
+            <summary class="page-toc-label">{tocTitle}</summary>
             <ol>
               {toc.map((t) => (
                 <li><a href={t.href} data-toc-link={t.href}>{t.label}</a></li>
               ))}
             </ol>
-          </aside>
+          </details>
           <div class="page-toc-content">
             <slot />
           </div>
@@ -176,6 +205,50 @@ const nav = [
         })();
       </script>
     )}
+    <script is:inline>
+      // Mobile navigation drawer + responsive open-state for the
+      // sidebar TOCs. On wide viewports the TOCs are always open and
+      // the disclosure widget on .side-nav is visually neutralised by
+      // CSS; on narrow viewports they default to closed so the long
+      // navigation list doesn't push content below the fold.
+      (() => {
+        const mq = window.matchMedia("(min-width: 901px)");
+        const sideNavs = document.querySelectorAll("details.side-nav");
+        function syncSideNavs() {
+          for (const d of sideNavs) {
+            if (mq.matches) d.setAttribute("open", "");
+            else d.removeAttribute("open");
+          }
+        }
+        syncSideNavs();
+        mq.addEventListener("change", syncSideNavs);
+
+        const toggle = document.querySelector(".nav-toggle");
+        const nav = document.getElementById("primary-nav");
+        if (toggle && nav) {
+          function setOpen(open) {
+            toggle.setAttribute("aria-expanded", open ? "true" : "false");
+            toggle.setAttribute(
+              "aria-label",
+              open ? "Close navigation menu" : "Open navigation menu",
+            );
+            nav.toggleAttribute("data-open", open);
+          }
+          toggle.addEventListener("click", () => {
+            const open = toggle.getAttribute("aria-expanded") !== "true";
+            setOpen(open);
+          });
+          // Close after following an in-page link on mobile.
+          nav.addEventListener("click", (e) => {
+            const target = e.target;
+            if (target && target.tagName === "A") setOpen(false);
+          });
+          // Reset state when crossing the breakpoint.
+          const mqNav = window.matchMedia("(min-width: 721px)");
+          mqNav.addEventListener("change", () => setOpen(false));
+        }
+      })();
+    </script>
     <script is:inline>
       // Inject a copy button into every <pre> block.
       (() => {
@@ -244,6 +317,35 @@ const nav = [
         mql.addEventListener("change", () => {
           if ((localStorage.getItem("ppvm-theme") || "auto") === "auto") apply("auto");
         });
+      })();
+    </script>
+    <button type="button" class="back-to-top" aria-label="Back to top" hidden>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M12 19V5"/>
+        <path d="m5 12 7-7 7 7"/>
+      </svg>
+    </button>
+    <script is:inline>
+      // Show the back-to-top button after the reader has scrolled past
+      // ~1.2× the viewport — far enough that "scroll back up" is a real
+      // chore. Clicking smooth-scrolls to the top and (for keyboard
+      // users) returns focus to the masthead brand.
+      (() => {
+        const btn = document.querySelector(".back-to-top");
+        if (!btn) return;
+        const threshold = () => Math.max(window.innerHeight * 1.2, 600);
+        function sync() {
+          const show = window.scrollY > threshold();
+          btn.toggleAttribute("hidden", !show);
+        }
+        btn.addEventListener("click", () => {
+          window.scrollTo({ top: 0, behavior: "smooth" });
+          const brand = document.querySelector(".brand");
+          if (brand && brand.focus) brand.focus({ preventScroll: true });
+        });
+        window.addEventListener("scroll", sync, { passive: true });
+        window.addEventListener("resize", sync);
+        sync();
       })();
     </script>
     <footer class="foot">

--- a/docs/src/pages/api.astro
+++ b/docs/src/pages/api.astro
@@ -55,7 +55,8 @@ function groupByKind(items: ApiItemT[]): KindGroup[] {
 ---
 <Base title="Reference" current="api">
   <div class="api-shell" data-lang-filter="all">
-    <aside class="api-toc" aria-label="API contents">
+    <details class="api-toc side-nav" aria-label="API contents">
+      <summary class="api-toc-summary">API contents</summary>
       <input type="search" class="toc-filter" placeholder="search the API…" autocomplete="off" />
 
       <div class="lang-toggle" role="tablist" aria-label="Filter by language">
@@ -97,7 +98,7 @@ function groupByKind(items: ApiItemT[]): KindGroup[] {
           ))}
         </div>
       ))}
-    </aside>
+    </details>
 
     <div>
       <div class="titleblock" style="margin-bottom: 1.5rem;">

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -2486,6 +2486,11 @@ details.side-nav > summary {
   display: block;
   list-style: none;
   cursor: default;
+  /* On wide viewports the disclosure is forced open and the summary
+     reads as a plain heading. Disable pointer events so a stray click
+     can't toggle the <details> closed — the mobile breakpoint below
+     restores them. */
+  pointer-events: none;
 }
 details.side-nav > summary::-webkit-details-marker { display: none; }
 details.side-nav > summary::marker { content: ""; }
@@ -2498,12 +2503,16 @@ details.side-nav > summary::marker { content: ""; }
   margin: 0.2em 0 1rem;
   list-style: none;
   cursor: default;
+  pointer-events: none;
 }
 .api-toc.side-nav > .api-toc-summary::-webkit-details-marker { display: none; }
 .api-toc.side-nav > .api-toc-summary::marker { content: ""; }
+@media (max-width: 980px) {
+  .api-toc.side-nav > .api-toc-summary { pointer-events: auto; cursor: pointer; }
+}
 
 @media (max-width: 900px) {
-  details.side-nav > summary { cursor: pointer; }
+  details.side-nav > summary { cursor: pointer; pointer-events: auto; }
   details.side-nav > summary::after {
     content: "▾";
     float: right;

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -2365,6 +2365,338 @@ html[data-theme="dark"] .notebook-body .jp-OutputArea img {
 /* Smooth scroll */
 html { scroll-behavior: smooth; scroll-padding-top: 4.5rem; }
 
+/* ──────────── Section pager ────────────
+   Rendered automatically by Base.astro at the end of every page that
+   belongs to a multi-section walk-through (Python Quick Start). Reads
+   as two hairline-bordered text links — prev on the left, next on the
+   right — and stacks vertically on phones. Uses the same arrow motif
+   as `.btn` so the affordance is consistent. */
+.section-pager {
+  display: none;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.2rem;
+  margin: 3.6rem 0 0;
+  padding-top: 1.4rem;
+  border-top: 1px solid var(--rule);
+}
+@media (max-width: 900px) {
+  .section-pager { display: grid; }
+}
+.section-pager-link {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.6rem 0;
+  border: 0;
+  background: transparent;
+  color: var(--ink-soft);
+  text-decoration: none;
+  transition: color 120ms ease;
+  min-height: 1px; /* keep the empty placeholder column stable */
+}
+.section-pager-link.section-pager-empty {
+  visibility: hidden;
+}
+.section-pager-prev { text-align: left; }
+.section-pager-next { text-align: right; align-items: flex-end; }
+.section-pager-dir {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  transition: color 120ms ease, transform 160ms ease;
+}
+.section-pager-label {
+  font-family: var(--sans-display);
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+}
+.section-pager-link:hover { color: var(--accent); }
+.section-pager-link:hover .section-pager-dir { color: var(--accent); }
+.section-pager-link:hover .section-pager-label { color: var(--accent); }
+.section-pager-prev:hover .section-pager-dir { transform: translateX(-2px); }
+.section-pager-next:hover .section-pager-dir { transform: translateX(2px); }
+
+@media (max-width: 540px) {
+  .section-pager { grid-template-columns: 1fr; gap: 0.6rem; }
+  .section-pager-next { text-align: left; align-items: flex-start; }
+  .section-pager-link { padding: 0.4rem 0; }
+}
+
+/* ──────────── Back-to-top floating button ────────────
+   Bottom-right pill that fades in once the reader has scrolled past
+   roughly 1.2× the viewport. Reverts to off-canvas via [hidden] so
+   it's a no-op above the fold. */
+.back-to-top {
+  position: fixed;
+  right: 1.4rem;
+  bottom: 1.4rem;
+  z-index: 20;
+  width: 40px;
+  height: 40px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--bg) 90%, transparent);
+  color: var(--ink-soft);
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  cursor: pointer;
+  padding: 0;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  box-shadow: 0 4px 14px -8px rgba(15, 12, 36, 0.25);
+  transition: opacity 180ms ease, transform 180ms ease, color 120ms ease, border-color 120ms ease, background 120ms ease;
+  opacity: 1;
+}
+@media (max-width: 900px) {
+  .back-to-top { display: inline-flex; }
+  .back-to-top[hidden] {
+    display: inline-flex;
+    pointer-events: none;
+    opacity: 0;
+    transform: translateY(6px);
+  }
+}
+.back-to-top:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.back-to-top:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.back-to-top svg { width: 18px; height: 18px; display: block; }
+
+@media (max-width: 720px) {
+  .back-to-top { right: 0.9rem; bottom: 0.9rem; width: 38px; height: 38px; }
+}
+
+/* ──────────── Side-nav disclosures ────────────
+   `.page-toc`, `.page-sections`, and `.api-toc` use a <details> element
+   so they can collapse on narrow viewports. On wide viewports the
+   inline script forces them open and the disclosure widget below is
+   neutralised so the summary reads as a plain heading (matches the
+   former <aside> + .page-toc-label layout). */
+details.side-nav { display: block; }
+details.side-nav > summary {
+  display: block;
+  list-style: none;
+  cursor: default;
+}
+details.side-nav > summary::-webkit-details-marker { display: none; }
+details.side-nav > summary::marker { content: ""; }
+.api-toc.side-nav > .api-toc-summary {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--ink-faint);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0.2em 0 1rem;
+  list-style: none;
+  cursor: default;
+}
+.api-toc.side-nav > .api-toc-summary::-webkit-details-marker { display: none; }
+.api-toc.side-nav > .api-toc-summary::marker { content: ""; }
+
+@media (max-width: 900px) {
+  details.side-nav > summary { cursor: pointer; }
+  details.side-nav > summary::after {
+    content: "▾";
+    float: right;
+    color: var(--ink-faint);
+    font-size: 0.85em;
+    margin-left: 0.4em;
+    transition: transform 160ms ease;
+  }
+  details.side-nav[open] > summary::after { transform: rotate(180deg); }
+  details.side-nav > summary:hover { color: var(--ink); }
+  details.side-nav > summary {
+    padding: 0.55rem 0;
+    margin: 0;
+  }
+  details.side-nav:not([open]) {
+    padding-bottom: 0.4rem !important;
+  }
+  /* The right-hand "On this page" TOC duplicates the left-hand nav on
+     small screens; hide it so the reader only sees one stacked list. */
+  details.page-toc--right.side-nav { display: none; }
+}
+
+/* ──────────── Mobile nav drawer ────────────
+   The hamburger sits to the right of the brand; it's hidden until the
+   masthead would otherwise overflow. When open, `.nav-links` becomes a
+   stacked drawer that slides out from beneath the masthead. */
+.nav-toggle {
+  display: none;
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  width: 38px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--ink);
+  padding: 0;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.nav-toggle:hover { border-color: var(--accent); color: var(--accent); }
+.nav-toggle-bars,
+.nav-toggle-bars::before,
+.nav-toggle-bars::after {
+  display: block;
+  width: 18px;
+  height: 1.5px;
+  background: currentColor;
+  border-radius: 1px;
+  transition: transform 180ms ease, opacity 120ms ease;
+}
+.nav-toggle-bars { position: relative; }
+.nav-toggle-bars::before,
+.nav-toggle-bars::after {
+  content: "";
+  position: absolute;
+  left: 0;
+}
+.nav-toggle-bars::before { top: -6px; }
+.nav-toggle-bars::after  { top:  6px; }
+.nav-toggle[aria-expanded="true"] .nav-toggle-bars { background: transparent; }
+.nav-toggle[aria-expanded="true"] .nav-toggle-bars::before { transform: translateY(6px) rotate(45deg); }
+.nav-toggle[aria-expanded="true"] .nav-toggle-bars::after  { transform: translateY(-6px) rotate(-45deg); }
+
+@media (max-width: 720px) {
+  .masthead-inner {
+    padding: 0.7rem var(--gutter);
+    gap: 0.8rem;
+  }
+  .brand .brand-sub { display: none; }
+  .nav-toggle { display: inline-flex; }
+  .nav-links {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    background: var(--bg);
+    border-bottom: 1px solid var(--rule);
+    padding: 0.4rem var(--gutter) 0.9rem;
+    font-size: 1rem;
+    /* Collapsed by default; toggled open by JS via [data-open]. */
+    max-height: 0;
+    overflow: hidden;
+    visibility: hidden;
+    transition: max-height 220ms ease, padding 220ms ease, visibility 0s linear 220ms;
+  }
+  .nav-links[data-open] {
+    max-height: calc(100vh - 4rem);
+    overflow-y: auto;
+    visibility: visible;
+    transition: max-height 220ms ease, padding 220ms ease, visibility 0s;
+  }
+  .nav-links a {
+    padding: 0.65rem 0;
+    border-bottom: 1px solid var(--rule-soft);
+  }
+  .nav-links a:last-of-type { border-bottom: 0; }
+  .nav-links a[aria-current="page"] {
+    color: var(--accent);
+    border-bottom-color: var(--rule-soft);
+  }
+  .nav-links .theme-toggle {
+    margin: 0.6rem 0 0;
+    align-self: flex-start;
+  }
+}
+
+/* ──────────── Small-screen typography & spacing ────────────
+   Tightens the global rhythm so long-form pages don't feel cramped at
+   the top (huge h1) and starved at the sides (excessive padding). */
+@media (max-width: 720px) {
+  html { font-size: 16px; }
+  h1 { font-size: clamp(2rem, 7.5vw, 2.6rem); }
+  h2 { font-size: 1.32rem; margin: 2em 0 0.5em; }
+  h3 { font-size: 1.02rem; margin: 1.5em 0 0.4em; }
+  p.lede { font-size: 1.06rem; }
+
+  .shell { padding: 2.4rem var(--gutter) 3.4rem; }
+  .titleblock { margin-bottom: 1.8rem; padding-bottom: 1.1rem; }
+  .titleblock .meta { gap: 0.6rem 1.4rem; margin-top: 1rem; }
+  .titleblock .byline { font-size: 1rem; }
+
+  pre {
+    padding: 0.85rem 0.9rem;
+    font-size: 0.8rem;
+    /* On very narrow viewports, let pre extend to the gutter so long
+       code lines have a bit more breathing room. */
+    margin-left: calc(-1 * var(--gutter) * 0.4);
+    margin-right: calc(-1 * var(--gutter) * 0.4);
+    border-left-width: 2px;
+    border-radius: 3px;
+  }
+  figure.example pre { margin-left: 0; margin-right: 0; }
+
+  .copy-btn { font-size: 0.62rem; padding: 2px 6px; }
+}
+
+@media (max-width: 480px) {
+  h1 { font-size: clamp(1.8rem, 8.5vw, 2.3rem); letter-spacing: -0.02em; }
+  .titleblock .meta { font-size: 0.72rem; }
+}
+
+/* Hero — phone layout. The atom cloud is a brand signature, not a
+   foreground element; on small screens we shrink the hero copy and
+   pull the cloud's centre of mass off the reading column. */
+@media (max-width: 720px) {
+  .hero {
+    padding: 2.6rem var(--gutter) 2.8rem;
+    gap: 2rem;
+  }
+  .hero-text h1 { font-size: clamp(2.4rem, 11vw, 3rem); margin-bottom: 1rem; }
+  .hero-text .byline { font-size: 1.02rem; margin-bottom: 1.6rem; }
+  .hero-text .meta { gap: 0.6rem 1.4rem; padding-top: 0.9rem; margin-bottom: 1.6rem; }
+  .hero-cta { gap: 0.9rem 1.6rem; }
+  .hero-code { padding: 0.8rem 0.85rem; }
+  .hero-code pre { font-size: 0.78rem; }
+  .hero-code figcaption { flex-wrap: wrap; gap: 0.3rem 0.8rem; }
+  /* The cloud reads well above 720px; on phones, fade it harder so it
+     doesn't compete with the reading column. */
+  .atom-cloud { opacity: 0.55; }
+  .shell.home { padding-top: 2.4rem; padding-bottom: 3rem; }
+  .shell.home .triptych { gap: 1.6rem; margin: 2.4rem 0 2.8rem; }
+}
+
+/* QS hero + API title — keep them in scale. */
+@media (max-width: 720px) {
+  .qs-hero { padding: 2rem var(--gutter) 1.8rem; }
+  .qs-hero h1 { font-size: clamp(1.8rem, 7vw, 2.4rem); }
+  .qs-hero .audience { font-size: 0.98rem; }
+  .qs-crosslink { padding: 1rem 1.1rem; }
+  .api-shell { padding: 2rem var(--gutter) 4rem; }
+  .api-item { padding: 0.8rem 0.9rem 0.85rem; }
+  .api-item .path { margin-left: 0; width: 100%; }
+}
+
+/* Footer stacks vertically on phones with smaller gaps. */
+@media (max-width: 540px) {
+  .foot-inner { flex-direction: column; gap: 0.4rem; }
+  .foot { padding: 1.2rem var(--gutter) 1.6rem; font-size: 0.78rem; }
+}
+
+/* Tap-target hygiene: the theme toggle is a primary control and needs
+   to clear ~36px so iOS doesn't double-tap-zoom it. */
+@media (max-width: 720px) {
+  .theme-toggle { padding: 3px; }
+  .theme-toggle button { width: 34px; height: 30px; }
+  .theme-toggle button svg { width: 16px; height: 16px; }
+}
+
 /* Print */
 @media print {
   .masthead, .foot, .api-toc { display: none; }


### PR DESCRIPTION
## Summary

- Adds a hamburger drawer to the masthead so the 5-item nav + theme toggle stops overflowing on phones; hides `.brand-sub` and tightens masthead padding below 720 px.
- Converts `.page-toc`, `.page-sections`, and `.api-toc` from `<aside>` to `<details class="side-nav">` so they collapse on mobile. An inline script forces them open at ≥ 901 px, preserving the desktop look; on mobile the summary becomes a tappable disclosure with a chevron, and the redundant right-hand "On this page" TOC is hidden ≤ 900 px since the left "Sections" rail already lists everything.
- Tightens global type & spacing at ≤ 720 px (body 16 px, clamped h1, reduced `.shell` / hero / `pre` / titleblock padding, atom-cloud faded to 55 %). Footer stacks at ≤ 540 px; theme-toggle buttons grow to a 34 × 30 px tap target.
- Adds a **section pager** (prev/next links) that the layout auto-generates from the existing `sections` + `currentSection` props — currently used by the Python Quick Start. Placeholder column keeps the grid balanced on the first/last sections.
- Adds a **back-to-top** floating pill that fades in past `max(viewportHeight × 1.2, 600 px)` and smooth-scrolls to the top, returning focus to the brand for keyboard users.
- Per request, both the section pager and back-to-top are shown only at ≤ 900 px, where the sidebars collapse and inline navigation aids actually matter.

## Test plan
- [x] Open `/` on a phone-width viewport (≤ 720 px): brand-sub hidden, hamburger toggles a stacked drawer, theme toggle reachable inside the drawer.
- [x] `/quickstart/python`, `/quickstart/python/tableau`, `/quickstart/python/next-steps`: section pager renders with the correct prev/next labels (and an empty cell for the first / last section).
- [x] On desktop ≥ 901 px: TOCs render identically to before (sticky, no disclosure widget), section-pager and back-to-top are hidden.
- [x] `/develop`: scroll past ~1.2× the viewport on a phone-width window — back-to-top fades in; tapping it smooth-scrolls to the top.
- [x] `/api`: API TOC opens on desktop, collapses on mobile; filter + lang toggle still work inside the disclosure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)