### PR TITLE
docs: dephased XY-chain notebook + cached notebook execution

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -78,6 +78,23 @@ jobs:
           cache: "npm"
           cache-dependency-path: docs/package-lock.json
 
+      - name: Restore executed-notebook cache
+        # Reuses already-executed notebook HTML across runs. The key
+        # mirrors what `build-notebooks.py` hashes per-notebook: every
+        # Jupytext source + the lockfiles + every Cargo.toml. If any
+        # of those change, the cache misses and the build script
+        # re-executes the affected notebooks (still reusing the
+        # unchanged ones via the per-notebook content hash). The
+        # `restore-keys` fallback gives us a partial hit when *some*
+        # of those inputs change — the script then re-executes only
+        # the notebooks whose fingerprint no longer matches.
+        uses: actions/cache@v4
+        with:
+          path: docs/.notebook-cache
+          key: notebooks-v1-${{ hashFiles('docs/notebooks/**/*.py', 'Cargo.lock', 'Cargo.toml', 'crates/*/Cargo.toml', 'ppvm-python/uv.lock') }}
+          restore-keys: |
+            notebooks-v1-
+
       - name: Install Astro deps
         # `npm ci` is faster than `npm install` and asserts the
         # lockfile is in sync; it fails loudly if package.json and

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: docs/.notebook-cache
-          key: notebooks-v1-${{ hashFiles('docs/notebooks/**/*.py', 'Cargo.lock', 'Cargo.toml', 'crates/*/Cargo.toml', 'ppvm-python/uv.lock') }}
+          key: notebooks-v1-${{ hashFiles('docs/notebooks/**/*.py', 'docs/scripts/build-notebooks.py', 'Cargo.lock', 'Cargo.toml', 'crates/*/Cargo.toml', 'ppvm-python/uv.lock') }}
           restore-keys: |
             notebooks-v1-
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,17 +48,22 @@ If you are an AI agent picking up a task in this repository:
    - **Docs notebooks (`docs/notebooks/*.py`)**: executed at build time
      by [`docs/scripts/build-notebooks.py`](docs/scripts/build-notebooks.py)
      and embedded into `/examples/<slug>`. Outputs are content-addressed
