### PR TITLE
docs(home): tabbed hero example for Pauli propagation and tableau

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -22,4 +22,4 @@ jobs:
       - uses: astral-sh/setup-uv@v5
 
       - name: Run Python tests
-        run: uv run --project ppvm-python --group dev pytest ppvm-python/test/
+        run: uv run --project ppvm-python --group dev pytest ppvm-python/test/ docs/examples/

--- a/docs/examples/stim_program.py
+++ b/docs/examples/stim_program.py
@@ -18,11 +18,11 @@ prog = StimProgram.parse(
 # Run once against a fresh tableau.
 tab = GeneralizedTableau(n_qubits=2)
 tab.run(prog)
-print("single-run ok")
+print("single-run ok")  # → single-run ok
 
 # Multi-shot sampling. The two measurement outcomes are correlated on every shot.
 shots = sample_stim(prog, n_qubits=2, num_shots=16, seed=0)
-print(f"sampled {len(shots)} shots")
-print("first shot:", shots[0])
+print(f"sampled {len(shots)} shots")  # → sampled 16 shots
+print("first shot:", shots[0])  # → first shot: [<MeasurementResult.ONE: 1>, <MeasurementResult.ONE: 1>]
 all_correlated = all(s[0] == s[1] for s in shots)
-print("all shots correlated:", all_correlated)
+print("all shots correlated:", all_correlated)  # → all shots correlated: True

--- a/docs/examples/stim_sampling.py
+++ b/docs/examples/stim_sampling.py
@@ -26,7 +26,9 @@ shots = sample_stim(prog, n_qubits=2, num_shots=200, seed=42)
 patterns = Counter(tuple(int(r) for r in shot) for shot in shots)
 for pattern, count in sorted(patterns.items()):
     print(f"{pattern}: {count}")
+# → (0, 0): 102
+# → (1, 1): 98
 
 # A GHZ state should only produce (0, 0) or (1, 1) — never (0, 1) or (1, 0).
 correlated_fraction = sum(c for p, c in patterns.items() if p[0] == p[1]) / len(shots)
-print(f"correlated fraction: {correlated_fraction}")
+print(f"correlated fraction: {correlated_fraction}")  # → correlated fraction: 1.0

--- a/docs/examples/tableau_ghz.py
+++ b/docs/examples/tableau_ghz.py
@@ -14,5 +14,5 @@ tab.cnot(0, 1)
 r0 = tab.measure(0)
 r1 = tab.measure(1)
 
-print(f"qubit 0: {r0}, qubit 1: {r1}")
-print("correlated:", r0 == r1)
+print(f"qubit 0: {r0}, qubit 1: {r1}")  # → qubit 0: 1, qubit 1: 1
+print("correlated:", r0 == r1)  # → correlated: True

--- a/docs/examples/test_examples.py
+++ b/docs/examples/test_examples.py
@@ -17,11 +17,10 @@ Format:
     # → first
     # → second
 
-Every example must end up registered: ``test_all_examples_are_covered``
-fails if a ``.py`` file in the examples directories is missing from the
-discovered set, and a per-file precondition check fails if a file has
-zero ``# → `` markers (we don't want examples that silently pass without
-verifying any output).
+Example files are auto-discovered from the examples directories via
+``_discover()``; there is no separate registration step. A per-file
+precondition check still fails if a file has zero ``# → `` markers (we
+don't want examples that silently pass without verifying any output).
 
 Run from the repository root:
 

