### PR TITLE
chore: add Apache 2.0 license, CLA, and SPDX header tooling

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,30 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: '.github/cla-signatures.json'
+          path-to-document: 'https://github.com/QuEraComputing/ppvm/blob/main/CLA.md'
+          branch: 'main'
+          allowlist: dependabot[bot],renovate[bot],pre-commit-ci[bot]
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-allsigned-prcomment: 'All contributors have signed the CLA ✔'

--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -1,0 +1,16 @@
+name: License headers
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    name: hawkeye check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check SPDX headers
+        uses: korandoru/hawkeye@v6

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,128 @@
+# ppvm Individual Contributor License Agreement
+
+Thank you for your interest in contributing to **ppvm** (the "Project"),
+maintained by QuEra Computing Inc. ("We" or "Us"). This Contributor License
+Agreement ("Agreement") documents the rights granted by contributors to Us.
+It is adapted from the Apache Software Foundation Individual Contributor
+License Agreement v2.2 and complements the Project's Apache License,
+Version 2.0 (see `LICENSE`).
+
+To make this Agreement effective, please indicate your acceptance by signing
+your commits as described in the "How to accept this Agreement" section
+below, or by signing electronically when prompted on a pull request.
+
+You accept and agree to the following terms and conditions for Your present
+and future Contributions submitted to Us. Except for the license granted
+herein to Us and recipients of software distributed by Us, You reserve all
+right, title, and interest in and to Your Contributions.
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) shall mean the copyright owner or legal entity
+authorized by the copyright owner that is making this Agreement with Us. For
+legal entities, the entity making a Contribution and all other entities that
+control, are controlled by, or are under common control with that entity are
+considered to be a single Contributor. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the direction or
+management of such entity, whether by contract or otherwise, or (ii)
+ownership of fifty percent (50%) or more of the outstanding shares, or (iii)
+beneficial ownership of such entity.
+
+**"Contribution"** shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally
+submitted by You to Us for inclusion in, or documentation of, the Project.
+For the purposes of this definition, "submitted" means any form of
+electronic, verbal, or written communication sent to Us or our
+representatives, including but not limited to communication on electronic
+mailing lists, source code control systems, and issue tracking systems that
+are managed by, or on behalf of, Us for the purpose of discussing and
+improving the Project, but excluding communication that is conspicuously
+marked or otherwise designated in writing by You as "Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+Us and to recipients of software distributed by Us a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare derivative works of, publicly display, publicly perform,
+sublicense, and distribute Your Contributions and such derivative works.
+
+You agree that Your Contributions may be licensed to third parties under
+the Apache License, Version 2.0 under which the Project is distributed, and
+You agree that We may also license Your Contributions under any other
+OSI-approved open source license that the Project may adopt in the future,
+provided that such relicensing does not retroactively impair the rights You
+retain in Your Contributions outside the Project.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+Us and to recipients of software distributed by Us a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable (except as stated in
+this section) patent license to make, have made, use, offer to sell, sell,
+import, and otherwise transfer the Project, where such license applies only
+to those patent claims licensable by You that are necessarily infringed by
+Your Contribution(s) alone or by combination of Your Contribution(s) with
+the Project to which such Contribution(s) was submitted. If any entity
+institutes patent litigation against You or any other entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that Your Contribution,
+or the Project to which You have contributed, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or the Project shall
+terminate as of the date such litigation is filed.
+
+## 4. Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses. If your employer(s)
+   has rights to intellectual property that You create that includes Your
+   Contributions, You represent that You have received permission to make
+   Contributions on behalf of that employer, that Your employer has waived
+   such rights for Your Contributions to Us, or that Your employer has
+   executed a separate Corporate CLA with Us.
+
+2. Each of Your Contributions is Your original creation (see Section 7 for
+   submissions on behalf of others).
+
+3. Your Contribution submissions include complete details of any third-party
+   license or other restriction (including, but not limited to, related
+   patents and trademarks) of which You are personally aware and which are
+   associated with any part of Your Contributions.
+
+## 5. Support
+
+You are not expected to provide support for Your Contributions, except to
+the extent You desire to provide support. You may provide support for free,
+for a fee, or not at all. Unless required by applicable law or agreed to in
+writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including,
+without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 6. Notification of Changes
+
+You agree to notify Us of any facts or circumstances of which You become
+aware that would make these representations inaccurate in any respect.
+
+## 7. Submissions on behalf of others
+
+Should You wish to submit work that is not Your original creation, You may
+submit it to Us separately from any Contribution, identifying the complete
+details of its source and of any license or other restriction (including,
+but not limited to, related patents, trademarks, and license agreements) of
+which You are personally aware, and conspicuously marking the work as
+"Submitted on behalf of a third-party: [named here]".
+
+## How to accept this Agreement
+
+By submitting a pull request to this repository, You indicate Your
+acceptance of this Agreement for all Contributions in that pull request and
+for all future Contributions You submit to the Project. For non-trivial
+contributions, We may additionally request that You sign this Agreement
+electronically via [CLA Assistant](https://cla-assistant.io/) or an
+equivalent tool linked from the pull request.
+
+Contributors who are submitting on behalf of an employer should arrange for
+a Corporate CLA to be executed separately; contact the maintainers if one
+is required for your contribution.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 QuEra Computing Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+ppvm - Pauli Propagation and Virtual Machine
+Copyright 2026 QuEra Computing Inc.
+
+This product includes software developed at
+QuEra Computing Inc. (https://www.quera.com/).

--- a/README.md
+++ b/README.md
@@ -86,3 +86,14 @@ fn main() {
     println!("{}", state.trace(&zero_state));  // 1
 }
 ```
+
+# License
+
+ppvm is licensed under the [Apache License, Version 2.0](LICENSE).
+See [NOTICE](NOTICE) for attribution requirements.
+
+# Contributing
+
+Contributions are welcome. By submitting a pull request to this repository,
+you agree to license your contribution under the Apache License, Version 2.0
+and to the terms of the [Contributor License Agreement](CLA.md).

--- a/crates/ppvm-python-native/src/interface.rs
+++ b/crates/ppvm-python-native/src/interface.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use paste::paste;
 use ppvm_runtime::prelude::*;
 use ppvm_runtime::strategy::{

--- a/crates/ppvm-python-native/src/interface_tableau.rs
+++ b/crates/ppvm-python-native/src/interface_tableau.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use bnum::types::{U256, U512, U1024, U2048};
 use paste::paste;
 use ppvm_tableau::prelude::*;

--- a/crates/ppvm-python-native/src/lib.rs
+++ b/crates/ppvm-python-native/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use pyo3::prelude::*;
 
 pub mod interface;

--- a/crates/ppvm-python-native/src/stim_program.rs
+++ b/crates/ppvm-python-native/src/stim_program.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use pyo3::exceptions::{PyIOError, PyValueError};
 use pyo3::prelude::*;
 use std::ops::Deref;

--- a/crates/ppvm-runtime/benches/gate.rs
+++ b/crates/ppvm-runtime/benches/gate.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use criterion::{Criterion, criterion_group, criterion_main};
 use ppvm_runtime::{prelude::*, strategy::CoefficientThreshold};
 use rayon::current_num_threads;

--- a/crates/ppvm-runtime/benches/micro.rs
+++ b/crates/ppvm-runtime/benches/micro.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::time::Duration;
 
 use criterion::{Criterion, criterion_group, criterion_main};

--- a/crates/ppvm-runtime/benches/random-circuit.rs
+++ b/crates/ppvm-runtime/benches/random-circuit.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use criterion::{Criterion, criterion_group, criterion_main};
 use ppvm_runtime::prelude::*;
 use rayon::current_num_threads;

--- a/crates/ppvm-runtime/benches/trotter-scaling.rs
+++ b/crates/ppvm-runtime/benches/trotter-scaling.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use criterion::{Criterion, criterion_group, criterion_main};
 use ppvm_runtime::prelude::*;
 use ppvm_runtime::strategy::CoefficientThreshold;

--- a/crates/ppvm-runtime/benches/trotter.rs
+++ b/crates/ppvm-runtime/benches/trotter.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use criterion::{Criterion, criterion_group, criterion_main};
 use ppvm_runtime::prelude::*;
 use ppvm_runtime::strategy::CoefficientThreshold;

--- a/crates/ppvm-runtime/src/char.rs
+++ b/crates/ppvm-runtime/src/char.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// A single-qubit Pauli symbol.
 ///
 /// The four standard Paulis are encoded so that the low two bits identify

--- a/crates/ppvm-runtime/src/config/dashmap.rs
+++ b/crates/ppvm-runtime/src/config/dashmap.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::marker::PhantomData;
 
 use crate::traits::{Coefficient, NoStrategy, PauliWordTrait, Strategy};

--- a/crates/ppvm-runtime/src/config/fx64hash.rs
+++ b/crates/ppvm-runtime/src/config/fx64hash.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::marker::PhantomData;
 

--- a/crates/ppvm-runtime/src/config/fxhash.rs
+++ b/crates/ppvm-runtime/src/config/fxhash.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::marker::PhantomData;
 

--- a/crates/ppvm-runtime/src/config/gxhash.rs
+++ b/crates/ppvm-runtime/src/config/gxhash.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::marker::PhantomData;
 

--- a/crates/ppvm-runtime/src/config/indexmap.rs
+++ b/crates/ppvm-runtime/src/config/indexmap.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::marker::PhantomData;
 
 use crate::traits::{Coefficient, NoStrategy, PauliWordTrait, Strategy};

--- a/crates/ppvm-runtime/src/config/mod.rs
+++ b/crates/ppvm-runtime/src/config/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::hash::BuildHasher;
 
 use crate::traits::{ACMap, Coefficient, PauliStorage, PauliWordTrait, Strategy};

--- a/crates/ppvm-runtime/src/lib.rs
+++ b/crates/ppvm-runtime/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Core runtime for the ppvm quantum-circuit simulator.
 //!
 //! `ppvm-runtime` defines the low-level types every ppvm backend uses:

--- a/crates/ppvm-runtime/src/loss/clifford.rs
+++ b/crates/ppvm-runtime/src/loss/clifford.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Clifford behavior for `LossyPauliWord` is provided by the blanket impl
 // `impl<T: PauliWordTrait> Clifford for T` in `crate::traits::clifford`.
 // `LossyPauliWord::get_lbit` reports actual loss bits, so the gates correctly

--- a/crates/ppvm-runtime/src/loss/data.rs
+++ b/crates/ppvm-runtime/src/loss/data.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::char::Pauli;
 use crate::traits::{PauliIter, PauliStorage, PauliWordTrait};
 use bitvec::prelude::BitArray;

--- a/crates/ppvm-runtime/src/loss/mod.rs
+++ b/crates/ppvm-runtime/src/loss/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 mod clifford;
 mod data;
 mod trace;

--- a/crates/ppvm-runtime/src/loss/trace.rs
+++ b/crates/ppvm-runtime/src/loss/trace.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::hash::BuildHasher;
 
 use super::data::LossyPauliWord;

--- a/crates/ppvm-runtime/src/map/dashmap.rs
+++ b/crates/ppvm-runtime/src/map/dashmap.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::hash::BuildHasher;
 
 use crate::{pattern::PauliPattern, traits::*};

--- a/crates/ppvm-runtime/src/map/hashmap.rs
+++ b/crates/ppvm-runtime/src/map/hashmap.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::{collections::HashMap, hash::BuildHasher};
 
 use crate::traits::*;

--- a/crates/ppvm-runtime/src/map/mod.rs
+++ b/crates/ppvm-runtime/src/map/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 mod hashmap;
 
 #[cfg(feature = "dashmap")]

--- a/crates/ppvm-runtime/src/pattern/contains.rs
+++ b/crates/ppvm-runtime/src/pattern/contains.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use super::data::{Decorated, NotIdentity, OpPattern, PauliPattern};
 use crate::char::Pauli;
 use crate::traits::PauliIter;

--- a/crates/ppvm-runtime/src/pattern/data.rs
+++ b/crates/ppvm-runtime/src/pattern/data.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // pattern intermediate representation
 
 #[cfg(feature = "bincode")]

--- a/crates/ppvm-runtime/src/pattern/display.rs
+++ b/crates/ppvm-runtime/src/pattern/display.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use super::data::{Decorated, NotIdentity, OpPattern, PauliPattern};
 
 impl std::fmt::Display for NotIdentity {

--- a/crates/ppvm-runtime/src/pattern/enumerate.rs
+++ b/crates/ppvm-runtime/src/pattern/enumerate.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use super::data::{Decorated, OpPattern, PauliPattern};
 use crate::char::Pauli;
 use crate::traits::{PauliStorage, PauliWordTrait};

--- a/crates/ppvm-runtime/src/pattern/from.rs
+++ b/crates/ppvm-runtime/src/pattern/from.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use super::data::{NotIdentity, PauliPattern};
 use crate::char::Pauli;
 

--- a/crates/ppvm-runtime/src/pattern/mod.rs
+++ b/crates/ppvm-runtime/src/pattern/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 mod contains;
 mod data;
 mod display;

--- a/crates/ppvm-runtime/src/pattern/parse.rs
+++ b/crates/ppvm-runtime/src/pattern/parse.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::Result;
 use std::collections::BTreeSet;
 

--- a/crates/ppvm-runtime/src/pattern/trace.rs
+++ b/crates/ppvm-runtime/src/pattern/trace.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use super::contains::Contains;
 use super::data::PauliPattern;
 

--- a/crates/ppvm-runtime/src/phase/clifford.rs
+++ b/crates/ppvm-runtime/src/phase/clifford.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::hash::BuildHasher;
 
 use super::data::PhasedPauliWord;

--- a/crates/ppvm-runtime/src/phase/data.rs
+++ b/crates/ppvm-runtime/src/phase/data.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::hash::BuildHasher;
 
 use num::Integer;

--- a/crates/ppvm-runtime/src/phase/mod.rs
+++ b/crates/ppvm-runtime/src/phase/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 mod clifford;
 mod data;
 mod mul;

--- a/crates/ppvm-runtime/src/phase/mul.rs
+++ b/crates/ppvm-runtime/src/phase/mul.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use bitvec::view::BitView;
 use num::PrimInt;
 

--- a/crates/ppvm-runtime/src/strategy.rs
+++ b/crates/ppvm-runtime/src/strategy.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::traits::*;
 
 /// Two strategies run in sequence: `S1` then `S2`.

--- a/crates/ppvm-runtime/src/sum/approx.rs
+++ b/crates/ppvm-runtime/src/sum/approx.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use super::data::PauliSum;
 use crate::{
     config::Config,

--- a/crates/ppvm-runtime/src/sum/clifford.rs
+++ b/crates/ppvm-runtime/src/sum/clifford.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     config::Config,
     phase::PhasedPauliWord,

--- a/crates/ppvm-runtime/src/sum/data.rs
+++ b/crates/ppvm-runtime/src/sum/data.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::config::Config;
 use crate::traits::*;
 

--- a/crates/ppvm-runtime/src/sum/display.rs
+++ b/crates/ppvm-runtime/src/sum/display.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use itertools::Itertools;
 
 use crate::traits::*;

--- a/crates/ppvm-runtime/src/sum/mod.rs
+++ b/crates/ppvm-runtime/src/sum/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 mod clifford;
 mod data;
 mod display;

--- a/crates/ppvm-runtime/src/sum/noise.rs
+++ b/crates/ppvm-runtime/src/sum/noise.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::char::Pauli;
 use crate::loss::LossyPauliWord;
 use crate::traits::*;

--- a/crates/ppvm-runtime/src/sum/ops.rs
+++ b/crates/ppvm-runtime/src/sum/ops.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::ops::{AddAssign, MulAssign};
 
 use num::One;

--- a/crates/ppvm-runtime/src/sum/proj.rs
+++ b/crates/ppvm-runtime/src/sum/proj.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::traits::*;
 use crate::{char::Pauli, config::Config, sum::PauliSum};
 

--- a/crates/ppvm-runtime/src/sum/rot1.rs
+++ b/crates/ppvm-runtime/src/sum/rot1.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::traits::*;
 use crate::{char::Pauli, config::Config, sum::PauliSum};
 

--- a/crates/ppvm-runtime/src/sum/rot2.rs
+++ b/crates/ppvm-runtime/src/sum/rot2.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use super::rot1::rotate_1_map_insert_closure;
 use crate::traits::*;
 use crate::{char::Pauli, config::Config, sum::PauliSum};

--- a/crates/ppvm-runtime/src/sum/trace.rs
+++ b/crates/ppvm-runtime/src/sum/trace.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     config::Config,
     sum::PauliSum,

--- a/crates/ppvm-runtime/src/traits/branch/crx.rs
+++ b/crates/ppvm-runtime/src/traits/branch/crx.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::config::Config;
 
 /// Controlled `RX` rotation.

--- a/crates/ppvm-runtime/src/traits/branch/mod.rs
+++ b/crates/ppvm-runtime/src/traits/branch/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 mod crx;
 mod proj;
 mod rot1;

--- a/crates/ppvm-runtime/src/traits/branch/proj.rs
+++ b/crates/ppvm-runtime/src/traits/branch/proj.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Projective Z-basis projectors `|0⟩⟨0|` and `|1⟩⟨1|`.
 pub trait Projection {
     /// Project qubit `pos` onto `|0⟩`.

--- a/crates/ppvm-runtime/src/traits/branch/rot1.rs
+++ b/crates/ppvm-runtime/src/traits/branch/rot1.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::char::Pauli;
 use crate::config::Config;
 

--- a/crates/ppvm-runtime/src/traits/branch/rot2.rs
+++ b/crates/ppvm-runtime/src/traits/branch/rot2.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::config::Config;
 
 macro_rules! def_rotation {

--- a/crates/ppvm-runtime/src/traits/branch/tgate.rs
+++ b/crates/ppvm-runtime/src/traits/branch/tgate.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::config::Config;
 
 /// The non-Clifford `T` gate and its adjoint.

--- a/crates/ppvm-runtime/src/traits/branch/u3.rs
+++ b/crates/ppvm-runtime/src/traits/branch/u3.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::config::Config;
 
 /// The general single-qubit `U3(θ, φ, λ)` gate.

--- a/crates/ppvm-runtime/src/traits/clifford.rs
+++ b/crates/ppvm-runtime/src/traits/clifford.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::traits::PauliWordTrait;
 
 /// The minimal Clifford gate set: the single-qubit Paulis (`X`, `Y`, `Z`),

--- a/crates/ppvm-runtime/src/traits/coefficient.rs
+++ b/crates/ppvm-runtime/src/traits/coefficient.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use num::traits::Float;
 
 /// Numeric coefficient type usable inside a

--- a/crates/ppvm-runtime/src/traits/map.rs
+++ b/crates/ppvm-runtime/src/traits/map.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::hash::BuildHasher;
 
 use crate::traits::{Coefficient, PauliStorage, PauliWordTrait};

--- a/crates/ppvm-runtime/src/traits/measure.rs
+++ b/crates/ppvm-runtime/src/traits/measure.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Projective Z-basis measurement returning a bare boolean outcome.
 pub trait Measure {
     /// Measure qubit `addr0` in the computational basis. Returns

--- a/crates/ppvm-runtime/src/traits/mod.rs
+++ b/crates/ppvm-runtime/src/traits/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 mod branch;
 mod clifford;
 mod coefficient;

--- a/crates/ppvm-runtime/src/traits/noise.rs
+++ b/crates/ppvm-runtime/src/traits/noise.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::config::Config;
 
 // FIXME: most channels don't need to own probs, we can just reference them and clean up the code

--- a/crates/ppvm-runtime/src/traits/ptm.rs
+++ b/crates/ppvm-runtime/src/traits/ptm.rs
@@ -1,1 +1,2 @@
-
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0

--- a/crates/ppvm-runtime/src/traits/reset.rs
+++ b/crates/ppvm-runtime/src/traits/reset.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Reset a qubit to the `|0⟩` computational-basis state.
 pub trait Reset {
     /// Reset qubit `addr0` to `|0⟩`.

--- a/crates/ppvm-runtime/src/traits/storage.rs
+++ b/crates/ppvm-runtime/src/traits/storage.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use bitvec::view::BitViewSized;
 use std::hash::Hash;
 

--- a/crates/ppvm-runtime/src/traits/strategy.rs
+++ b/crates/ppvm-runtime/src/traits/strategy.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use super::coefficient::Coefficient;
 use super::map::ACMap;
 use super::storage::PauliStorage;

--- a/crates/ppvm-runtime/src/traits/trace.rs
+++ b/crates/ppvm-runtime/src/traits/trace.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Trait for computing `trace(self * RHS)`.
 ///
 /// If a type implements `Trace`, a corresponding `TraceBy` implementation

--- a/crates/ppvm-runtime/src/traits/word_trait.rs
+++ b/crates/ppvm-runtime/src/traits/word_trait.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::char::Pauli;
 use crate::traits::PauliStorage;
 use std::fmt::Display;

--- a/crates/ppvm-runtime/src/word/clifford.rs
+++ b/crates/ppvm-runtime/src/word/clifford.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Clifford behavior for `PauliWord` is provided by the blanket impl
 // `impl<T: PauliWordTrait> Clifford for T` in `crate::traits::clifford`.
 

--- a/crates/ppvm-runtime/src/word/data.rs
+++ b/crates/ppvm-runtime/src/word/data.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::char::Pauli;
 use crate::traits::{PauliIter, PauliStorage, PauliWordTrait};
 use bitvec::array::BitArray;

--- a/crates/ppvm-runtime/src/word/mod.rs
+++ b/crates/ppvm-runtime/src/word/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 mod clifford;
 mod data;
 mod mul;

--- a/crates/ppvm-runtime/src/word/mul.rs
+++ b/crates/ppvm-runtime/src/word/mul.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::hash::BuildHasher;
 
 use crate::{traits::PauliStorage, traits::PauliWordTrait, word::PauliWord};

--- a/crates/ppvm-runtime/src/word/trace.rs
+++ b/crates/ppvm-runtime/src/word/trace.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::hash::BuildHasher;
 
 use super::data::PauliWord;

--- a/crates/ppvm-runtime/tests/cnot.rs
+++ b/crates/ppvm-runtime/tests/cnot.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use approx::assert_relative_eq;
 use ppvm_runtime::prelude::*;
 

--- a/crates/ppvm-runtime/tests/ghz.rs
+++ b/crates/ppvm-runtime/tests/ghz.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use ppvm_runtime::prelude::*;
 
 #[test]

--- a/crates/ppvm-runtime/tests/loss.rs
+++ b/crates/ppvm-runtime/tests/loss.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use ppvm_runtime::{prelude::*, strategy::MaxLossWeight};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 

--- a/crates/ppvm-runtime/tests/noise.rs
+++ b/crates/ppvm-runtime/tests/noise.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use ppvm_runtime::{prelude::*, strategy::CoefficientThreshold};
 use std::f64::consts::PI;
 

--- a/crates/ppvm-runtime/tests/strategy.rs
+++ b/crates/ppvm-runtime/tests/strategy.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use ppvm_runtime::{
     prelude::*,
     strategy::{CoefficientThreshold, CombinedStrategy, MaxPauliWeight},

--- a/crates/ppvm-stim/benches/tableau-msd-stim.rs
+++ b/crates/ppvm-stim/benches/tableau-msd-stim.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::time::Duration;
 
 use criterion::{Criterion, criterion_group, criterion_main};

--- a/crates/ppvm-stim/src/executor.rs
+++ b/crates/ppvm-stim/src/executor.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use bitvec::view::BitView;
 use itertools::Itertools;
 use num::Integer;

--- a/crates/ppvm-stim/src/lib.rs
+++ b/crates/ppvm-stim/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Parse and execute Stim circuits against a [`GeneralizedTableau`].
 //!
 //! Two-stage pipeline:

--- a/crates/ppvm-stim/src/prepare.rs
+++ b/crates/ppvm-stim/src/prepare.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use stim_parser::ast::{GateName, MeasureName, NoiseName};
 use stim_parser::extended::{ExtendedInstruction, ExtendedProgram, RawPassthrough};
 

--- a/crates/ppvm-stim/tests/executor.rs
+++ b/crates/ppvm-stim/tests/executor.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use ppvm_runtime::config::indexmap::ByteFxHashF64;
 use ppvm_stim::{execute, parse_extended};
 use ppvm_tableau::prelude::*;

--- a/crates/ppvm-stim/tests/prepare.rs
+++ b/crates/ppvm-stim/tests/prepare.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use ppvm_stim::{ExecError, parse_extended, prepare};
 
 fn err_from_src(src: &str) -> ExecError {

--- a/crates/ppvm-stim/tests/run.rs
+++ b/crates/ppvm-stim/tests/run.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use ppvm_runtime::config::indexmap::ByteFxHashF64;
 use ppvm_stim::{Error, ExecError, ExtendedParseError, ParseError, run_file, run_string};
 use ppvm_tableau::prelude::*;

--- a/crates/ppvm-stim/tests/stim_corpus.rs
+++ b/crates/ppvm-stim/tests/stim_corpus.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::PathBuf;
 
 use ppvm_runtime::config::indexmap::ByteFxHashF64;

--- a/crates/ppvm-sym/src/add.rs
+++ b/crates/ppvm-sym/src/add.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::term::{Inner, Prod, Sum, Term};
 
 impl std::ops::AddAssign<f64> for Sum {

--- a/crates/ppvm-sym/src/coeff.rs
+++ b/crates/ppvm-sym/src/coeff.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use ppvm_runtime::traits::{Coefficient, ComplexCoefficient};
 
 use crate::{Prod, Sum, Term, term::Inner};

--- a/crates/ppvm-sym/src/display.rs
+++ b/crates/ppvm-sym/src/display.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fmt::Display;
 
 use crate::term::Prod;

--- a/crates/ppvm-sym/src/eval.rs
+++ b/crates/ppvm-sym/src/eval.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use super::term::{Prod, Sum, Term};
 use anyhow::Result;
 

--- a/crates/ppvm-sym/src/lib.rs
+++ b/crates/ppvm-sym/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Symbolic, parametric Pauli propagation.
 //!
 //! `ppvm-sym` provides a [`Term`] type that represents a polynomial in

--- a/crates/ppvm-sym/src/mul.rs
+++ b/crates/ppvm-sym/src/mul.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use core::panic;
 
 use ppvm_runtime::prelude::*;

--- a/crates/ppvm-sym/src/term.rs
+++ b/crates/ppvm-sym/src/term.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::{collections::BTreeMap, hash::Hash};
 
 use fxhash::FxHashMap;

--- a/crates/ppvm-tableau/benches/measure-scaling.rs
+++ b/crates/ppvm-tableau/benches/measure-scaling.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::time::Duration;
 
 use criterion::{Criterion, criterion_group, criterion_main};

--- a/crates/ppvm-tableau/benches/micro.rs
+++ b/crates/ppvm-tableau/benches/micro.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::time::Duration;
 
 use bnum::types::U256;

--- a/crates/ppvm-tableau/benches/tableau-msd-fused.rs
+++ b/crates/ppvm-tableau/benches/tableau-msd-fused.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::time::Duration;
 
 use criterion::{Criterion, criterion_group, criterion_main};

--- a/crates/ppvm-tableau/benches/tableau-msd.rs
+++ b/crates/ppvm-tableau/benches/tableau-msd.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::time::Duration;
 
 use criterion::{Criterion, criterion_group, criterion_main};

--- a/crates/ppvm-tableau/benches/tableau.rs
+++ b/crates/ppvm-tableau/benches/tableau.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::time::Duration;
 
 use criterion::{Criterion, criterion_group, criterion_main};

--- a/crates/ppvm-tableau/examples/profile_breakdown.rs
+++ b/crates/ppvm-tableau/examples/profile_breakdown.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Profile the time breakdown inside branch_with_coefficients:
 //! computation (phase + multiply) vs HashMap accumulation.
 

--- a/crates/ppvm-tableau/examples/profile_combined.rs
+++ b/crates/ppvm-tableau/examples/profile_combined.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Profile the time breakdown of a fused circuit with variable T gates.
 
 use std::time::Instant;

--- a/crates/ppvm-tableau/examples/profile_measure.rs
+++ b/crates/ppvm-tableau/examples/profile_measure.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Ad-hoc profiling binary to measure measurement time scaling.
 /// Run: cargo run -p ppvm-tableau --example profile_measure --release
 use ppvm_runtime::config::fx64hash::Byte8F64;

--- a/crates/ppvm-tableau/examples/profile_msd.rs
+++ b/crates/ppvm-tableau/examples/profile_msd.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::time::Instant;
 
 use ppvm_runtime::config::fx64hash::Byte8F64;

--- a/crates/ppvm-tableau/examples/profile_rayon.rs
+++ b/crates/ppvm-tableau/examples/profile_rayon.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Profile the rayon vs sequential coefficient branching at various scales.
 //!
 //! This measures only the T-gate application phase (where coefficients branch),

--- a/crates/ppvm-tableau/examples/profile_scaling.rs
+++ b/crates/ppvm-tableau/examples/profile_scaling.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::time::Instant;
 
 use ppvm_runtime::config::fx64hash::Byte8F64;

--- a/crates/ppvm-tableau/src/data.rs
+++ b/crates/ppvm-tableau/src/data.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::{fmt::Debug, marker::PhantomData};
 
 use fxhash::FxHashMap as HashMap;

--- a/crates/ppvm-tableau/src/display.rs
+++ b/crates/ppvm-tableau/src/display.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::prelude::*;
 use num::complex::Complex;
 use std::fmt::Display;

--- a/crates/ppvm-tableau/src/gates/clifford.rs
+++ b/crates/ppvm-tableau/src/gates/clifford.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::prelude::*;
 use bitvec::view::BitView;
 use bitvec::view::BitViewSized;

--- a/crates/ppvm-tableau/src/gates/mod.rs
+++ b/crates/ppvm-tableau/src/gates/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 mod clifford;
 mod reset;
 mod rot1;

--- a/crates/ppvm-tableau/src/gates/reset.rs
+++ b/crates/ppvm-tableau/src/gates/reset.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fmt::Debug;
 
 use crate::prelude::*;

--- a/crates/ppvm-tableau/src/gates/rot1.rs
+++ b/crates/ppvm-tableau/src/gates/rot1.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use bitvec::view::BitView;
 use num::PrimInt;
 use num::{

--- a/crates/ppvm-tableau/src/gates/rot2.rs
+++ b/crates/ppvm-tableau/src/gates/rot2.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use bitvec::view::BitView;

--- a/crates/ppvm-tableau/src/gates/tgate.rs
+++ b/crates/ppvm-tableau/src/gates/tgate.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::prelude::*;
 use bitvec::view::BitView;
 use num::PrimInt;

--- a/crates/ppvm-tableau/src/gates/u3.rs
+++ b/crates/ppvm-tableau/src/gates/u3.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::prelude::*;
 use num::Complex;
 

--- a/crates/ppvm-tableau/src/lib.rs
+++ b/crates/ppvm-tableau/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Generalized stabilizer-tableau simulator built on top of `ppvm-runtime`.
 //!
 //! Provides a forward-evolving state representation using the stabilizer

--- a/crates/ppvm-tableau/src/measure.rs
+++ b/crates/ppvm-tableau/src/measure.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use super::data::{compute_phase_with_mask_static, symplectic_inner};
 use crate::prelude::*;
 use bitvec::view::BitView;

--- a/crates/ppvm-tableau/src/noise.rs
+++ b/crates/ppvm-tableau/src/noise.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::fmt::Debug;
 
 use bitvec::view::BitView;

--- a/crates/ppvm-tableau/src/sparsevec.rs
+++ b/crates/ppvm-tableau/src/sparsevec.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use num::complex::{Complex, ComplexFloat};
 use num::traits::{One, Zero};
 

--- a/crates/ppvm-tableau/src/tableau_index.rs
+++ b/crates/ppvm-tableau/src/tableau_index.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use num::PrimInt;
 use std::hash::Hash;
 use std::ops::{BitAnd, BitOrAssign, BitXor, Shl};

--- a/crates/ppvm-tableau/src/tableau_like.rs
+++ b/crates/ppvm-tableau/src/tableau_like.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! [`TableauLike`](crate::tableau_like::TableauLike) trait: shared interface for stabilizer-tableau backends.
 //!
 //! Any type implementing [`TableauLike`](crate::tableau_like::TableauLike) gets default implementations of

--- a/crates/ppvm-tableau/tests/gates.rs
+++ b/crates/ppvm-tableau/tests/gates.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Comprehensive gate and public-API tests for ppvm-tableau.
 //!
 //! Covers:

--- a/crates/ppvm-tableau/tests/measure.rs
+++ b/crates/ppvm-tableau/tests/measure.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::f64::consts::FRAC_PI_2;
 
 use num::complex::Complex64;

--- a/crates/ppvm-tableau/tests/msd_batch.rs
+++ b/crates/ppvm-tableau/tests/msd_batch.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Integration test: verify that the full MSD circuit using batch methods
 //! produces identical measurement outcomes to the naive individual-gate version.
 

--- a/crates/ppvm-tableau/tests/tableau.rs
+++ b/crates/ppvm-tableau/tests/tableau.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use bnum::types::U256;
 use itertools::Itertools;
 use num::complex::Complex;

--- a/crates/stim-parser/src/ast.rs
+++ b/crates/stim-parser/src/ast.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Pure-Stim AST. Tags are preserved verbatim; the parser does not
 //! resolve the Stim dialect — that is the consumer's responsibility.
 

--- a/crates/stim-parser/src/display.rs
+++ b/crates/stim-parser/src/display.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! `Display` impls for both Stim AST layers.
 //!
 //! Output is canonical Stim: 4-space indentation inside `REPEAT` blocks,

--- a/crates/stim-parser/src/extended/ast.rs
+++ b/crates/stim-parser/src/extended/ast.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Typed AST for Stim with PPVM tag-based extensions promoted to
 //! first-class instruction variants.
 

--- a/crates/stim-parser/src/extended/interpret.rs
+++ b/crates/stim-parser/src/extended/interpret.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Post-pass interpretation from the vanilla Stim AST to the extended AST.
 
 use crate::ast::{GateName, NoiseName, Program, RawInstruction, Tag, TagParam};

--- a/crates/stim-parser/src/extended/mod.rs
+++ b/crates/stim-parser/src/extended/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Extended Stim dialect - interprets PPVM tag-based extensions into a
 //! typed AST.
 

--- a/crates/stim-parser/src/extended/parser.rs
+++ b/crates/stim-parser/src/extended/parser.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Public entry point for the extended-dialect parse.
 
 use crate::ast::ParseError;

--- a/crates/stim-parser/src/grammar.rs
+++ b/crates/stim-parser/src/grammar.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Chumsky 0.12 grammar for Stim source.
 //!
 //! Reads top-to-bottom: whitespace/comments -> numbers -> pi-expressions ->

--- a/crates/stim-parser/src/lib.rs
+++ b/crates/stim-parser/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod ast;
 mod display;
 pub mod extended;

--- a/crates/stim-parser/src/line_map.rs
+++ b/crates/stim-parser/src/line_map.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Maps byte offsets in source to 1-indexed line/column positions.
 pub struct LineMap {
     /// `starts[i]` = byte offset of the start of line (i+1).

--- a/crates/stim-parser/src/parser.rs
+++ b/crates/stim-parser/src/parser.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::Arc;
 
 use crate::ast::{ArgCount, ParseError, Program, RawInstruction, SyntaxError, Tag, TargetArity};

--- a/crates/stim-parser/src/table.rs
+++ b/crates/stim-parser/src/table.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Instruction lookup table for the Stim parser.
 //!
 //! [`lookup`] maps a raw instruction name (e.g. `"H"`) to a [`TableEntry`]

--- a/crates/stim-parser/tests/errors.rs
+++ b/crates/stim-parser/tests/errors.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use stim_parser::prelude::*;
 
 #[test]

--- a/crates/stim-parser/tests/extended.rs
+++ b/crates/stim-parser/tests/extended.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use stim_parser::ast::{AnnotationKind, GateName, MeasureName, NoiseName};
 use stim_parser::extended::{
     Axis, ExtendedInstruction, ExtendedParseError, ExtendedProgram, RawPassthrough, parse_extended,

--- a/crates/stim-parser/tests/gates.rs
+++ b/crates/stim-parser/tests/gates.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use stim_parser::prelude::*;
 
 fn instructions(p: &Program) -> &[RawInstruction] {

--- a/crates/stim-parser/tests/measure.rs
+++ b/crates/stim-parser/tests/measure.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use stim_parser::prelude::*;
 
 #[test]

--- a/crates/stim-parser/tests/noise.rs
+++ b/crates/stim-parser/tests/noise.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use stim_parser::prelude::*;
 
 fn approx_eq(a: f64, b: f64) {

--- a/crates/stim-parser/tests/proptest_ast.rs
+++ b/crates/stim-parser/tests/proptest_ast.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! AST-level property test: `parse(print(p))` reaches `p` (modulo
 //! source-derived `line` metadata).
 //!

--- a/crates/stim-parser/tests/proptest_parse.rs
+++ b/crates/stim-parser/tests/proptest_parse.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Robustness fuzz: arbitrary inputs must never panic the parser.
 //!
 //! Both `parse` and `parse_extended` are public entry points that consume

--- a/crates/stim-parser/tests/proptest_roundtrip.rs
+++ b/crates/stim-parser/tests/proptest_roundtrip.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Printer-fixpoint property checked over generated inputs.
 //!
 //! The hand-written corpus in `tests/roundtrip.rs` covers ~22 cases.

--- a/crates/stim-parser/tests/roundtrip.rs
+++ b/crates/stim-parser/tests/roundtrip.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Printer-fixpoint roundtrip tests for both AST layers.
 //!
 //! The grammar accepts a much wider input surface than the printer

--- a/crates/stim-parser/tests/syntax.rs
+++ b/crates/stim-parser/tests/syntax.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use stim_parser::prelude::*;
 
 #[test]

--- a/crates/stim-parser/tests/tags.rs
+++ b/crates/stim-parser/tests/tags.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use stim_parser::prelude::*;
 
 fn approx_eq(a: f64, b: f64) {

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -353,7 +353,7 @@ const nav = [
     </script>
     <footer class="foot">
       <div class="foot-inner">
-        <span>ppvm · QuEra Computing · open source, MIT-style license</span>
+        <span>ppvm · QuEra Computing · open source, Apache License 2.0</span>
         <span>
           <a href="https://github.com/QuEraComputing/ppvm">source</a> ·
           documentation generated <time>{new Date().toISOString().slice(0, 10)}</time>

--- a/licenserc.header.txt
+++ b/licenserc.header.txt
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: {{props["inceptionYear"]}} {{props["copyrightOwner"]}}
+SPDX-License-Identifier: Apache-2.0

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -1,0 +1,23 @@
+headerPath = "licenserc.header.txt"
+
+includes = [
+  "crates/**/*.rs",
+  "ppvm-python/src/**/*.py",
+]
+
+excludes = [
+  "**/target/**",
+  "**/node_modules/**",
+  "**/.venv/**",
+  "**/generated/**",
+  "**/*.lock",
+  "docs/**",
+  "examples/**",
+  "julia-benchmarks/**",
+]
+
+useDefaultMapping = true
+
+[properties]
+inceptionYear = 2026
+copyrightOwner = "QuEra Computing Inc."

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,4 @@
 [tools]
 prek = "latest"
+# License header checker/formatter (used by prek hawkeye hook)
+"github:korandoru/hawkeye" = "latest"

--- a/ppvm-python/src/ppvm/__init__.py
+++ b/ppvm-python/src/ppvm/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 from ppvm_python_native import StimProgram as StimProgram
 
 from .generalized_tableau import GeneralizedTableau as GeneralizedTableau

--- a/ppvm-python/src/ppvm/generalized_tableau.py
+++ b/ppvm-python/src/ppvm/generalized_tableau.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 import enum
 from dataclasses import InitVar, dataclass, field
 

--- a/ppvm-python/src/ppvm/mixins.py
+++ b/ppvm-python/src/ppvm/mixins.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 from collections.abc import Sequence
 from typing import Any
 

--- a/ppvm-python/src/ppvm/paulisum.py
+++ b/ppvm-python/src/ppvm/paulisum.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 import re
 from collections.abc import Sequence

--- a/ppvm-python/src/ppvm/squin_interpreter/__init__.py
+++ b/ppvm-python/src/ppvm/squin_interpreter/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 """TODO: once we open-source, all of this will be moved into bloqade-circuit"""
 
 from ._interp import GeneralizedTableauInterpreter as GeneralizedTableauInterpreter

--- a/ppvm-python/src/ppvm/squin_interpreter/_interp.py
+++ b/ppvm-python/src/ppvm/squin_interpreter/_interp.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 from dataclasses import dataclass, field
 
 from kirin import interp

--- a/ppvm-python/src/ppvm/squin_interpreter/device.py
+++ b/ppvm-python/src/ppvm/squin_interpreter/device.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 from dataclasses import dataclass, field
 from typing import Any, ParamSpec, TypeVar, cast
 

--- a/ppvm-python/src/ppvm/squin_interpreter/impls/__init__.py
+++ b/ppvm-python/src/ppvm/squin_interpreter/impls/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-License-Identifier: Apache-2.0

--- a/ppvm-python/src/ppvm/squin_interpreter/impls/gate.py
+++ b/ppvm-python/src/ppvm/squin_interpreter/impls/gate.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 from typing import Any
 

--- a/ppvm-python/src/ppvm/squin_interpreter/impls/noise.py
+++ b/ppvm-python/src/ppvm/squin_interpreter/impls/noise.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any
 
 from bloqade.squin import noise

--- a/ppvm-python/src/ppvm/squin_interpreter/qubit.py
+++ b/ppvm-python/src/ppvm/squin_interpreter/qubit.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 from dataclasses import dataclass
 from typing import Any
 

--- a/ppvm-python/src/ppvm/types.py
+++ b/ppvm-python/src/ppvm/types.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Union
 
 import ppvm_python_native

--- a/prek.toml
+++ b/prek.toml
@@ -69,6 +69,18 @@ entry = "uvx ruff check ppvm-python/"
 pass_filenames = false
 types = ["python"]
 
+# License headers: hawkeye (Rust-based SPDX header checker)
+# Install once with: cargo install hawkeye  (or: cargo binstall hawkeye)
+# Run `hawkeye format` manually to apply headers to new files.
+[[repos]]
+repo = "local"
+[[repos.hooks]]
+id = "hawkeye"
+name = "hawkeye license header check"
+language = "system"
+entry = "hawkeye check"
+pass_filenames = false
+
 # Python: ty type check
 [[repos]]
 repo = "local"


### PR DESCRIPTION
## Summary

- Adopt **Apache License 2.0** for the project (was previously unlicensed); add `LICENSE` and `NOTICE`.
- Add `CLA.md`, an Individual CLA adapted from the Apache ICLA v2.2, so contributors grant explicit copyright + patent licenses and the project retains the right to relicense.
- Wire up **CLA Assistant Lite** (`contributor-assistant/github-action`) — signatures stored in `.github/cla-signatures.json` in this repo, not on a third-party server.
- Wire up **hawkeye** for per-file SPDX header enforcement: local prek hook + CI workflow, with the tool itself managed by mise (`github:korandoru/hawkeye`).
- Backfill `SPDX-FileCopyrightText` / `SPDX-License-Identifier` headers across all in-scope sources (`crates/**/*.rs`, `ppvm-python/src/**/*.py`) — 156 files.
- Update README and the docs-site footer (`docs/src/layouts/Base.astro`) to reflect Apache 2.0 instead of "MIT-style".

## Test plan

- [ ] Verify `mise exec -- hawkeye check` passes locally on this branch (passed in pre-commit).
- [ ] Verify the new `License headers` CI job passes on this PR.
- [ ] Verify the `CLA Assistant` workflow runs and posts the sign-CLA comment on this PR (since I haven't signed yet on this repo).
- [ ] After merge, in `Settings → Branches → main`, add **`CLA Assistant / CLAAssistant`** and **`License headers / hawkeye check`** as required status checks.
- [ ] Sanity-check the docs-site footer in a local `npx astro dev` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)