### PR TITLE
docs(readme): tighten layout and rename to "Pauli Propagation Virtual Machine"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,44 @@
-[![Documentation](https://img.shields.io/badge/Documentation-6437FF)](https://congenial-bassoon-l436wp3.pages.github.io/)
+# Pauli Propagation Virtual Machine
 
-* Python build: [![CI - python](https://github.com/QuEraComputing/ppvm/actions/workflows/python-ci.yml/badge.svg)](https://github.com/QuEraComputing/ppvm/actions/workflows/python-ci.yml)
-* Rust build: [![CI - rust](https://github.com/QuEraComputing/ppvm/actions/workflows/rust-ci.yml/badge.svg)](https://github.com/QuEraComputing/ppvm/actions/workflows/rust-ci.yml)
+A fast quantum circuit simulator written in Rust, with Python bindings.
 
-# PPVM - Pauli Propagation and Virtual Machine
+[![Docs](https://img.shields.io/badge/docs-6437FF)](https://congenial-bassoon-l436wp3.pages.github.io/)
+[![CI - rust](https://github.com/QuEraComputing/ppvm/actions/workflows/rust-ci.yml/badge.svg)](https://github.com/QuEraComputing/ppvm/actions/workflows/rust-ci.yml)
+[![CI - python](https://github.com/QuEraComputing/ppvm/actions/workflows/python-ci.yml/badge.svg)](https://github.com/QuEraComputing/ppvm/actions/workflows/python-ci.yml)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
-**PPVM** is a fast quantum circuit simulator.
-It is implemented in rust, but also offers [python bindings](#python).
+## Install
 
-# Short example
-
-## Python
-
-Install with [uv](https://docs.astral.sh/uv/):
+**Python** (with [uv](https://docs.astral.sh/uv/)):
 
 ```bash
 uv add git+https://github.com/QuEraComputing/ppvm.git#subdirectory=ppvm-python
 ```
 
-### Pauli Propagation
-
-```python
-from ppvm import PauliSum
-
-# Start with the terms for which you want to compute the average
-state = PauliSum.new(n_qubits = 2, terms = ["ZZ"])
-
-# Create a GHZ state
-# NOTE: since this is Pauli Propagation, we need to backwards propagate, hence
-# the CNOT needs to precede the Hadamard
-state.cnot(0, 1)
-state.h(0)
-
-# The state is now represented as IZ
-print(state)  # 1.000 * IZ
-
-# Compute the average value
-print(state.overlap_with_zero())
-```
-
-
-### Generalized Stabilizer Tableau
-
-```python
-from ppvm import GeneralizedTableau
-
-tab = GeneralizedTableau(n_qubits=2)
-tab.h(0)
-tab.cnot(0, 1)
-
-r0 = tab.measure(0)
-r1 = tab.measure(1)
-print(f"Qubit 0: {r0}, Qubit 1: {r1}")  # always correlated
-```
-
-## Rust
-
-Install with
+**Rust**:
 
 ```toml
 [dependencies]
 ppvm-runtime = { git = "https://github.com/QuEraComputing/ppvm" }
 ```
 
-```rust
-use ppvm_runtime::prelude::*;
+## Example
 
-fn main() {
-    // Start with the terms for which you want to compute the average
-    let mut state: PauliSum<config::indexmap::ByteFxHashF64<1>> =
-        PauliSum::builder().n_qubits(2).build();
-    state += ("ZZ", 1.0);
+Pauli propagation runs **backwards** (Heisenberg picture): write gates in reverse order.
 
-    // Create a GHZ state
-    // NOTE: since this is Pauli Propagation, we need to backwards propagate, hence
-    // the CNOT needs to precede the Hadamard
-    state.cnot(0, 1);
-    state.h(0);
+```python
+from ppvm import PauliSum
 
-    // The state is now represented as IZ
-    println!("{}", state);  // 1.000 * IZ
+state = PauliSum.new(n_qubits=2, terms=["ZZ"])
+state.cnot(0, 1)   # GHZ preparation, written in reverse
+state.h(0)
 
-    // Compute the average value
-    let zero_state: PauliPattern = "Z?*".into();
-    println!("{}", state.trace(&zero_state));  // 1
-}
+print(state)                    # 1.000 * IZ
+print(state.overlap_with_zero())
 ```
 
-# License
+See the [documentation](https://congenial-bassoon-l436wp3.pages.github.io/) for the Rust API, the generalized stabilizer tableau, Stim integration, and symbolic propagation.
 
-PPVM is licensed under the [Apache License, Version 2.0](LICENSE).
-See [NOTICE](NOTICE) for attribution requirements.
+## License & contributing
 
-# Contributing
-
-Contributions are welcome — see [`CONTRIBUTING.md`](CONTRIBUTING.md) for
-the workflow and licensing terms. By opening a pull request you agree to
-the Apache License 2.0 and the [Contributor License Agreement](CLA.md).
+Licensed under [Apache 2.0](LICENSE); see [NOTICE](NOTICE) for attribution. Contributions are welcome — read [`CONTRIBUTING.md`](CONTRIBUTING.md) and the [CLA](CLA.md) before opening a pull request.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ uv add git+https://github.com/QuEraComputing/ppvm.git#subdirectory=ppvm-python
 ppvm-runtime = { git = "https://github.com/QuEraComputing/ppvm" }
 ```
 
-## Example
+## Examples
 
 Pauli propagation runs **backwards** (Heisenberg picture): write gates in reverse order.
 
@@ -37,7 +37,22 @@ print(state)                    # 1.000 * IZ
 print(state.overlap_with_zero())
 ```
 
-See the [documentation](https://congenial-bassoon-l436wp3.pages.github.io/) for the Rust API, the generalized stabilizer tableau, Stim integration, and symbolic propagation.
+The generalized stabilizer tableau is itself a form of Pauli propagation — it
+tracks stabilizer generators under Heisenberg evolution, extended to handle
+non-Clifford gates and measurements:
+
+```python
+from ppvm import GeneralizedTableau
+
+tab = GeneralizedTableau(n_qubits=2)
+tab.h(0)
+tab.cnot(0, 1)
+
+r0, r1 = tab.measure(0), tab.measure(1)
+print(f"Qubit 0: {r0}, Qubit 1: {r1}")  # always correlated
+```
+
+See the [documentation](https://congenial-bassoon-l436wp3.pages.github.io/) for the Rust API, Stim integration, and symbolic propagation.
 
 ## License & contributing
 


### PR DESCRIPTION
## Summary
- Rename title to **Pauli Propagation Virtual Machine** (drops the awkward "Pauli Propagation and Virtual Machine").
- Consolidate badges into a single row and tighten the install section.
- Drop the duplicate Rust example; keep one Python example demonstrating the Heisenberg-picture gate-order gotcha, with a docs link covering the tableau / Stim / symbolic backends.
- Fold license + contributing into a single compact footer.

## Test plan
- [ ] Rendered README looks clean on github.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)