--- a/docs/examples/test_examples.py
+++ b/docs/examples/test_examples.py
@@ -1,10 +1,27 @@
 """
 Documentation doctests.
 
-Each example shipped in ``docs/examples/*.py`` is executed end-to-end as a
-subprocess. The expected stdout, recorded below, must match exactly. If you
-edit an example file (or the API it exercises) you must also update the
-expected output here — that is the point: docs and code cannot drift.
+Each example shipped in ``docs/examples/*.py`` (and the runnable Python
+snippets shipped with the ``ppvm-usage`` skill) is executed end-to-end as
+a subprocess. Expected output lives **inside the example file**, as
+``# → <line>`` comments next to the ``print`` statements (or in a small
+trailing block when one ``print`` is called from a loop). The test
+extracts those markers in source order, joins them, and compares against
+the captured stdout.
+
+Format:
+
+    print(f"qubit 0: {r0}")  # → qubit 0: 1
+    for x in xs:
+        print(x)
+    # → first
+    # → second
+
+Every example must end up registered: ``test_all_examples_are_covered``
+fails if a ``.py`` file in the examples directories is missing from the
+discovered set, and a per-file precondition check fails if a file has
+zero ``# → `` markers (we don't want examples that silently pass without
+verifying any output).
 
 Run from the repository root:
 
@@ -13,70 +30,29 @@ Run from the repository root:
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
 EXAMPLES_DIR = Path(__file__).resolve().parent
+SKILL_DIR = (REPO_ROOT / "skills/ppvm-usage/examples/python").resolve()
 
-# (filename, expected_stdout) pairs. Expected output is matched exactly
-# after stripping trailing whitespace from each line.
-EXAMPLES: list[tuple[str, str]] = [
-    (
-        "paulisum_ghz.py",
-        """\
-1.000 * IZ
-1.0
-""",
-    ),
-    (
-        "tableau_ghz.py",
-        """\
-qubit 0: 1, qubit 1: 1
-correlated: True
-""",
-    ),
-    (
-        "stim_program.py",
-        """\
-single-run ok
-sampled 16 shots
-first shot: [<MeasurementResult.ONE: 1>, <MeasurementResult.ONE: 1>]
-all shots correlated: True
-""",
-    ),
-    (
-        "stim_sampling.py",
-        """\
-(0, 0): 102
-(1, 1): 98
-correlated fraction: 1.0
-""",
-    ),
-]
+# Match any line containing "# → <text>" — the marker is the arrow
+# (U+2192), preceded by "# " and an optional single space afterwards.
+_MARKER = re.compile(r"#\s*→\s?(.*?)\s*$")
 
-# Runnable copies of the Python code blocks in
-# ``skills/ppvm-usage/SKILL.md`` live alongside the skill (so ``ion add``
-# fetches them with the rest of the skill). They are exercised here so
-# CI catches drift between the snippets the skill ships to agents and
-# the actual public ppvm-python API.
-SKILL_DIR = (Path(__file__).resolve().parents[2] / "skills/ppvm-usage/examples/python").resolve()
-SKILL_EXAMPLES: list[tuple[str, str]] = [
-    (
-        "verify.py",
-        """\
-ok
-""",
-    ),
-    (
-        "noise_truncation.py",
-        """\
-layers=5 terms=7 max_weight=4 finite_overlap=True
-""",
-    ),
-]
+
+def _expected_from_source(path: Path) -> str:
+    lines: list[str] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        m = _MARKER.search(raw)
+        if m is not None:
+            lines.append(m.group(1))
+    return ("\n".join(lines) + "\n") if lines else ""
 
 
 def _run(path: Path) -> str:
@@ -99,56 +75,52 @@ def _normalize(text: str) -> str:
     return "\n".join(line.rstrip() for line in text.splitlines()).strip() + "\n"
 
 
-@pytest.mark.parametrize(("filename", "expected"), EXAMPLES, ids=[e[0] for e in EXAMPLES])
-def test_example_runs_and_matches_expected_output(filename: str, expected: str) -> None:
-    path = EXAMPLES_DIR / filename
-    assert path.exists(), f"missing example file: {path}"
+def _discover(directory: Path) -> list[Path]:
+    skip = {"__init__.py", "test_examples.py"}
+    return sorted(
+        p
+        for p in directory.glob("*.py")
+        if p.name not in skip and "__pycache__" not in p.parts
+    )
 
+
+DOCS_EXAMPLES = _discover(EXAMPLES_DIR)
+SKILL_EXAMPLES = _discover(SKILL_DIR)
+
+
+@pytest.mark.parametrize("path", DOCS_EXAMPLES, ids=[p.name for p in DOCS_EXAMPLES])
+def test_docs_example(path: Path) -> None:
+    expected = _expected_from_source(path)
+    assert expected, (
+        f"{path.relative_to(REPO_ROOT)} has no `# → ` expected-output markers; "
+        "add at least one next to a print() so CI verifies behavior."
+    )
     stdout = _run(path)
-
     assert _normalize(stdout) == _normalize(expected), (
-        f"\nexample {filename} produced unexpected output.\n"
-        f"--- expected ---\n{expected}"
+        f"\nexample {path.name} produced unexpected output.\n"
+        f"--- expected (from `# → ` markers) ---\n{expected}"
         f"--- got ---\n{stdout}"
     )
 
 
 @pytest.mark.parametrize(
-    ("filename", "expected"),
-    SKILL_EXAMPLES,
-    ids=[f"skill/{e[0]}" for e in SKILL_EXAMPLES],
+    "path", SKILL_EXAMPLES, ids=[f"skill/{p.name}" for p in SKILL_EXAMPLES]
 )
-def test_skill_example_runs_and_matches_expected_output(filename: str, expected: str) -> None:
-    path = SKILL_DIR / filename
-    assert path.exists(), f"missing skill example file: {path}"
-
+def test_skill_example(path: Path) -> None:
+    expected = _expected_from_source(path)
+    assert expected, (
+        f"{path.relative_to(REPO_ROOT)} has no `# → ` expected-output markers; "
+        "add at least one next to a print() so CI verifies behavior."
+    )
     stdout = _run(path)
-
     assert _normalize(stdout) == _normalize(expected), (
-        f"\nskill example {filename} produced unexpected output.\n"
-        f"--- expected ---\n{expected}"
+        f"\nskill example {path.name} produced unexpected output.\n"
+        f"--- expected (from `# → ` markers) ---\n{expected}"
         f"--- got ---\n{stdout}"
     )
 
 
-def test_all_examples_are_covered() -> None:
-    """Guard against forgetting to register a new example in either list."""
-    skip = {"__init__.py", "test_examples.py"}
-
-    on_disk = {
-        p.name
-        for p in EXAMPLES_DIR.glob("*.py")
-        if p.name not in skip and "__pycache__" not in p.parts
-    }
-    registered = {name for name, _ in EXAMPLES}
-    missing = on_disk - registered
-    assert not missing, (
-        f"docs/examples file(s) present on disk but not registered in EXAMPLES: {sorted(missing)}"
-    )
-
-    skill_on_disk = {p.name for p in SKILL_DIR.glob("*.py")}
-    skill_registered = {name for name, _ in SKILL_EXAMPLES}
-    skill_missing = skill_on_disk - skill_registered
-    assert not skill_missing, (
-        f"skill example file(s) present on disk but not registered in SKILL_EXAMPLES: {sorted(skill_missing)}"
-    )
+def test_examples_directories_are_nonempty() -> None:
+    """Guard against an accidentally empty examples directory hiding the matrix."""
+    assert DOCS_EXAMPLES, f"no example files discovered under {EXAMPLES_DIR}"
+    assert SKILL_EXAMPLES, f"no skill example files discovered under {SKILL_DIR}"

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -81,26 +81,30 @@ const tableauCode = stripDocstring(tableauGhz);
       <figure class="hero-code" data-example-active="paulisum">
         <figcaption>
           <div class="hero-code-tabs" role="tablist" aria-label="Backend example">
-            <button type="button" role="tab" data-example-set="paulisum" aria-selected="true" class="hero-code-tab">Pauli propagation</button>
-            <button type="button" role="tab" data-example-set="tableau" aria-selected="false" class="hero-code-tab">Generalized tableau</button>
+            <button type="button" role="tab" id="hero-tab-paulisum" aria-controls="hero-panel-paulisum" aria-selected="true" tabindex="0" data-example-set="paulisum" class="hero-code-tab">Pauli propagation</button>
+            <button type="button" role="tab" id="hero-tab-tableau" aria-controls="hero-panel-tableau" aria-selected="false" tabindex="-1" data-example-set="tableau" class="hero-code-tab">Generalized tableau</button>
           </div>
           <span class="hero-code-file">
             <code data-example-pane="paulisum">paulisum_ghz.py</code><code data-example-pane="tableau" hidden>tableau_ghz.py</code>
             · tested
           </span>
         </figcaption>
-        <pre data-example-pane="paulisum"><code class="language-python">{paulisumCode}</code></pre>
-        <pre data-example-pane="tableau" hidden><code class="language-python">{tableauCode}</code></pre>
-        <p class="hero-code-note" data-example-pane="paulisum">
-          Pauli propagation moves observables <em>backwards</em> through the
-          circuit, so gates are applied in reverse of the textbook order.
-          Same idea in Python and Rust.
-        </p>
-        <p class="hero-code-note" data-example-pane="tableau" hidden>
-          The generalized tableau evolves the state <em>forwards</em> and
-          samples measurement outcomes. GHZ correlations fall out of two
-          single-qubit measurements.
-        </p>
+        <div role="tabpanel" id="hero-panel-paulisum" aria-labelledby="hero-tab-paulisum" data-example-pane="paulisum">
+          <pre><code class="language-python">{paulisumCode}</code></pre>
+          <p class="hero-code-note">
+            Pauli propagation moves observables <em>backwards</em> through the
+            circuit, so gates are applied in reverse of the textbook order.
+            Same idea in Python and Rust.
+          </p>
+        </div>
+        <div role="tabpanel" id="hero-panel-tableau" aria-labelledby="hero-tab-tableau" data-example-pane="tableau" hidden>
+          <pre><code class="language-python">{tableauCode}</code></pre>
+          <p class="hero-code-note">
+            The generalized tableau evolves the state <em>forwards</em> and
+            samples measurement outcomes. GHZ correlations fall out of two
+            single-qubit measurements.
+          </p>
+        </div>
       </figure>
     </section>
   </div>
@@ -223,18 +227,50 @@ what it covers, then wait for my actual task.</code></pre>
     (() => {
       const figure = document.querySelector(".hero-code");
       if (!figure) return;
-      const tabs = figure.querySelectorAll("[data-example-set]");
+      const tabs = Array.from(figure.querySelectorAll('[role="tab"][data-example-set]'));
       const panes = figure.querySelectorAll("[data-example-pane]");
-      tabs.forEach((tab) => {
-        tab.addEventListener("click", () => {
-          const target = tab.getAttribute("data-example-set");
-          figure.setAttribute("data-example-active", target);
-          tabs.forEach((t) => t.setAttribute("aria-selected", t === tab ? "true" : "false"));
-          panes.forEach((p) => {
-            const match = p.getAttribute("data-example-pane") === target;
-            if (match) p.removeAttribute("hidden");
-            else p.setAttribute("hidden", "");
-          });
+      if (tabs.length === 0) return;
+
+      const activate = (tab, { focus } = { focus: false }) => {
+        const target = tab.getAttribute("data-example-set");
+        figure.setAttribute("data-example-active", target);
+        tabs.forEach((t) => {
+          const selected = t === tab;
+          t.setAttribute("aria-selected", selected ? "true" : "false");
+          t.setAttribute("tabindex", selected ? "0" : "-1");
+        });
+        panes.forEach((p) => {
+          const match = p.getAttribute("data-example-pane") === target;
+          if (match) p.removeAttribute("hidden");
+          else p.setAttribute("hidden", "");
+        });
+        if (focus) tab.focus();
+      };
+
+      tabs.forEach((tab, i) => {
+        tab.addEventListener("click", () => activate(tab));
+        tab.addEventListener("keydown", (e) => {
+          let next = null;
+          switch (e.key) {
+            case "ArrowRight":
+            case "ArrowDown":
+              next = tabs[(i + 1) % tabs.length];
+              break;
+            case "ArrowLeft":
+            case "ArrowUp":
+              next = tabs[(i - 1 + tabs.length) % tabs.length];
+              break;
+            case "Home":
+              next = tabs[0];
+              break;
+            case "End":
+              next = tabs[tabs.length - 1];
+              break;
+          }
+          if (next) {
+            e.preventDefault();
+            activate(next, { focus: true });
+          }
         });
       });
     })();

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Base from "../layouts/Base.astro";
 import paulisumGhz from "../../examples/paulisum_ghz.py?raw";
+import tableauGhz from "../../examples/tableau_ghz.py?raw";
 const base = import.meta.env.BASE_URL.replace(/\/$/, "");
 
 function stripDocstring(src: string): string {
@@ -9,7 +10,8 @@ function stripDocstring(src: string): string {
   if (m) s = s.slice(m[0].length);
   return s.trimEnd() + "\n";
 }
-const heroCode = stripDocstring(paulisumGhz);
+const paulisumCode = stripDocstring(paulisumGhz);
+const tableauCode = stripDocstring(tableauGhz);
 ---
 <Base title="Overview" current="home">
   <div class="hero-wrap">
@@ -76,16 +78,28 @@ const heroCode = stripDocstring(paulisumGhz);
         </div>
       </div>
 
-      <figure class="hero-code">
+      <figure class="hero-code" data-example-active="paulisum">
         <figcaption>
-          <span class="hero-code-title">Heisenberg-picture GHZ in 6 lines</span>
-          <span class="hero-code-file"><code>paulisum_ghz.py</code> · tested</span>
+          <div class="hero-code-tabs" role="tablist" aria-label="Backend example">
+            <button type="button" role="tab" data-example-set="paulisum" aria-selected="true" class="hero-code-tab">Pauli propagation</button>
+            <button type="button" role="tab" data-example-set="tableau" aria-selected="false" class="hero-code-tab">Generalized tableau</button>
+          </div>
+          <span class="hero-code-file">
+            <code data-example-pane="paulisum">paulisum_ghz.py</code><code data-example-pane="tableau" hidden>tableau_ghz.py</code>
+            · tested
+          </span>
         </figcaption>
-        <pre><code class="language-python">{heroCode}</code></pre>
-        <p class="hero-code-note">
+        <pre data-example-pane="paulisum"><code class="language-python">{paulisumCode}</code></pre>
+        <pre data-example-pane="tableau" hidden><code class="language-python">{tableauCode}</code></pre>
+        <p class="hero-code-note" data-example-pane="paulisum">
           Pauli propagation moves observables <em>backwards</em> through the
           circuit, so gates are applied in reverse of the textbook order.
           Same idea in Python and Rust.
+        </p>
+        <p class="hero-code-note" data-example-pane="tableau" hidden>
+          The generalized tableau evolves the state <em>forwards</em> and
+          samples measurement outcomes. GHZ correlations fall out of two
+          single-qubit measurements.
         </p>
       </figure>
     </section>
@@ -204,6 +218,27 @@ what it covers, then wait for my actual task.</code></pre>
       or browse the <a href={`${base}/api`}>API Reference</a>.
     </p>
   </article>
+
+  <script is:inline>
+    (() => {
+      const figure = document.querySelector(".hero-code");
+      if (!figure) return;
+      const tabs = figure.querySelectorAll("[data-example-set]");
+      const panes = figure.querySelectorAll("[data-example-pane]");
+      tabs.forEach((tab) => {
+        tab.addEventListener("click", () => {
+          const target = tab.getAttribute("data-example-set");
+          figure.setAttribute("data-example-active", target);
+          tabs.forEach((t) => t.setAttribute("aria-selected", t === tab ? "true" : "false"));
+          panes.forEach((p) => {
+            const match = p.getAttribute("data-example-pane") === target;
+            if (match) p.removeAttribute("hidden");
+            else p.setAttribute("hidden", "");
+          });
+        });
+      });
+    })();
+  </script>
 
   <script is:inline>
     (() => {

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -1137,9 +1137,11 @@ li { margin: 0.25em 0; }
   color: var(--ink-faint);
 }
 .hero-code-tabs {
-  display: inline-flex;
-  gap: 1.2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 1.2rem;
   align-items: baseline;
+  min-width: 0;
 }
 .hero-code-tab {
   background: transparent;
@@ -1157,9 +1159,18 @@ li { margin: 0.25em 0; }
   transition: color 120ms ease, border-color 120ms ease;
 }
 .hero-code-tab:hover { color: var(--ink-soft); }
+.hero-code-tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 1px;
+}
 .hero-code-tab[aria-selected="true"] {
   color: var(--ink);
   border-bottom-color: var(--accent);
+}
+@media (max-width: 480px) {
+  .hero-code-tabs { gap: 0.3rem 0.9rem; }
+  .hero-code-tab { font-size: 0.68rem; letter-spacing: 0.06em; }
 }
 .hero-code-file { font-family: var(--mono); font-size: 0.7rem; color: var(--ink-mute); }
 .hero-code-file code { background: none; border: 0; padding: 0; font-size: inherit; color: inherit; }

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -1136,6 +1136,31 @@ li { margin: 0.25em 0; }
   text-transform: uppercase;
   color: var(--ink-faint);
 }
+.hero-code-tabs {
+  display: inline-flex;
+  gap: 1.2rem;
+  align-items: baseline;
+}
+.hero-code-tab {
+  background: transparent;
+  border: 0;
+  padding: 0 0 0.15rem;
+  margin: 0;
+  font-family: var(--mono);
+  font-weight: 400;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  cursor: pointer;
+  border-bottom: 1px solid transparent;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+.hero-code-tab:hover { color: var(--ink-soft); }
+.hero-code-tab[aria-selected="true"] {
+  color: var(--ink);
+  border-bottom-color: var(--accent);
+}
 .hero-code-file { font-family: var(--mono); font-size: 0.7rem; color: var(--ink-mute); }
 .hero-code-file code { background: none; border: 0; padding: 0; font-size: inherit; color: inherit; }
 .hero-code pre {

--- a/skills/ppvm-usage/examples/python/noise_truncation.py
+++ b/skills/ppvm-usage/examples/python/noise_truncation.py
@@ -40,3 +40,4 @@ overlap = ps.overlap_with_zero()
 assert top_weight <= MAX_WEIGHT, top_weight
 assert math.isfinite(overlap), overlap
 print(f"layers={LAYERS} terms={len(ps)} max_weight={top_weight} finite_overlap=True")
+# → layers=5 terms=7 max_weight=4 finite_overlap=True

--- a/skills/ppvm-usage/examples/python/verify.py
+++ b/skills/ppvm-usage/examples/python/verify.py
@@ -13,4 +13,4 @@ ps = PauliSum.new(2, "ZZ")
 ps.cnot(0, 1)
 ps.h(0)
 assert ps.overlap_with_zero() == 1.0, ps.overlap_with_zero()
-print("ok")
+print("ok")  # → ok


### PR DESCRIPTION
## Summary
- Replace the static hero-code title on the landing page with a 2-tab tablist so the generalized tableau gets equal billing alongside Pauli propagation.
- The figcaption tabs, filename, code block, and italic note all swap between `paulisum_ghz.py` and `tableau_ghz.py`.
- Matches the visual language already in use: uppercase mono labels with the brand-accent underline on the active tab, mirroring the install-tabs pattern.

## Test plan
- [x] `cd docs && npm run build` succeeds
- [x] Visit `/` locally and verify both tabs swap code, filename, and note
- [x] Check active-tab styling in light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)