-     cached under `docs/.notebook-cache/`, fingerprinted by notebook
-     source + every `Cargo.toml` + `Cargo.lock` + `ppvm-python/uv.lock`.
-     CI persists this via `actions/cache` (see the "Restore
+     cached under `docs/.notebook-cache/`, fingerprinted by
+     `CACHE_SCHEMA_VERSION` + the extractor script itself + the
+     notebook source + every `Cargo.toml` + `Cargo.lock` +
+     `ppvm-python/uv.lock`. (The extractor is in the fingerprint so
+     rendering/sanitiser edits invalidate cached outputs automatically.)
+     CI persists the directory via `actions/cache` (see the "Restore
      executed-notebook cache" step in
      [`.github/workflows/docs.yml`](.github/workflows/docs.yml)).
      **If you change the fingerprint inputs**, update both
      `_shared_fingerprint_files()` in the script *and* the
-     `hashFiles(...)` call in the workflow — they must stay in sync.
-     Force a clean re-execution with `PPVM_NOTEBOOK_CACHE=0`. Full
-     rationale lives under `§ 2.1 Notebook execution & caching` in the
-     Developer Guide.
+     `hashFiles(...)` call in the workflow — they must stay in sync
+     (both already list `docs/scripts/build-notebooks.py`). Force a
+     clean re-execution with `PPVM_NOTEBOOK_CACHE=0`, or bump
+     `CACHE_SCHEMA_VERSION` for a global invalidation that survives
+     in the cache. Full rationale lives under `§ 2.1 Notebook
+     execution & caching` in the Developer Guide.
 5. Respect the `Config`-trait generics in `ppvm-runtime`; do not introduce
    runtime dispatch where a compile-time bound suffices.
 6. Pauli propagation runs **backwards** (Heisenberg picture). Reverse the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,20 @@ If you are an AI agent picking up a task in this repository:
      Per-step commands and the `astro:dev` / `astro:build` escape
      hatches are documented under `§ 2 → "This docs site"` in the
      Developer Guide and in [`docs/README.md`](docs/README.md).
+   - **Docs notebooks (`docs/notebooks/*.py`)**: executed at build time
+     by [`docs/scripts/build-notebooks.py`](docs/scripts/build-notebooks.py)
+     and embedded into `/examples/<slug>`. Outputs are content-addressed
+     cached under `docs/.notebook-cache/`, fingerprinted by notebook
+     source + every `Cargo.toml` + `Cargo.lock` + `ppvm-python/uv.lock`.
+     CI persists this via `actions/cache` (see the "Restore
+     executed-notebook cache" step in
+     [`.github/workflows/docs.yml`](.github/workflows/docs.yml)).
+     **If you change the fingerprint inputs**, update both
+     `_shared_fingerprint_files()` in the script *and* the
+     `hashFiles(...)` call in the workflow — they must stay in sync.
+     Force a clean re-execution with `PPVM_NOTEBOOK_CACHE=0`. Full
+     rationale lives under `§ 2.1 Notebook execution & caching` in the
+     Developer Guide.
 5. Respect the `Config`-trait generics in `ppvm-runtime`; do not introduce
    runtime dispatch where a compile-time bound suffices.
 6. Pauli propagation runs **backwards** (Heisenberg picture). Reverse the

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -7,3 +7,7 @@ src/data/python-api.json
 # under `docs/notebooks/` are tracked; the executed HTML fragments,
 # their metadata, and the index are regenerated on every build.
 src/generated/
+# Content-addressed cache for executed notebooks. CI populates this
+# via `actions/cache`; locally it survives across builds so editing
+# a CSS rule doesn't force a 10-minute notebook re-run.
+.notebook-cache/

--- a/docs/notebooks/nearest_neighbor_dephasing.py
+++ b/docs/notebooks/nearest_neighbor_dephasing.py
@@ -375,4 +375,4 @@ plt.show()
 
 # %% [markdown]
 #
-# While small dt value improve accuracy for larger $\gamma$, this is not true for smaller ones - this is because we kept the truncation error fixed and at small time step, more truncations happen which dominate at small $\gamma$. We therefore recommend the following convergence procedure: fix $\delta t$, converge with respect to truncation. Then decrease $\delta t$ and repeat until time-step error negligible.
+# While smaller dt values improve accuracy for larger $\gamma$, this is not true for smaller ones - this is because we kept the truncation error fixed and at small time step, more truncations happen which dominate at small $\gamma$. We therefore recommend the following convergence procedure: fix $\delta t$, converge with respect to truncation. Then decrease $\delta t$ and repeat until time-step error negligible.

--- a/docs/notebooks/nearest_neighbor_dephasing.py
+++ b/docs/notebooks/nearest_neighbor_dephasing.py
@@ -1,0 +1,378 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.19.1
+#   kernelspec:
+#     display_name: ppvm (3.12.12)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Dephased Nearest-Neighbour XY Chain
+#
+# In this example we simulate the infinite-temperature spin correlator of the
+# **nearest-neighbour XY chain with local dephasing**
+#
+# $$H = J \sum_i (X_i X_{i+1} + Y_i Y_{i+1})$$
+#
+# with periodic boundary conditions.  We work in the Heisenberg picture, where
+# observables evolve under the adjoint Lindblad equation
+#
+# $$\dot O=i[H,O]+\gamma\sum_j(Z_jOZ_j-O).$$
+#
+# The observable is
+#
+# $$C_j(t)=2^{-L}\operatorname{Tr}[Z_j(t)Z_i],$$
+#
+# where $i$ is the middle site of the chain.  The goal is to extract transport
+# coefficients from the long-wavelength relaxation of this correlator.  In one
+# dimension, diffusion implies that the local autocorrelator decays as
+#
+# $$C_i(t)\sim t^{-1/2}.$$
+#
+# It is often cleaner to analyze the same dynamics in momentum space, with
+#
+# $$C_k(t)=\sum_j e^{-ikx_j}C_j(t),$$
+#
+# where $x_j$ is the periodic distance from the initially perturbed site.  For a
+# diffusive mode one expects
+#
+# $$C_k(t)\sim e^{-Dk^2t}$$
+#
+# at small momentum, so the decay rate $\lambda(k)$ gives the diffusion
+# constant through $\lambda(k)/k^2\to D$.
+#
+# We compute the correlator in two ways:
+#
+# 1. Trotterized Heisenberg-picture Pauli propagation with ppvm.
+# 2. An exact finite-size benchmark obtained by solving the closed bilinear
+#    operator equation for $B_{mn}=c_m^\dagger c_n$.
+#
+# The ppvm result is approximate because of Trotter error and Pauli-string
+# truncation.  The bilinear benchmark is exact for the nearest-neighbour
+# dephased free-fermion problem.
+
+# %%
+import matplotlib.pyplot as plt
+import numpy as np
+from tqdm import tqdm
+
+from ppvm import PauliSum
+
+# %% [markdown]
+# ## Parameters
+
+# %%
+L = 51
+J = 1.0
+gamma = 1.0
+dt = 0.01
+time = 4.0
+min_abs_coeff = 1e-8
+max_pauli_weight = L+1 # no weight truncation
+
+site0 = L // 2
+steps = int(time / dt)
+times = np.arange(steps + 1) * dt
+
+# %% [markdown]
+# ## Trotterized ppvm simulation
+#
+# We initialise the Heisenberg observable as $Z_i$.  During each Trotter step
+# we apply local $Z$-dephasing and then reverse the nearest-neighbour
+# $R_{XX}$, $R_{YY}$ gate layers.  The bonds are split into even and odd
+# layers.  Bonds within one layer are disjoint for even $L$, so this ordering is
+# closer to the usual parallel nearest-neighbour Trotter circuit than sweeping
+# through all bonds one by one.
+#
+# The dephasing part of the adjoint Lindblad equation
+#
+# $$\dot O=\gamma\sum_j(Z_jOZ_j-O)$$
+#
+# damps a single $X$ or $Y$ operator by $e^{-2\gamma\delta t}$.  Therefore
+# the corresponding Pauli-error probability per Trotter step is
+#
+# $$p_Z=\frac{1-e^{-2\gamma\delta t}}{2}.$$
+
+# %%
+observable = PauliSum.new(
+    L,
+    f"Z{site0}",
+    min_abs_coeff=min_abs_coeff,
+    max_pauli_weight=max_pauli_weight,
+)
+z_ops = [PauliSum.new(L, f"Z{j}") for j in range(L)]
+
+theta = 2 * J * dt
+p_z = (1 - np.exp(-2 * gamma * dt)) / 2
+bond_layers = [
+    [(j, (j + 1) % L) for j in range(0, L, 2)],
+    [(j, (j + 1) % L) for j in range(1, L, 2)],
+]
+
+
+def trotter_step(obs):
+    for q in range(L):
+        obs.pauli_error(q, [0.0, 0.0, p_z])
+    for layer in reversed(bond_layers):
+        for a, b in reversed(layer):
+            obs.ryy(a, b, theta)
+            obs.rxx(a, b, theta)
+
+
+# %%
+ppvm_corr = np.empty((steps + 1, L))
+
+for n, _ in tqdm(enumerate(times), total=len(times)):
+    ppvm_corr[n] = [observable.overlap(z) for z in z_ops]
+    if n == steps:
+        break
+    trotter_step(observable)
+
+print(f"Current max Pauli weight: {observable.current_max_weight()}")
+
+# %% [markdown]
+# ## Exact bilinear benchmark
+#
+# For nearest-neighbour interactions the Jordan-Wigner fermions remain closed
+# under the adjoint Lindblad equation.  The bilinears
+#
+# $$B_{mn}=c_m^\dagger c_n$$
+#
+# obey
+#
+# $$
+# \partial_t B_{mn}
+# =
+# i\,2J(B_{m+1,n}+B_{m-1,n}-B_{m,n+1}-B_{m,n-1})
+# -4\gamma(1-\delta_{mn})B_{mn}.
+# $$
+#
+# By linearity, the quantities
+#
+# $$F_{mn}(t)=2^{-L}\operatorname{Tr}[B_{mn}(t)Z_i]$$
+#
+# obey the same equation with initial condition
+#
+# $$F_{mn}(0)=-\frac{1}{2}\delta_{mi}\delta_{ni}.$$
+#
+# The spin correlator is recovered from the diagonal entries:
+#
+# $$C_j(t)=-2F_{jj}(t).$$
+
+# %%
+def exact_bilinear_correlator(L, J, gamma, times, site0):
+    dim = L * L
+
+    def idx(m, n):
+        return (m % L) * L + (n % L)
+
+    generator = np.zeros((dim, dim), dtype=complex)
+    for m in range(L):
+        for n in range(L):
+            row = idx(m, n)
+            generator[row, idx(m + 1, n)] += 1j * 2 * J
+            generator[row, idx(m - 1, n)] += 1j * 2 * J
+            generator[row, idx(m, n + 1)] += -1j * 2 * J
+            generator[row, idx(m, n - 1)] += -1j * 2 * J
+            if m != n:
+                generator[row, row] += -4 * gamma
+
+    evals, evecs = np.linalg.eig(generator)
+    evecs_inv = np.linalg.inv(evecs)
+
+    f0 = np.zeros(dim, dtype=complex)
+    f0[idx(site0, site0)] = -0.5
+    coeffs = evecs_inv @ f0
+
+    corr = np.empty((len(times), L))
+    diag = [idx(j, j) for j in range(L)]
+    for nt, t in enumerate(times):
+        ft = evecs @ (np.exp(evals * t) * coeffs)
+        corr[nt] = np.real(-2 * ft[diag])
+    return corr
+
+
+exact_corr = exact_bilinear_correlator(L, J, gamma, times, site0)
+
+# %% [markdown]
+# ## Results
+#
+# The autocorrelator checks the time dependence at the initially perturbed site.
+# We plot it on log-log axes and then show the relative error to the exact
+# bilinear solution.  The final-time profile checks spatial propagation around
+# the periodic chain.
+
+# %%
+fig, ax = plt.subplots()
+ax.loglog(times[1:], ppvm_corr[1:, site0], "o", ms=3, label="ppvm")
+ax.loglog(times[1:], exact_corr[1:, site0], "-", label="exact bilinear")
+ax.set_xlabel("Time $t$")
+ax.set_ylabel(r"$C_i(t)$")
+ax.set_title("Nearest-neighbour XY chain with dephasing")
+ax.legend()
+plt.tight_layout()
+plt.show()
+
+# %%
+rel_err = np.abs(ppvm_corr[:, site0] - exact_corr[:, site0]) / np.maximum(
+    np.abs(exact_corr[:, site0]), 1e-15
+)
+
+fig, ax = plt.subplots()
+ax.semilogy(times, rel_err, "o-", ms=3)
+ax.set_xlabel("Time $t$")
+ax.set_ylabel("Relative error")
+ax.set_title("Autocorrelator error relative to exact bilinear solution")
+plt.tight_layout()
+plt.show()
+
+# %%
+x = (np.arange(L) - site0 + L // 2) % L - L // 2
+order = np.argsort(x)
+
+fig, ax = plt.subplots()
+ax.plot(x[order], ppvm_corr[-1, order], "o", ms=4, label="ppvm")
+ax.plot(x[order], exact_corr[-1, order], "-", label="exact bilinear")
+ax.set_xlabel("Distance from initial site")
+ax.set_ylabel(r"$C_j(t)$")
+ax.set_title(f"Profile at $t={times[-1]:.2f}$")
+ax.legend()
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## Fourier-space decay
+#
+# We now inspect low-momentum relaxation by Fourier transforming the spatial correlator,
+#
+# $$C_k(t)=\sum_j e^{-ikx_j}C_j(t).$$
+#
+# For diffusive transport the low-$k$ decay rate scales as
+# $\lambda(k)\propto k^2$.
+
+# %%
+k = 2 * np.pi * np.arange(1, min(5, L // 2) + 1) / L
+phase = np.exp(-1j * np.outer(x, k))
+ppvm_ck = ppvm_corr @ phase
+exact_ck = exact_corr @ phase
+
+fig, ax = plt.subplots()
+for n, kk in enumerate(k):
+    ax.plot(times, np.real(ppvm_ck[:, n] / ppvm_ck[0, n]), "o", ms=3, label=rf"ppvm $k={kk:.2f}$")
+    ax.plot(times, np.real(exact_ck[:, n] / exact_ck[0, n]), "-", label=rf"exact $k={kk:.2f}$")
+ax.set_xlabel("Time $t$")
+ax.set_ylabel(r"$C_k(t)/C_k(0)$")
+ax.set_yscale("log")
+ax.set_title("Low-momentum mode decay")
+ax.legend(fontsize=8, ncol=2)
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## Diffusive rate fit
+#
+# We fit each Fourier mode to
+#
+# $$\log |C_k(t)| = a_k - \lambda(k)t$$
+#
+# in the window $2\leq t\leq4$.  For diffusion, $\lambda(k)/k^2$ should approach
+# a constant.  In the infinite-system hydrodynamic limit of the exact
+# nearest-neighbour solution, that constant is
+#
+# $$D_\infty=\frac{2J^2}{\gamma}.$$
+
+# %%
+fit_tmin = 2.0
+fit_tmax = 4.0
+fit_mask = (times >= fit_tmin) & (times <= fit_tmax)
+
+lambda_k = []
+for n in range(len(k)):
+    y = np.abs(exact_ck[:, n])
+    mask = fit_mask & (y > 0)
+    slope, intercept = np.polyfit(times[mask], np.log(y[mask]), 1)
+    lambda_k.append(-slope)
+lambda_k = np.array(lambda_k)
+
+D_exact = 2 * J**2 / gamma
+print(f"D_infinity = {D_exact:.6g}")
+
+fig, ax = plt.subplots()
+ax.plot(k, lambda_k / k**2, "o-", label=r"$\lambda(k)/k^2$")
+ax.axhline(D_exact, ls="--", color="black", label=rf"$D_\infty={D_exact:.3g}$")
+ax.set_xlabel(r"$k$")
+ax.set_ylabel(r"$\lambda(k)/k^2$")
+ax.set_title(r"Diffusion estimate from $2\leq t\leq4$")
+ax.legend()
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+# ## Appendix: Errors in ppvm simulation
+#
+# Here we discuss the interplay between Trotter and truncation errors. We vary only $\gamma$, keeping all other parameters fixed, and compare
+# the ppvm autocorrelator to the exact bilinear result.  The plotted error is
+# the maximum relative error over all times.  We repeat the comparison with the
+# original Trotter step and with a ten times smaller step size.
+
+# %%
+gamma_values = np.array([1e-4,0.001, 0.01,0.1, 1.0])
+dt_values = [dt, dt / 10]
+max_rel_errors = {dt_value: [] for dt_value in dt_values}
+
+
+def ppvm_autocorrelator(gamma_value, dt_value):
+    steps_value = int(time / dt_value)
+    times_value = np.arange(steps_value + 1) * dt_value
+    theta_value = 2 * J * dt_value
+    p_z_value = (1 - np.exp(-2 * gamma_value * dt_value)) / 2
+    obs = PauliSum.new(
+        L,
+        f"Z{site0}",
+        min_abs_coeff=min_abs_coeff,
+        max_pauli_weight=max_pauli_weight,
+    )
+    z0 = PauliSum.new(L, f"Z{site0}")
+    ppvm_auto = np.empty(len(times_value))
+
+    for n, _ in enumerate(times_value):
+        ppvm_auto[n] = obs.overlap(z0)
+        if n == steps_value:
+            break
+        for q in range(L):
+            obs.pauli_error(q, [0.0, 0.0, p_z_value])
+        for layer in reversed(bond_layers):
+            for a, b in reversed(layer):
+                obs.ryy(a, b, theta_value)
+                obs.rxx(a, b, theta_value)
+    return times_value, ppvm_auto
+
+
+for dt_value in dt_values:
+    for gamma_value in tqdm(gamma_values, desc=f"dt={dt_value:g}"):
+        times_value, ppvm_auto = ppvm_autocorrelator(gamma_value, dt_value)
+        exact_auto = exact_bilinear_correlator(L, J, gamma_value, times_value, site0)[:, site0]
+        rel = np.abs(ppvm_auto - exact_auto) / np.maximum(np.abs(exact_auto), 1e-15)
+        max_rel_errors[dt_value].append(np.max(rel))
+
+fig, ax = plt.subplots()
+for dt_value in dt_values:
+    ax.loglog(gamma_values, max_rel_errors[dt_value], "o-", label=rf"$\delta t={dt_value:g}$")
+ax.set_xlabel(r"$\gamma$")
+ax.set_ylabel("Maximum relative autocorrelator error")
+ax.set_title("Maximum ppvm error versus dephasing strength")
+ax.legend()
+plt.tight_layout()
+plt.show()
+
+# %% [markdown]
+#
+# While small dt value improve accuracy for larger $\gamma$, this is not true for smaller ones - this is because we kept the truncation error fixed and at small time step, more truncations happen which dominate at small $\gamma$. We therefore recommend the following convergence procedure: fix $\delta t$, converge with respect to truncation. Then decrease $\delta t$ and repeat until time-step error negligible.

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "//extract": "Build steps that produce inputs the Astro pages depend on.",
     "extract:rust": "node scripts/extract-rust.mjs",
     "extract:python": "node scripts/extract-python.mjs",
-    "extract:notebooks": "uv run --project ../ppvm-python --with jupytext --with nbconvert --with nbclient --with ipykernel --with matplotlib --with numpy --with bleach python scripts/build-notebooks.py",
+    "extract:notebooks": "uv run --project ../ppvm-python --with jupytext --with nbconvert --with nbclient --with ipykernel --with matplotlib --with numpy --with bleach --with tqdm python scripts/build-notebooks.py",
     "extract": "npm run extract:rust && npm run extract:python && npm run extract:notebooks",
     "//astro": "Raw Astro commands — use these only if you've extracted the inputs yourself.",
     "astro:dev": "astro dev --host 127.0.0.1 --port 4321",

--- a/docs/scripts/build-notebooks.py
+++ b/docs/scripts/build-notebooks.py
@@ -19,11 +19,20 @@ Pipeline per notebook (``foo.py``):
 
 Executed outputs are also written to a content-addressed cache under
 ``docs/.notebook-cache/`` (or ``$PPVM_NOTEBOOK_CACHE_DIR``). The cache
-key is ``sha256(notebook source + Cargo.lock + Cargo.toml files +
-uv.lock)`` — so docs-only or CSS-only PRs reuse already-executed
-notebooks instead of re-running them. GH Actions persists this
-directory across runs via ``actions/cache``; the nightly full-rebuild
-catches numerical drift that the lockfile-only fingerprint misses.
+key is ``sha256(CACHE_SCHEMA_VERSION + this script's source + notebook
+source + Cargo.lock + Cargo.toml files + uv.lock)`` — so docs-only or
+CSS-only PRs reuse already-executed notebooks, and any change to the
+extractor itself (rendering, sanitiser, matplotlib setup) invalidates
+every entry automatically. Bump ``CACHE_SCHEMA_VERSION`` if you need
+to force a global invalidation for some other reason. GH Actions
+persists this directory across runs via ``actions/cache``.
+
+The fingerprint deliberately does not hash Rust ``.rs`` or Python
+package sources, so a numerical change inside a crate that doesn't
+touch a lockfile or ``Cargo.toml`` will not invalidate cached
+outputs. Rely on ``cargo test --workspace`` / ``pytest`` to catch
+those; if we add a scheduled full-rebuild workflow in the future, it
+will serve as a second safety net.
 
 Designed to be invoked from CI as the step before ``npx astro build``.
 """
@@ -62,6 +71,12 @@ CACHE_DIR = Path(
 # Set ``PPVM_NOTEBOOK_CACHE=0`` to force re-execution regardless of
 # what's on disk (useful when investigating numerical drift).
 CACHE_ENABLED = os.environ.get("PPVM_NOTEBOOK_CACHE", "1") != "0"
+# Bump this to force-invalidate every cached notebook output. Useful
+# when the cached artefact layout changes incompatibly (e.g. a new
+# field in the sidecar JSON that downstream Astro pages depend on).
+# Routine pipeline edits don't need a bump because the script's own
+# source is part of the fingerprint via ``_shared_fingerprint_files``.
+CACHE_SCHEMA_VERSION = "1"
 
 # Switch matplotlib to the IPython "inline" backend before any cell
 # runs so ``plt.show()`` triggers Jupyter's display hook and embeds
@@ -233,16 +248,22 @@ def detect_language(nb: nbformat.NotebookNode) -> str:
     return (lang or "python").lower()
 
 
-# Files outside ``docs/notebooks/`` whose contents influence notebook
-# numerics. Hashed once into ``_shared_fingerprint`` and combined with
-# the notebook source to form each notebook's cache key.
+# Files whose contents influence notebook outputs. Hashed once into
+# ``_shared_fingerprint`` and combined with the notebook source to
+# form each notebook's cache key.
 #
-# We intentionally do NOT hash Rust ``.rs`` sources — that would blow
-# up the fingerprint on cosmetic changes. Cargo.toml + Cargo.lock +
-# uv.lock cover dependency bumps and version changes; the nightly
-# full-rebuild job catches drift that slips through.
+# Includes this script itself so changes to the rendering / sanitiser
+# / matplotlib-setup path invalidate cached outputs automatically —
+# without that, a fix to (say) the bleach allow-list would silently
+# keep serving the previous (potentially insecure or broken) HTML
+# for every unchanged notebook source.
+#
+# We intentionally do NOT hash Rust ``.rs`` or Python package
+# sources — that would blow up the fingerprint on cosmetic changes.
+# Cargo.toml + Cargo.lock + uv.lock cover dependency bumps and
+# version changes; ``cargo test`` / ``pytest`` catch the rest.
 def _shared_fingerprint_files() -> list[Path]:
-    files: list[Path] = []
+    files: list[Path] = [Path(__file__).resolve()]
     for name in ("Cargo.lock", "Cargo.toml"):
         p = REPO_ROOT / name
         if p.exists():
@@ -256,9 +277,15 @@ def _shared_fingerprint_files() -> list[Path]:
 
 def _compute_shared_fingerprint() -> bytes:
     h = hashlib.sha256()
+    h.update(b"schema=")
+    h.update(CACHE_SCHEMA_VERSION.encode("utf-8"))
+    h.update(b"\0")
     for f in _shared_fingerprint_files():
-        rel = f.relative_to(REPO_ROOT).as_posix()
-        h.update(rel.encode("utf-8"))
+        try:
+            label = f.relative_to(REPO_ROOT).as_posix()
+        except ValueError:
+            label = f.name
+        h.update(label.encode("utf-8"))
         h.update(b"\0")
         h.update(f.read_bytes())
         h.update(b"\0")

--- a/docs/scripts/build-notebooks.py
+++ b/docs/scripts/build-notebooks.py
@@ -17,13 +17,24 @@ Pipeline per notebook (``foo.py``):
    ``<name>.json`` with metadata (title, ordered headings) that the
    Astro index page can render without parsing HTML.
 
+Executed outputs are also written to a content-addressed cache under
+``docs/.notebook-cache/`` (or ``$PPVM_NOTEBOOK_CACHE_DIR``). The cache
+key is ``sha256(notebook source + Cargo.lock + Cargo.toml files +
+uv.lock)`` — so docs-only or CSS-only PRs reuse already-executed
+notebooks instead of re-running them. GH Actions persists this
+directory across runs via ``actions/cache``; the nightly full-rebuild
+catches numerical drift that the lockfile-only fingerprint misses.
+
 Designed to be invoked from CI as the step before ``npx astro build``.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 import re
+import shutil
 import sys
 from pathlib import Path
 
@@ -35,8 +46,22 @@ from nbconvert import HTMLExporter
 
 HERE = Path(__file__).resolve().parent
 DOCS = HERE.parent
+REPO_ROOT = DOCS.parent
 SOURCE_DIR = DOCS / "notebooks"
 OUTPUT_DIR = DOCS / "src" / "generated" / "notebooks"
+# Content-addressed cache for executed notebooks. Keyed by
+# ``sha256(notebook source + shared runtime fingerprint)``; populated
+# on every successful execution, read on subsequent runs. CI restores
+# this directory via ``actions/cache`` so docs-only PRs reuse already-
+# executed notebooks instead of re-running them. Override with
+# ``PPVM_NOTEBOOK_CACHE_DIR=…`` (used by the GH Actions workflow to
+# point at a stable cross-job location).
+CACHE_DIR = Path(
+    os.environ.get("PPVM_NOTEBOOK_CACHE_DIR", DOCS / ".notebook-cache")
+).resolve()
+# Set ``PPVM_NOTEBOOK_CACHE=0`` to force re-execution regardless of
+# what's on disk (useful when investigating numerical drift).
+CACHE_ENABLED = os.environ.get("PPVM_NOTEBOOK_CACHE", "1") != "0"
 
 # Switch matplotlib to the IPython "inline" backend before any cell
 # runs so ``plt.show()`` triggers Jupyter's display hook and embeds
@@ -208,11 +233,100 @@ def detect_language(nb: nbformat.NotebookNode) -> str:
     return (lang or "python").lower()
 
 
+# Files outside ``docs/notebooks/`` whose contents influence notebook
+# numerics. Hashed once into ``_shared_fingerprint`` and combined with
+# the notebook source to form each notebook's cache key.
+#
+# We intentionally do NOT hash Rust ``.rs`` sources — that would blow
+# up the fingerprint on cosmetic changes. Cargo.toml + Cargo.lock +
+# uv.lock cover dependency bumps and version changes; the nightly
+# full-rebuild job catches drift that slips through.
+def _shared_fingerprint_files() -> list[Path]:
+    files: list[Path] = []
+    for name in ("Cargo.lock", "Cargo.toml"):
+        p = REPO_ROOT / name
+        if p.exists():
+            files.append(p)
+    uv_lock = REPO_ROOT / "ppvm-python" / "uv.lock"
+    if uv_lock.exists():
+        files.append(uv_lock)
+    files.extend(sorted((REPO_ROOT / "crates").glob("*/Cargo.toml")))
+    return files
+
+
+def _compute_shared_fingerprint() -> bytes:
+    h = hashlib.sha256()
+    for f in _shared_fingerprint_files():
+        rel = f.relative_to(REPO_ROOT).as_posix()
+        h.update(rel.encode("utf-8"))
+        h.update(b"\0")
+        h.update(f.read_bytes())
+        h.update(b"\0")
+    return h.digest()
+
+
+_shared_fingerprint: bytes | None = None
+
+
+def shared_fingerprint() -> bytes:
+    global _shared_fingerprint
+    if _shared_fingerprint is None:
+        _shared_fingerprint = _compute_shared_fingerprint()
+    return _shared_fingerprint
+
+
+def notebook_cache_key(source: Path) -> str:
+    h = hashlib.sha256()
+    h.update(shared_fingerprint())
+    h.update(b"\0")
+    h.update(source.read_bytes())
+    return h.hexdigest()
+
+
+def _try_restore_from_cache(source: Path, slug: str) -> dict | None:
+    if not CACHE_ENABLED:
+        return None
+    key = notebook_cache_key(source)
+    html_cached = CACHE_DIR / f"{key}.html"
+    meta_cached = CACHE_DIR / f"{key}.json"
+    if not (html_cached.exists() and meta_cached.exists()):
+        return None
+    try:
+        meta = json.loads(meta_cached.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    # Slug may have changed since the cache entry was written (e.g. file
+    # rename). Trust the current slug; rewrite meta and copy under the
+    # current output name.
+    meta["slug"] = slug
+    shutil.copyfile(html_cached, OUTPUT_DIR / f"{slug}.html")
+    (OUTPUT_DIR / f"{slug}.json").write_text(
+        json.dumps(meta, indent=2), encoding="utf-8"
+    )
+    sys.stderr.write(f"[notebooks] cache hit  {source.name} ({key[:12]})\n")
+    return meta
+
+
+def _write_cache(source: Path, html: str, meta: dict) -> None:
+    if not CACHE_ENABLED:
+        return
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    key = notebook_cache_key(source)
+    (CACHE_DIR / f"{key}.html").write_text(html, encoding="utf-8")
+    (CACHE_DIR / f"{key}.json").write_text(
+        json.dumps(meta, indent=2), encoding="utf-8"
+    )
+
+
 def build_one(source: Path) -> dict:
-    sys.stderr.write(f"[notebooks] building {source.name}\n")
+    slug = slug_for(source)
+    cached = _try_restore_from_cache(source, slug)
+    if cached is not None:
+        return cached
+
+    sys.stderr.write(f"[notebooks] executing {source.name}\n")
     nb = jupytext.read(source, fmt="py:percent")
     title, headings = extract_title_and_headings(nb)
-    slug = slug_for(source)
     language = detect_language(nb)
 
     prepend_setup_cell(nb)
@@ -231,6 +345,7 @@ def build_one(source: Path) -> dict:
     (OUTPUT_DIR / f"{slug}.json").write_text(
         json.dumps(meta, indent=2), encoding="utf-8"
     )
+    _write_cache(source, html, meta)
     return meta
 
 

--- a/docs/src/pages/develop.astro
+++ b/docs/src/pages/develop.astro
@@ -297,7 +297,19 @@ npm run build          # extract everything, then `astro build` → dist/</code>
       keyed by
     </p>
 
-    <pre><code class="language-text">sha256(notebook source + Cargo.lock + Cargo.toml + crates/*/Cargo.toml + ppvm-python/uv.lock)</code></pre>
+    <pre><code class="language-text">sha256(CACHE_SCHEMA_VERSION + docs/scripts/build-notebooks.py + notebook source + Cargo.lock + Cargo.toml + crates/*/Cargo.toml + ppvm-python/uv.lock)</code></pre>
+
+    <p>
+      Hashing the extractor itself means that a change to the
+      rendering / sanitiser / matplotlib-setup logic invalidates
+      every cached entry automatically — without that, a tweak to the
+      bleach allow-list would silently keep serving the previous
+      HTML for every unchanged notebook source. The
+      <code>CACHE_SCHEMA_VERSION</code> constant at the top of the
+      script is an explicit global invalidation knob for changes the
+      hash can't see (e.g. a new field in the sidecar JSON that
+      downstream Astro pages start depending on).
+    </p>
 
     <p>
       On the next run the script restores from the cache when the hash
@@ -320,8 +332,11 @@ npm run build          # extract everything, then `astro build` → dist/</code>
       Rust crate without a dependency or Cargo.toml bump won't
       invalidate cached notebook outputs on a docs-only PR — rely on
       the standard test suites (<code>cargo test --workspace</code>,
-      <code>pytest</code>) plus the nightly full-rebuild to catch
-      those.
+      <code>pytest</code>) to catch those. (A scheduled full-rebuild
+      workflow as a second safety net would be a reasonable future
+      addition, but none exists today; bump
+      <code>CACHE_SCHEMA_VERSION</code> manually if you ever need to
+      force a global re-execution.)
     </p>
 
     <p>
@@ -347,17 +362,23 @@ npm run build          # extract everything, then `astro build` → dist/</code>
       Adding a new notebook: drop a Jupytext file under
       <code>docs/notebooks/</code> — no extractor change needed.
       Changing how notebooks render (sanitiser allow-list, matplotlib
-      DPI, output format): <code>docs/scripts/build-notebooks.py</code>.
-      Changing the fingerprint inputs (e.g. another lockfile becomes
-      relevant): edit <code>_shared_fingerprint_files()</code> in that
-      same script <em>and</em> the <code>hashFiles(...)</code> argument
-      on the cache step in
-      <code>.github/workflows/docs.yml</code> — those two lists must
-      stay in sync, otherwise the GH Actions cache key drifts from the
+      DPI, output format): <code>docs/scripts/build-notebooks.py</code>
+      — every edit to this file already invalidates the cache via the
+      fingerprint, so no version bump is needed for routine pipeline
+      tweaks. Changing the fingerprint <em>inputs</em> (e.g. another
+      lockfile becomes relevant): edit
+      <code>_shared_fingerprint_files()</code> in that same script
+      <em>and</em> the <code>hashFiles(...)</code> argument on the
+      cache step in <code>.github/workflows/docs.yml</code> — those
+      two lists must stay in sync (note that
+      <code>docs/scripts/build-notebooks.py</code> itself appears in
+      both), otherwise the GH Actions cache key drifts from the
       script's per-notebook key and you get either stale outputs or
-      perpetual misses. Bump the <code>notebooks-v1-</code> prefix in
-      the workflow to force-invalidate every cache entry if the
-      schema of cached artefacts changes incompatibly. Changing the
+      perpetual misses. To force a global invalidation independent of
+      file content (e.g. cached-artefact schema change), bump
+      <code>CACHE_SCHEMA_VERSION</code> in the script; bump the
+      <code>notebooks-v1-</code> prefix in the workflow when the GH
+      Actions cache itself needs a clean slate. Changing the
       Examples landing or per-notebook page chrome: the two
       <code>.astro</code> files under
       <code>docs/src/pages/examples/</code>.

--- a/docs/src/pages/develop.astro
+++ b/docs/src/pages/develop.astro
@@ -246,6 +246,123 @@ npm run build          # extract everything, then `astro build` → dist/</code>
       <code>src/generated/notebooks/index.json</code>.
     </p>
 
+    <h3 id="notebook-pipeline">2.1 Notebook execution &amp; caching</h3>
+
+    <p>
+      The script behind <code>npm run extract:notebooks</code> lives at
+      <code><a href="https://github.com/QuEraComputing/ppvm/blob/main/docs/scripts/build-notebooks.py">docs/scripts/build-notebooks.py</a></code>.
+      Per-notebook pipeline:
+    </p>
+
+    <ol>
+      <li>
+        Read the Jupytext <code>percent</code>-format <code>.py</code> file
+        and convert to an in-memory <code>ipynb</code>.
+      </li>
+      <li>
+        Prepend a hidden setup cell that switches matplotlib to the
+        IPython <code>inline</code> backend — without this, <code>plt.show()</code>
+        renders to a buffer that never reaches the cell output and plots
+        are silently dropped.
+      </li>
+      <li>
+        Execute every code cell via <code>nbclient</code>. Text output,
+        tracebacks, and matplotlib figures are captured inline; figures
+        are embedded as base64 PNGs.
+      </li>
+      <li>
+        Drop the hidden setup cell, render to an HTML fragment via
+        <code>nbconvert</code>'s <code>basic</code> template (no
+        JupyterLab chrome — the site stylesheet themes the
+        <code>.jp-*</code> classes), and sanitise through
+        <code>bleach</code> against an allow-list that permits
+        <code>data:image/png</code> URLs but strips scripts and
+        iframes.
+      </li>
+      <li>
+        Write <code>docs/src/generated/notebooks/&lt;slug&gt;.html</code> +
+        <code>&lt;slug&gt;.json</code> (title, ordered headings,
+        language, source path). The Astro routes at
+        <code>docs/src/pages/examples/index.astro</code> and
+        <code>[slug].astro</code> consume <code>index.json</code> +
+        the per-slug fragments at build time.
+      </li>
+    </ol>
+
+    <p>
+      <strong>Content-addressed cache.</strong> Executing every notebook
+      from scratch on every PR is expensive — the long-running examples
+      can dominate CI. To avoid that, every successful run also writes
+      its output to <code>docs/.notebook-cache/&lt;hash&gt;.&lbrace;html,json&rbrace;</code>,
+      keyed by
+    </p>
+
+    <pre><code class="language-text">sha256(notebook source + Cargo.lock + Cargo.toml + crates/*/Cargo.toml + ppvm-python/uv.lock)</code></pre>
+
+    <p>
+      On the next run the script restores from the cache when the hash
+      matches and only re-executes notebooks whose fingerprint
+      changed. CI persists the directory via <code>actions/cache</code>
+      keyed on the same set of files (see the "Restore executed-notebook
+      cache" step in
+      <code><a href="https://github.com/QuEraComputing/ppvm/blob/main/.github/workflows/docs.yml">.github/workflows/docs.yml</a></code>),
+      so a docs-only PR that touches only <code>.astro</code> or
+      <code>.css</code> hits the cache for every notebook and the
+      build takes seconds.
+    </p>
+
+    <p>
+      <strong>What the fingerprint deliberately does <em>not</em>
+      include</strong>: Rust <code>.rs</code> sources and Python
+      package sources. Hashing every workspace file would force a
+      re-execution on any cosmetic edit, which is exactly the cost we
+      want to avoid. The tradeoff is that a numerical change inside a
+      Rust crate without a dependency or Cargo.toml bump won't
+      invalidate cached notebook outputs on a docs-only PR — rely on
+      the standard test suites (<code>cargo test --workspace</code>,
+      <code>pytest</code>) plus the nightly full-rebuild to catch
+      those.
+    </p>
+
+    <p>
+      Override knobs (mostly for debugging):
+    </p>
+
+    <ul>
+      <li>
+        <code>PPVM_NOTEBOOK_CACHE=0</code> — force re-execution of every
+        notebook regardless of cache state (use when investigating
+        suspected numerical drift).
+      </li>
+      <li>
+        <code>PPVM_NOTEBOOK_CACHE_DIR=&lt;path&gt;</code> — point the
+        cache at a non-default directory (CI uses this implicitly via
+        the default <code>docs/.notebook-cache</code>; tweak only if
+        you need to share a cache across worktrees).
+      </li>
+    </ul>
+
+    <p>
+      <strong>Where to look when you need to change this.</strong>
+      Adding a new notebook: drop a Jupytext file under
+      <code>docs/notebooks/</code> — no extractor change needed.
+      Changing how notebooks render (sanitiser allow-list, matplotlib
+      DPI, output format): <code>docs/scripts/build-notebooks.py</code>.
+      Changing the fingerprint inputs (e.g. another lockfile becomes
+      relevant): edit <code>_shared_fingerprint_files()</code> in that
+      same script <em>and</em> the <code>hashFiles(...)</code> argument
+      on the cache step in
+      <code>.github/workflows/docs.yml</code> — those two lists must
+      stay in sync, otherwise the GH Actions cache key drifts from the
+      script's per-notebook key and you get either stale outputs or
+      perpetual misses. Bump the <code>notebooks-v1-</code> prefix in
+      the workflow to force-invalidate every cache entry if the
+      schema of cached artefacts changes incompatibly. Changing the
+      Examples landing or per-notebook page chrome: the two
+      <code>.astro</code> files under
+      <code>docs/src/pages/examples/</code>.
+    </p>
+
     <p>
       Local prerequisites the scripts assume: <code>node ≥ 20</code>
       (Astro 5), <code>uv</code>, Rust nightly


### PR DESCRIPTION
## Summary

- New executed-notebook example **Dephased Nearest-Neighbour XY Chain** at `docs/notebooks/nearest_neighbor_dephasing.py`. It Trotterises the XY chain under local dephasing in the Heisenberg picture and compares ppvm against an exact bilinear free-fermion benchmark (autocorrelator, spatial profile, low-momentum mode decay, diffusion-constant fit, and a Trotter-vs-truncation error sweep). Renders at `/examples/nearest-neighbor-dephasing` with all 6 matplotlib figures embedded as inline base64 PNGs.
- Content-addressed cache for executed notebooks. `build-notebooks.py` writes each executed notebook's HTML/JSON to `docs/.notebook-cache/<sha256>.{html,json}`, keyed by `notebook source + every Cargo.toml + Cargo.lock + ppvm-python/uv.lock`. The docs workflow restores that directory via `actions/cache`, so a docs-only PR (CSS, Astro layout, prose tweaks) reuses cached notebook outputs instead of re-executing every notebook from scratch — cutting most docs PRs from ~minutes back to seconds. `PPVM_NOTEBOOK_CACHE=0` forces a clean re-execution.
- Documents the pipeline, fingerprint scope, and override knobs in a new `§ 2.1 Notebook execution & caching` of the Developer Guide, and adds a TL;DR + sync-warning bullet in `AGENTS.md` so future agents know the script's `_shared_fingerprint_files()` and the workflow's `hashFiles(...)` list must stay in sync.

The fingerprint **deliberately** excludes Rust `.rs` and Python package sources — hashing those would invalidate the cache on cosmetic changes. The tradeoff (a numerical change without a Cargo.toml/lockfile bump won't trigger re-execution on a docs-only PR) is documented in the guide; the existing `cargo test --workspace` and `pytest` suites plus a future nightly full-rebuild are the safety net.

## Test plan

- [x] `npm run extract:notebooks` cold — all three notebooks execute and produce HTML fragments with embedded PNGs.
- [x] `npm run extract:notebooks` warm — all three report `cache hit` and the build finishes in seconds.
- [x] `PPVM_NOTEBOOK_CACHE=0 npm run extract:notebooks` — forces re-execution as expected.
- [x] `npm run astro:build` — all 15 pages render including `/examples/nearest-neighbor-dephasing/` and the updated `/develop/`.
- [ ] First CI run on this PR populates the cache; a follow-up no-op push should hit the cache on the "Restore executed-notebook cache" step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)