### PR TITLE
chore: attribute copyright to 'The PPVM Authors' collective

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,14 @@
+# This is the list of PPVM authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since
+# in some cases their employer may be the copyright holder. To see the
+# full list of contributors, see the revision history in source control.
+#
+# Names should be added to this file as either:
+#     Name <email@example.com>
+# or
+#     Organization
+#
+# Please keep the list sorted.
+
+QuEra Computing Inc.

--- a/CLA.md
+++ b/CLA.md
@@ -1,6 +1,6 @@
-# ppvm Individual Contributor License Agreement
+# PPVM Individual Contributor License Agreement
 
-Thank you for your interest in contributing to **ppvm** (the "Project"),
+Thank you for your interest in contributing to **PPVM** (the "Project"),
 maintained by QuEra Computing Inc. ("We" or "Us"). This Contributor License
 Agreement ("Agreement") documents the rights granted by contributors to Us.
 It is adapted from the Apache Software Foundation Individual Contributor

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,10 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 QuEra Computing Inc.
+   Copyright 2026 The PPVM Authors.
+
+   For a list of copyright holders, see the AUTHORS file at the root of
+   this repository.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,6 @@
-ppvm - Pauli Propagation and Virtual Machine
-Copyright 2026 QuEra Computing Inc.
+PPVM - Pauli Propagation and Virtual Machine
+Copyright 2026 The PPVM Authors.
 
