### PR TITLE
docs: smoke-test the notebook-execution cache

### DIFF
--- a/docs/src/pages/develop.astro
+++ b/docs/src/pages/develop.astro
@@ -319,8 +319,8 @@ npm run build          # extract everything, then `astro build` → dist/</code>
       cache" step in
       <code><a href="https://github.com/QuEraComputing/ppvm/blob/main/.github/workflows/docs.yml">.github/workflows/docs.yml</a></code>),
       so a docs-only PR that touches only <code>.astro</code> or
-      <code>.css</code> hits the cache for every notebook and the
-      build takes seconds.
+      <code>.css</code> files hits the cache for every notebook and
+      the build completes in seconds.
     </p>
 
     <p>


### PR DESCRIPTION
## Summary

Smoke-tests the content-addressed notebook cache introduced in #90. This PR's diff is a one-sentence wording polish in `§ 2.1` of the Developer Guide — none of the inputs that go into the per-notebook fingerprint (`docs/notebooks/**/*.py`, `docs/scripts/build-notebooks.py`, every `Cargo.toml`, `Cargo.lock`, `ppvm-python/uv.lock`) are touched.

If the cache is wired up correctly, the docs build job should:

- Restore `docs/.notebook-cache/` via `actions/cache` (the key derived from `hashFiles(...)` matches the one #90 produced after merge to `main`).
- Have `build-notebooks.py` print `[notebooks] cache hit  <name>` for **all three** notebooks (`msd.py`, `nearest_neighbor_dephasing.py`, `trotter.py`) — no executions.
- Finish the `extract:notebooks` step in seconds rather than minutes.

This is the meta-test: not "does the docs site still build" (we know it does) but "does the cache that we just added actually let unrelated PRs skip notebook execution end-to-end through GH Actions cache restore?".

## Test plan

- [ ] CI's "Build Astro site" job logs show three `cache hit` lines from `[notebooks]` and zero `executing` lines.
- [ ] The cache step reports a `Cache hit for primary key`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)