-This product includes software developed at
-QuEra Computing Inc. (https://www.quera.com/).
+This product is initially developed at QuEra Computing Inc.
+(https://www.quera.com/). See the AUTHORS file for the full list of
+copyright holders.

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
 PPVM - Pauli Propagation and Virtual Machine
 Copyright 2026 The PPVM Authors.
 
-This product is initially developed at QuEra Computing Inc.
+This product was initially developed at QuEra Computing Inc.
 (https://www.quera.com/). See the AUTHORS file for the full list of
 copyright holders.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 * Python build: [![CI - python](https://github.com/QuEraComputing/ppvm/actions/workflows/python-ci.yml/badge.svg)](https://github.com/QuEraComputing/ppvm/actions/workflows/python-ci.yml)
 * Rust build: [![CI - rust](https://github.com/QuEraComputing/ppvm/actions/workflows/rust-ci.yml/badge.svg)](https://github.com/QuEraComputing/ppvm/actions/workflows/rust-ci.yml)
 
-# ppvm - Pauli Propagation and Virtual Machine
+# PPVM - Pauli Propagation and Virtual Machine
 
-**ppvm** is a fast quantum circuit simulator.
+**PPVM** is a fast quantum circuit simulator.
 It is implemented in rust, but also offers [python bindings](#python).
 
 # Short example
@@ -89,7 +89,7 @@ fn main() {
 
 # License
 
-ppvm is licensed under the [Apache License, Version 2.0](LICENSE).
+PPVM is licensed under the [Apache License, Version 2.0](LICENSE).
 See [NOTICE](NOTICE) for attribution requirements.
 
 # Contributing

--- a/crates/ppvm-python-native/src/interface.rs
+++ b/crates/ppvm-python-native/src/interface.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use paste::paste;

--- a/crates/ppvm-python-native/src/interface_tableau.rs
+++ b/crates/ppvm-python-native/src/interface_tableau.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use bnum::types::{U256, U512, U1024, U2048};

--- a/crates/ppvm-python-native/src/lib.rs
+++ b/crates/ppvm-python-native/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use pyo3::prelude::*;

--- a/crates/ppvm-python-native/src/stim_program.rs
+++ b/crates/ppvm-python-native/src/stim_program.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use pyo3::exceptions::{PyIOError, PyValueError};

--- a/crates/ppvm-runtime/benches/gate.rs
+++ b/crates/ppvm-runtime/benches/gate.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{Criterion, criterion_group, criterion_main};

--- a/crates/ppvm-runtime/benches/micro.rs
+++ b/crates/ppvm-runtime/benches/micro.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::time::Duration;

--- a/crates/ppvm-runtime/benches/random-circuit.rs
+++ b/crates/ppvm-runtime/benches/random-circuit.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{Criterion, criterion_group, criterion_main};

--- a/crates/ppvm-runtime/benches/trotter-scaling.rs
+++ b/crates/ppvm-runtime/benches/trotter-scaling.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{Criterion, criterion_group, criterion_main};

--- a/crates/ppvm-runtime/benches/trotter.rs
+++ b/crates/ppvm-runtime/benches/trotter.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{Criterion, criterion_group, criterion_main};

--- a/crates/ppvm-runtime/src/char.rs
+++ b/crates/ppvm-runtime/src/char.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 /// A single-qubit Pauli symbol.

--- a/crates/ppvm-runtime/src/config/dashmap.rs
+++ b/crates/ppvm-runtime/src/config/dashmap.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::marker::PhantomData;

--- a/crates/ppvm-runtime/src/config/fx64hash.rs
+++ b/crates/ppvm-runtime/src/config/fx64hash.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;

--- a/crates/ppvm-runtime/src/config/fxhash.rs
+++ b/crates/ppvm-runtime/src/config/fxhash.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;

--- a/crates/ppvm-runtime/src/config/gxhash.rs
+++ b/crates/ppvm-runtime/src/config/gxhash.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;

--- a/crates/ppvm-runtime/src/config/indexmap.rs
+++ b/crates/ppvm-runtime/src/config/indexmap.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::marker::PhantomData;

--- a/crates/ppvm-runtime/src/config/mod.rs
+++ b/crates/ppvm-runtime/src/config/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::hash::BuildHasher;

--- a/crates/ppvm-runtime/src/lib.rs
+++ b/crates/ppvm-runtime/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Core runtime for the ppvm quantum-circuit simulator.

--- a/crates/ppvm-runtime/src/loss/clifford.rs
+++ b/crates/ppvm-runtime/src/loss/clifford.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 // Clifford behavior for `LossyPauliWord` is provided by the blanket impl

--- a/crates/ppvm-runtime/src/loss/data.rs
+++ b/crates/ppvm-runtime/src/loss/data.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::char::Pauli;

--- a/crates/ppvm-runtime/src/loss/mod.rs
+++ b/crates/ppvm-runtime/src/loss/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 mod clifford;

--- a/crates/ppvm-runtime/src/loss/trace.rs
+++ b/crates/ppvm-runtime/src/loss/trace.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::hash::BuildHasher;

--- a/crates/ppvm-runtime/src/map/dashmap.rs
+++ b/crates/ppvm-runtime/src/map/dashmap.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::hash::BuildHasher;

--- a/crates/ppvm-runtime/src/map/hashmap.rs
+++ b/crates/ppvm-runtime/src/map/hashmap.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{collections::HashMap, hash::BuildHasher};

--- a/crates/ppvm-runtime/src/map/mod.rs
+++ b/crates/ppvm-runtime/src/map/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 mod hashmap;

--- a/crates/ppvm-runtime/src/pattern/contains.rs
+++ b/crates/ppvm-runtime/src/pattern/contains.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::data::{Decorated, NotIdentity, OpPattern, PauliPattern};

--- a/crates/ppvm-runtime/src/pattern/data.rs
+++ b/crates/ppvm-runtime/src/pattern/data.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 // pattern intermediate representation

--- a/crates/ppvm-runtime/src/pattern/display.rs
+++ b/crates/ppvm-runtime/src/pattern/display.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::data::{Decorated, NotIdentity, OpPattern, PauliPattern};

--- a/crates/ppvm-runtime/src/pattern/enumerate.rs
+++ b/crates/ppvm-runtime/src/pattern/enumerate.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::data::{Decorated, OpPattern, PauliPattern};

--- a/crates/ppvm-runtime/src/pattern/from.rs
+++ b/crates/ppvm-runtime/src/pattern/from.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::data::{NotIdentity, PauliPattern};

--- a/crates/ppvm-runtime/src/pattern/mod.rs
+++ b/crates/ppvm-runtime/src/pattern/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 mod contains;

--- a/crates/ppvm-runtime/src/pattern/parse.rs
+++ b/crates/ppvm-runtime/src/pattern/parse.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;

--- a/crates/ppvm-runtime/src/pattern/trace.rs
+++ b/crates/ppvm-runtime/src/pattern/trace.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::contains::Contains;

--- a/crates/ppvm-runtime/src/phase/clifford.rs
+++ b/crates/ppvm-runtime/src/phase/clifford.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::hash::BuildHasher;

--- a/crates/ppvm-runtime/src/phase/data.rs
+++ b/crates/ppvm-runtime/src/phase/data.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::hash::BuildHasher;

--- a/crates/ppvm-runtime/src/phase/mod.rs
+++ b/crates/ppvm-runtime/src/phase/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 mod clifford;

--- a/crates/ppvm-runtime/src/phase/mul.rs
+++ b/crates/ppvm-runtime/src/phase/mul.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use bitvec::view::BitView;

--- a/crates/ppvm-runtime/src/strategy.rs
+++ b/crates/ppvm-runtime/src/strategy.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::traits::*;

--- a/crates/ppvm-runtime/src/sum/approx.rs
+++ b/crates/ppvm-runtime/src/sum/approx.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::data::PauliSum;

--- a/crates/ppvm-runtime/src/sum/clifford.rs
+++ b/crates/ppvm-runtime/src/sum/clifford.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/crates/ppvm-runtime/src/sum/data.rs
+++ b/crates/ppvm-runtime/src/sum/data.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::Config;

--- a/crates/ppvm-runtime/src/sum/display.rs
+++ b/crates/ppvm-runtime/src/sum/display.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use itertools::Itertools;

--- a/crates/ppvm-runtime/src/sum/mod.rs
+++ b/crates/ppvm-runtime/src/sum/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 mod clifford;

--- a/crates/ppvm-runtime/src/sum/noise.rs
+++ b/crates/ppvm-runtime/src/sum/noise.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::char::Pauli;

--- a/crates/ppvm-runtime/src/sum/ops.rs
+++ b/crates/ppvm-runtime/src/sum/ops.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::ops::{AddAssign, MulAssign};

--- a/crates/ppvm-runtime/src/sum/proj.rs
+++ b/crates/ppvm-runtime/src/sum/proj.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::traits::*;

--- a/crates/ppvm-runtime/src/sum/rot1.rs
+++ b/crates/ppvm-runtime/src/sum/rot1.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::traits::*;

--- a/crates/ppvm-runtime/src/sum/rot2.rs
+++ b/crates/ppvm-runtime/src/sum/rot2.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::rot1::rotate_1_map_insert_closure;

--- a/crates/ppvm-runtime/src/sum/trace.rs
+++ b/crates/ppvm-runtime/src/sum/trace.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{

--- a/crates/ppvm-runtime/src/traits/branch/crx.rs
+++ b/crates/ppvm-runtime/src/traits/branch/crx.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::Config;

--- a/crates/ppvm-runtime/src/traits/branch/mod.rs
+++ b/crates/ppvm-runtime/src/traits/branch/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 mod crx;

--- a/crates/ppvm-runtime/src/traits/branch/proj.rs
+++ b/crates/ppvm-runtime/src/traits/branch/proj.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 /// Projective Z-basis projectors `|0⟩⟨0|` and `|1⟩⟨1|`.

--- a/crates/ppvm-runtime/src/traits/branch/rot1.rs
+++ b/crates/ppvm-runtime/src/traits/branch/rot1.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::char::Pauli;

--- a/crates/ppvm-runtime/src/traits/branch/rot2.rs
+++ b/crates/ppvm-runtime/src/traits/branch/rot2.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::Config;

--- a/crates/ppvm-runtime/src/traits/branch/tgate.rs
+++ b/crates/ppvm-runtime/src/traits/branch/tgate.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::Config;

--- a/crates/ppvm-runtime/src/traits/branch/u3.rs
+++ b/crates/ppvm-runtime/src/traits/branch/u3.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::Config;

--- a/crates/ppvm-runtime/src/traits/clifford.rs
+++ b/crates/ppvm-runtime/src/traits/clifford.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::traits::PauliWordTrait;

--- a/crates/ppvm-runtime/src/traits/coefficient.rs
+++ b/crates/ppvm-runtime/src/traits/coefficient.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use num::traits::Float;

--- a/crates/ppvm-runtime/src/traits/map.rs
+++ b/crates/ppvm-runtime/src/traits/map.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::hash::BuildHasher;

--- a/crates/ppvm-runtime/src/traits/measure.rs
+++ b/crates/ppvm-runtime/src/traits/measure.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 /// Projective Z-basis measurement returning a bare boolean outcome.

--- a/crates/ppvm-runtime/src/traits/mod.rs
+++ b/crates/ppvm-runtime/src/traits/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 mod branch;

--- a/crates/ppvm-runtime/src/traits/noise.rs
+++ b/crates/ppvm-runtime/src/traits/noise.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::Config;

--- a/crates/ppvm-runtime/src/traits/ptm.rs
+++ b/crates/ppvm-runtime/src/traits/ptm.rs
@@ -1,2 +1,2 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0

--- a/crates/ppvm-runtime/src/traits/reset.rs
+++ b/crates/ppvm-runtime/src/traits/reset.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 /// Reset a qubit to the `|0⟩` computational-basis state.

--- a/crates/ppvm-runtime/src/traits/storage.rs
+++ b/crates/ppvm-runtime/src/traits/storage.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use bitvec::view::BitViewSized;

--- a/crates/ppvm-runtime/src/traits/strategy.rs
+++ b/crates/ppvm-runtime/src/traits/strategy.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::coefficient::Coefficient;

--- a/crates/ppvm-runtime/src/traits/trace.rs
+++ b/crates/ppvm-runtime/src/traits/trace.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 /// Trait for computing `trace(self * RHS)`.

--- a/crates/ppvm-runtime/src/traits/word_trait.rs
+++ b/crates/ppvm-runtime/src/traits/word_trait.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::char::Pauli;

--- a/crates/ppvm-runtime/src/word/clifford.rs
+++ b/crates/ppvm-runtime/src/word/clifford.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 // Clifford behavior for `PauliWord` is provided by the blanket impl

--- a/crates/ppvm-runtime/src/word/data.rs
+++ b/crates/ppvm-runtime/src/word/data.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::char::Pauli;

--- a/crates/ppvm-runtime/src/word/mod.rs
+++ b/crates/ppvm-runtime/src/word/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 mod clifford;

--- a/crates/ppvm-runtime/src/word/mul.rs
+++ b/crates/ppvm-runtime/src/word/mul.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::hash::BuildHasher;

--- a/crates/ppvm-runtime/src/word/trace.rs
+++ b/crates/ppvm-runtime/src/word/trace.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::hash::BuildHasher;

--- a/crates/ppvm-runtime/tests/cnot.rs
+++ b/crates/ppvm-runtime/tests/cnot.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use approx::assert_relative_eq;

--- a/crates/ppvm-runtime/tests/ghz.rs
+++ b/crates/ppvm-runtime/tests/ghz.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use ppvm_runtime::prelude::*;

--- a/crates/ppvm-runtime/tests/loss.rs
+++ b/crates/ppvm-runtime/tests/loss.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use ppvm_runtime::{prelude::*, strategy::MaxLossWeight};

--- a/crates/ppvm-runtime/tests/noise.rs
+++ b/crates/ppvm-runtime/tests/noise.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use ppvm_runtime::{prelude::*, strategy::CoefficientThreshold};

--- a/crates/ppvm-runtime/tests/strategy.rs
+++ b/crates/ppvm-runtime/tests/strategy.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use ppvm_runtime::{

--- a/crates/ppvm-stim/benches/tableau-msd-stim.rs
+++ b/crates/ppvm-stim/benches/tableau-msd-stim.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::time::Duration;

--- a/crates/ppvm-stim/src/executor.rs
+++ b/crates/ppvm-stim/src/executor.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use bitvec::view::BitView;

--- a/crates/ppvm-stim/src/lib.rs
+++ b/crates/ppvm-stim/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Parse and execute Stim circuits against a [`GeneralizedTableau`].

--- a/crates/ppvm-stim/src/prepare.rs
+++ b/crates/ppvm-stim/src/prepare.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use stim_parser::ast::{GateName, MeasureName, NoiseName};

--- a/crates/ppvm-stim/tests/executor.rs
+++ b/crates/ppvm-stim/tests/executor.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use ppvm_runtime::config::indexmap::ByteFxHashF64;

--- a/crates/ppvm-stim/tests/prepare.rs
+++ b/crates/ppvm-stim/tests/prepare.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use ppvm_stim::{ExecError, parse_extended, prepare};

--- a/crates/ppvm-stim/tests/run.rs
+++ b/crates/ppvm-stim/tests/run.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use ppvm_runtime::config::indexmap::ByteFxHashF64;

--- a/crates/ppvm-stim/tests/stim_corpus.rs
+++ b/crates/ppvm-stim/tests/stim_corpus.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::path::PathBuf;

--- a/crates/ppvm-sym/src/add.rs
+++ b/crates/ppvm-sym/src/add.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::term::{Inner, Prod, Sum, Term};

--- a/crates/ppvm-sym/src/coeff.rs
+++ b/crates/ppvm-sym/src/coeff.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use ppvm_runtime::traits::{Coefficient, ComplexCoefficient};

--- a/crates/ppvm-sym/src/display.rs
+++ b/crates/ppvm-sym/src/display.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::Display;

--- a/crates/ppvm-sym/src/eval.rs
+++ b/crates/ppvm-sym/src/eval.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::term::{Prod, Sum, Term};

--- a/crates/ppvm-sym/src/lib.rs
+++ b/crates/ppvm-sym/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Symbolic, parametric Pauli propagation.

--- a/crates/ppvm-sym/src/mul.rs
+++ b/crates/ppvm-sym/src/mul.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use core::panic;

--- a/crates/ppvm-sym/src/term.rs
+++ b/crates/ppvm-sym/src/term.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{collections::BTreeMap, hash::Hash};

--- a/crates/ppvm-tableau/benches/measure-scaling.rs
+++ b/crates/ppvm-tableau/benches/measure-scaling.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::time::Duration;

--- a/crates/ppvm-tableau/benches/micro.rs
+++ b/crates/ppvm-tableau/benches/micro.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::time::Duration;

--- a/crates/ppvm-tableau/benches/tableau-msd-fused.rs
+++ b/crates/ppvm-tableau/benches/tableau-msd-fused.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::time::Duration;

--- a/crates/ppvm-tableau/benches/tableau-msd.rs
+++ b/crates/ppvm-tableau/benches/tableau-msd.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::time::Duration;

--- a/crates/ppvm-tableau/benches/tableau.rs
+++ b/crates/ppvm-tableau/benches/tableau.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::time::Duration;

--- a/crates/ppvm-tableau/examples/profile_breakdown.rs
+++ b/crates/ppvm-tableau/examples/profile_breakdown.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Profile the time breakdown inside branch_with_coefficients:

--- a/crates/ppvm-tableau/examples/profile_combined.rs
+++ b/crates/ppvm-tableau/examples/profile_combined.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Profile the time breakdown of a fused circuit with variable T gates.

--- a/crates/ppvm-tableau/examples/profile_measure.rs
+++ b/crates/ppvm-tableau/examples/profile_measure.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 /// Ad-hoc profiling binary to measure measurement time scaling.

--- a/crates/ppvm-tableau/examples/profile_msd.rs
+++ b/crates/ppvm-tableau/examples/profile_msd.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::time::Instant;

--- a/crates/ppvm-tableau/examples/profile_rayon.rs
+++ b/crates/ppvm-tableau/examples/profile_rayon.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Profile the rayon vs sequential coefficient branching at various scales.

--- a/crates/ppvm-tableau/examples/profile_scaling.rs
+++ b/crates/ppvm-tableau/examples/profile_scaling.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::time::Instant;

--- a/crates/ppvm-tableau/src/data.rs
+++ b/crates/ppvm-tableau/src/data.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{fmt::Debug, marker::PhantomData};

--- a/crates/ppvm-tableau/src/display.rs
+++ b/crates/ppvm-tableau/src/display.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::prelude::*;

--- a/crates/ppvm-tableau/src/gates/clifford.rs
+++ b/crates/ppvm-tableau/src/gates/clifford.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::prelude::*;

--- a/crates/ppvm-tableau/src/gates/mod.rs
+++ b/crates/ppvm-tableau/src/gates/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 mod clifford;

--- a/crates/ppvm-tableau/src/gates/reset.rs
+++ b/crates/ppvm-tableau/src/gates/reset.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::Debug;

--- a/crates/ppvm-tableau/src/gates/rot1.rs
+++ b/crates/ppvm-tableau/src/gates/rot1.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use bitvec::view::BitView;

--- a/crates/ppvm-tableau/src/gates/rot2.rs
+++ b/crates/ppvm-tableau/src/gates/rot2.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;

--- a/crates/ppvm-tableau/src/gates/tgate.rs
+++ b/crates/ppvm-tableau/src/gates/tgate.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::prelude::*;

--- a/crates/ppvm-tableau/src/gates/u3.rs
+++ b/crates/ppvm-tableau/src/gates/u3.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::prelude::*;

--- a/crates/ppvm-tableau/src/lib.rs
+++ b/crates/ppvm-tableau/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Generalized stabilizer-tableau simulator built on top of `ppvm-runtime`.

--- a/crates/ppvm-tableau/src/measure.rs
+++ b/crates/ppvm-tableau/src/measure.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use super::data::{compute_phase_with_mask_static, symplectic_inner};

--- a/crates/ppvm-tableau/src/noise.rs
+++ b/crates/ppvm-tableau/src/noise.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::Debug;

--- a/crates/ppvm-tableau/src/sparsevec.rs
+++ b/crates/ppvm-tableau/src/sparsevec.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use num::complex::{Complex, ComplexFloat};

--- a/crates/ppvm-tableau/src/tableau_index.rs
+++ b/crates/ppvm-tableau/src/tableau_index.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use num::PrimInt;

--- a/crates/ppvm-tableau/src/tableau_like.rs
+++ b/crates/ppvm-tableau/src/tableau_like.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! [`TableauLike`](crate::tableau_like::TableauLike) trait: shared interface for stabilizer-tableau backends.

--- a/crates/ppvm-tableau/tests/gates.rs
+++ b/crates/ppvm-tableau/tests/gates.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Comprehensive gate and public-API tests for ppvm-tableau.

--- a/crates/ppvm-tableau/tests/measure.rs
+++ b/crates/ppvm-tableau/tests/measure.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::f64::consts::FRAC_PI_2;

--- a/crates/ppvm-tableau/tests/msd_batch.rs
+++ b/crates/ppvm-tableau/tests/msd_batch.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Integration test: verify that the full MSD circuit using batch methods

--- a/crates/ppvm-tableau/tests/tableau.rs
+++ b/crates/ppvm-tableau/tests/tableau.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use bnum::types::U256;

--- a/crates/stim-parser/src/ast.rs
+++ b/crates/stim-parser/src/ast.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Pure-Stim AST. Tags are preserved verbatim; the parser does not

--- a/crates/stim-parser/src/display.rs
+++ b/crates/stim-parser/src/display.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! `Display` impls for both Stim AST layers.

--- a/crates/stim-parser/src/extended/ast.rs
+++ b/crates/stim-parser/src/extended/ast.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Typed AST for Stim with PPVM tag-based extensions promoted to

--- a/crates/stim-parser/src/extended/interpret.rs
+++ b/crates/stim-parser/src/extended/interpret.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Post-pass interpretation from the vanilla Stim AST to the extended AST.

--- a/crates/stim-parser/src/extended/mod.rs
+++ b/crates/stim-parser/src/extended/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Extended Stim dialect - interprets PPVM tag-based extensions into a

--- a/crates/stim-parser/src/extended/parser.rs
+++ b/crates/stim-parser/src/extended/parser.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Public entry point for the extended-dialect parse.

--- a/crates/stim-parser/src/grammar.rs
+++ b/crates/stim-parser/src/grammar.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Chumsky 0.12 grammar for Stim source.

--- a/crates/stim-parser/src/lib.rs
+++ b/crates/stim-parser/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod ast;

--- a/crates/stim-parser/src/line_map.rs
+++ b/crates/stim-parser/src/line_map.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 /// Maps byte offsets in source to 1-indexed line/column positions.

--- a/crates/stim-parser/src/parser.rs
+++ b/crates/stim-parser/src/parser.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;

--- a/crates/stim-parser/src/table.rs
+++ b/crates/stim-parser/src/table.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Instruction lookup table for the Stim parser.

--- a/crates/stim-parser/tests/errors.rs
+++ b/crates/stim-parser/tests/errors.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use stim_parser::prelude::*;

--- a/crates/stim-parser/tests/extended.rs
+++ b/crates/stim-parser/tests/extended.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use stim_parser::ast::{AnnotationKind, GateName, MeasureName, NoiseName};

--- a/crates/stim-parser/tests/gates.rs
+++ b/crates/stim-parser/tests/gates.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use stim_parser::prelude::*;

--- a/crates/stim-parser/tests/measure.rs
+++ b/crates/stim-parser/tests/measure.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use stim_parser::prelude::*;

--- a/crates/stim-parser/tests/noise.rs
+++ b/crates/stim-parser/tests/noise.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use stim_parser::prelude::*;

--- a/crates/stim-parser/tests/proptest_ast.rs
+++ b/crates/stim-parser/tests/proptest_ast.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! AST-level property test: `parse(print(p))` reaches `p` (modulo

--- a/crates/stim-parser/tests/proptest_parse.rs
+++ b/crates/stim-parser/tests/proptest_parse.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Robustness fuzz: arbitrary inputs must never panic the parser.

--- a/crates/stim-parser/tests/proptest_roundtrip.rs
+++ b/crates/stim-parser/tests/proptest_roundtrip.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Printer-fixpoint property checked over generated inputs.

--- a/crates/stim-parser/tests/roundtrip.rs
+++ b/crates/stim-parser/tests/roundtrip.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 //! Printer-fixpoint roundtrip tests for both AST layers.

--- a/crates/stim-parser/tests/syntax.rs
+++ b/crates/stim-parser/tests/syntax.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use stim_parser::prelude::*;

--- a/crates/stim-parser/tests/tags.rs
+++ b/crates/stim-parser/tests/tags.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+// SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
 use stim_parser::prelude::*;

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -353,7 +353,7 @@ const nav = [
     </script>
     <footer class="foot">
       <div class="foot-inner">
-        <span>ppvm · QuEra Computing · open source, Apache License 2.0</span>
+        <span>PPVM · QuEra Computing · open source, Apache License 2.0</span>
         <span>
           <a href="https://github.com/QuEraComputing/ppvm">source</a> ·
           documentation generated <time>{new Date().toISOString().slice(0, 10)}</time>

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -20,4 +20,4 @@ useDefaultMapping = true
 
 [properties]
 inceptionYear = 2026
-copyrightOwner = "QuEra Computing Inc."
+copyrightOwner = "The PPVM Authors"

--- a/ppvm-python/src/ppvm/__init__.py
+++ b/ppvm-python/src/ppvm/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-FileCopyrightText: 2026 The PPVM Authors
 # SPDX-License-Identifier: Apache-2.0
 
 from ppvm_python_native import StimProgram as StimProgram

--- a/ppvm-python/src/ppvm/generalized_tableau.py
+++ b/ppvm-python/src/ppvm/generalized_tableau.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-FileCopyrightText: 2026 The PPVM Authors
 # SPDX-License-Identifier: Apache-2.0
 
 import enum

--- a/ppvm-python/src/ppvm/mixins.py
+++ b/ppvm-python/src/ppvm/mixins.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-FileCopyrightText: 2026 The PPVM Authors
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Sequence

--- a/ppvm-python/src/ppvm/paulisum.py
+++ b/ppvm-python/src/ppvm/paulisum.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-FileCopyrightText: 2026 The PPVM Authors
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/ppvm-python/src/ppvm/squin_interpreter/__init__.py
+++ b/ppvm-python/src/ppvm/squin_interpreter/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-FileCopyrightText: 2026 The PPVM Authors
 # SPDX-License-Identifier: Apache-2.0
 
 """TODO: once we open-source, all of this will be moved into bloqade-circuit"""

--- a/ppvm-python/src/ppvm/squin_interpreter/_interp.py
+++ b/ppvm-python/src/ppvm/squin_interpreter/_interp.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-FileCopyrightText: 2026 The PPVM Authors
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass, field

--- a/ppvm-python/src/ppvm/squin_interpreter/device.py
+++ b/ppvm-python/src/ppvm/squin_interpreter/device.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-FileCopyrightText: 2026 The PPVM Authors
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass, field

--- a/ppvm-python/src/ppvm/squin_interpreter/impls/__init__.py
+++ b/ppvm-python/src/ppvm/squin_interpreter/impls/__init__.py
@@ -1,2 +1,2 @@
-# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-FileCopyrightText: 2026 The PPVM Authors
 # SPDX-License-Identifier: Apache-2.0

--- a/ppvm-python/src/ppvm/squin_interpreter/impls/gate.py
+++ b/ppvm-python/src/ppvm/squin_interpreter/impls/gate.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-FileCopyrightText: 2026 The PPVM Authors
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/ppvm-python/src/ppvm/squin_interpreter/impls/noise.py
+++ b/ppvm-python/src/ppvm/squin_interpreter/impls/noise.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-FileCopyrightText: 2026 The PPVM Authors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any

--- a/ppvm-python/src/ppvm/squin_interpreter/qubit.py
+++ b/ppvm-python/src/ppvm/squin_interpreter/qubit.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-FileCopyrightText: 2026 The PPVM Authors
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass

--- a/ppvm-python/src/ppvm/types.py
+++ b/ppvm-python/src/ppvm/types.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 QuEra Computing Inc.
+# SPDX-FileCopyrightText: 2026 The PPVM Authors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Union


### PR DESCRIPTION
## Summary

Move from single-entity copyright (`QuEra Computing Inc.`) to a collective-authorship attribution, following the JAX / TensorFlow / Go convention. The CLA remains with QuEra Computing Inc. as the legal counterparty, since "The PPVM Authors" isn't a legal entity that can receive contributions.

Also standardize on uppercase **PPVM** in formal/prose contexts (titles, copyright lines, CLA text, docs footer). Lowercase `ppvm` is preserved for technical identifiers — Python package, crate names, file paths, imports.

### Changes

- **`AUTHORS`** (new): Go-style header + sorted list. Currently just `QuEra Computing Inc.`; future organizational or individual copyright holders append here.
- **`LICENSE`**: `Copyright 2026 The PPVM Authors.` with pointer to AUTHORS.
- **`NOTICE`**: same attribution; notes QuEra as the initial developer.
- **`CLA.md`**: title and intro prose now use "PPVM".
- **`README.md`**: title, intro, and license section now use "PPVM".
- **`docs/src/layouts/Base.astro`**: footer reads "PPVM".
- **`licenserc.toml`**: `copyrightOwner = "The PPVM Authors"`.
- **All 156 in-scope source files**: SPDX header updated via `hawkeye remove && hawkeye format`.

### Not changed

- **`CLA.md` legal counterparty** — the agreement is still with QuEra Computing Inc. (the JAX precedent is the same: CLA with Google, files attributed to "The JAX Authors").
- **Lowercase identifiers** (`ppvm-runtime`, `ppvm-python`, `from ppvm import`, directory names) — those are part of the API surface, not prose.

## Note on commit message

The single commit's title still reads `'The ppvm Authors'` (lowercase) due to a force-push restriction in this session — the *content* is correct. On squash-merge GitHub will use this PR's title (correct casing), so the merged commit will be right.

## Test plan

- [ ] CI passes (Rust + Python + License headers + CLA Assistant).
- [ ] Spot-check `head -3 crates/ppvm-runtime/src/lib.rs` → "SPDX-FileCopyrightText: 2026 The PPVM Authors".
- [ ] `mise exec -- hawkeye check` passes (verified locally).
- [ ] Browse the docs preview and confirm the footer reads "PPVM".

🤖 Generated with [Claude Code](https://claude.com/claude-code)