### PR TITLE
feat(python): per-gate truncate kwarg + explicit PauliSum.truncate()

### DIFF
--- a/crates/ppvm-python-native/src/interface.rs
+++ b/crates/ppvm-python-native/src/interface.rs
@@ -13,19 +13,34 @@ macro_rules! create_interface_loss_methods {
     ($name: ident, $type: ident, true) => {
         #[pymethods]
         impl $name {
-            pub fn loss_channel(&mut self, addr0: usize, p: f64) {
+            #[pyo3(signature = (addr0, p, truncate = true))]
+            pub fn loss_channel(&mut self, addr0: usize, p: f64, truncate: bool) {
                 self.inner.loss_channel(addr0, p);
-                self.inner.truncate();
+                if truncate {
+                    self.inner.truncate();
+                }
             }
 
-            pub fn correlated_loss_channel(&mut self, addr0: usize, addr1: usize, p: [f64; 3]) {
+            #[pyo3(signature = (addr0, addr1, p, truncate = true))]
+            pub fn correlated_loss_channel(
+                &mut self,
+                addr0: usize,
+                addr1: usize,
+                p: [f64; 3],
+                truncate: bool,
+            ) {
                 self.inner.correlated_loss_channel(addr0, addr1, p);
-                self.inner.truncate();
+                if truncate {
+                    self.inner.truncate();
+                }
             }
 
-            pub fn reset_loss_channel(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn reset_loss_channel(&mut self, addr0: usize, truncate: bool) {
                 self.inner.reset_loss_channel(addr0);
-                self.inner.truncate();
+                if truncate {
+                    self.inner.truncate();
+                }
             }
         }
     };
@@ -115,125 +130,169 @@ macro_rules! create_interface {
             // NOTE: macros can't be used in pymethods block
             // could either use multiple-pymethods feature (adds dependencies)
             // or better yet create working impl for all strategies
+            //
+            // Every gate exposes a `truncate: bool = True` kwarg. When
+            // `True` (the default) the inner `truncate()` runs immediately
+            // after the gate, matching the historical behaviour. Pass
+            // `truncate=False` to defer the cut — useful for chaining
+            // commuting gates (e.g. `rxx + ryy` on the same edge, or any
+            // other U(1)/Z₂-conserving composition) where truncating
+            // between them would break a conserved-charge structure that
+            // truncating only once at the end preserves.
+
+            /// Explicit truncate. Use with `truncate=False` on the gates
+            /// above to control exactly when the active strategy fires.
+            pub fn truncate(&mut self) {
+                self.inner.truncate();
+            }
 
             // clifford
-            pub fn x(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn x(&mut self, addr0: usize, truncate: bool) {
                 self.inner.x(addr0);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn y(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn y(&mut self, addr0: usize, truncate: bool) {
                 self.inner.y(addr0);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn z(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn z(&mut self, addr0: usize, truncate: bool) {
                 self.inner.z(addr0);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn h(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn h(&mut self, addr0: usize, truncate: bool) {
                 self.inner.h(addr0);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn s(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn s(&mut self, addr0: usize, truncate: bool) {
                 self.inner.s(addr0);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn cnot(&mut self, addr0: usize, addr1: usize) {
+            #[pyo3(signature = (addr0, addr1, truncate = true))]
+            pub fn cnot(&mut self, addr0: usize, addr1: usize, truncate: bool) {
                 self.inner.cnot(addr0, addr1);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn cz(&mut self, addr0: usize, addr1: usize) {
+            #[pyo3(signature = (addr0, addr1, truncate = true))]
+            pub fn cz(&mut self, addr0: usize, addr1: usize, truncate: bool) {
                 self.inner.cz(addr0, addr1);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
             // clifford extensions
-            pub fn s_adj(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn s_adj(&mut self, addr0: usize, truncate: bool) {
                 self.inner.s_adj(addr0);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn sqrt_x(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn sqrt_x(&mut self, addr0: usize, truncate: bool) {
                 self.inner.sqrt_x(addr0);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn sqrt_y(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn sqrt_y(&mut self, addr0: usize, truncate: bool) {
                 self.inner.sqrt_y(addr0);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn sqrt_x_adj(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn sqrt_x_adj(&mut self, addr0: usize, truncate: bool) {
                 self.inner.sqrt_x_adj(addr0);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn sqrt_y_adj(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn sqrt_y_adj(&mut self, addr0: usize, truncate: bool) {
                 self.inner.sqrt_y_adj(addr0);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
             // rot1
-            pub fn rx(&mut self, addr0: usize, theta: f64) {
+            #[pyo3(signature = (addr0, theta, truncate = true))]
+            pub fn rx(&mut self, addr0: usize, theta: f64, truncate: bool) {
                 self.inner.rx(addr0, theta);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn ry(&mut self, addr0: usize, theta: f64) {
+            #[pyo3(signature = (addr0, theta, truncate = true))]
+            pub fn ry(&mut self, addr0: usize, theta: f64, truncate: bool) {
                 self.inner.ry(addr0, theta);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn rz(&mut self, addr0: usize, theta: f64) {
+            #[pyo3(signature = (addr0, theta, truncate = true))]
+            pub fn rz(&mut self, addr0: usize, theta: f64, truncate: bool) {
                 self.inner.rz(addr0, theta);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
             // rot2
-            pub fn rxx(&mut self, addr0: usize, addr1: usize, theta: f64) {
+            #[pyo3(signature = (addr0, addr1, theta, truncate = true))]
+            pub fn rxx(&mut self, addr0: usize, addr1: usize, theta: f64, truncate: bool) {
                 self.inner.rxx(addr0, addr1, theta);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn ryy(&mut self, addr0: usize, addr1: usize, theta: f64) {
+            #[pyo3(signature = (addr0, addr1, theta, truncate = true))]
+            pub fn ryy(&mut self, addr0: usize, addr1: usize, theta: f64, truncate: bool) {
                 self.inner.ryy(addr0, addr1, theta);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn rzz(&mut self, addr0: usize, addr1: usize, theta: f64) {
+            #[pyo3(signature = (addr0, addr1, theta, truncate = true))]
+            pub fn rzz(&mut self, addr0: usize, addr1: usize, theta: f64, truncate: bool) {
                 self.inner.rzz(addr0, addr1, theta);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
             // noise
-            pub fn pauli_error(&mut self, addr0: usize, p: [f64; 3]) {
+            #[pyo3(signature = (addr0, p, truncate = true))]
+            pub fn pauli_error(&mut self, addr0: usize, p: [f64; 3], truncate: bool) {
                 self.inner.pauli_error(addr0, p);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn two_qubit_pauli_error(&mut self, addr0: usize, addr1: usize, p: [f64; 15]) {
+            #[pyo3(signature = (addr0, addr1, p, truncate = true))]
+            pub fn two_qubit_pauli_error(
+                &mut self,
+                addr0: usize,
+                addr1: usize,
+                p: [f64; 15],
+                truncate: bool,
+            ) {
                 self.inner.two_qubit_pauli_error(addr0, addr1, p);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn depolarize(&mut self, addr0: usize, p: f64) {
+            #[pyo3(signature = (addr0, p, truncate = true))]
+            pub fn depolarize(&mut self, addr0: usize, p: f64, truncate: bool) {
                 self.inner.depolarize(addr0, p);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn depolarize2(&mut self, addr0: usize, addr1: usize, p: f64) {
+            #[pyo3(signature = (addr0, addr1, p, truncate = true))]
+            pub fn depolarize2(&mut self, addr0: usize, addr1: usize, p: f64, truncate: bool) {
                 self.inner.depolarize2(addr0, addr1, p);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
-            pub fn amplitude_damping(&mut self, addr0: usize, gamma: f64) {
+            #[pyo3(signature = (addr0, gamma, truncate = true))]
+            pub fn amplitude_damping(&mut self, addr0: usize, gamma: f64, truncate: bool) {
                 self.inner.amplitude_damping(addr0, gamma);
-                self.inner.truncate();
+                if truncate { self.inner.truncate(); }
             }
 
 

--- a/crates/ppvm-python-native/src/interface_tableau.rs
+++ b/crates/ppvm-python-native/src/interface_tableau.rs
@@ -45,57 +45,91 @@ macro_rules! create_interface {
                 self.inner.measure(addr0)
             }
 
+            // All gate methods take a `truncate: bool = true` kwarg
+            // purely for API symmetry with `PauliSum` (which uses it to
+            // defer the auto-truncate). `GeneralizedTableau` has no
+            // analogous truncation step — the tableau representation is
+            // exact — so the kwarg is silently ignored here. Keeping the
+            // signature parallel lets the Python `RotationsMixin` /
+            // `CliffordMixin` / etc. work uniformly across both backends.
+
             // clifford
-            pub fn x(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn x(&mut self, addr0: usize, truncate: bool) {
+                let _ = truncate;
                 self.inner.x(addr0);
             }
 
-            pub fn y(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn y(&mut self, addr0: usize, truncate: bool) {
+                let _ = truncate;
                 self.inner.y(addr0);
             }
 
-            pub fn z(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn z(&mut self, addr0: usize, truncate: bool) {
+                let _ = truncate;
                 self.inner.z(addr0);
             }
 
-            pub fn h(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn h(&mut self, addr0: usize, truncate: bool) {
+                let _ = truncate;
                 self.inner.h(addr0);
             }
 
-            pub fn s(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn s(&mut self, addr0: usize, truncate: bool) {
+                let _ = truncate;
                 self.inner.s(addr0);
             }
 
-            pub fn s_adj(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn s_adj(&mut self, addr0: usize, truncate: bool) {
+                let _ = truncate;
                 self.inner.s_adj(addr0);
             }
 
             // clifford extensions
-            pub fn sqrt_x(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn sqrt_x(&mut self, addr0: usize, truncate: bool) {
+                let _ = truncate;
                 self.inner.sqrt_x(addr0);
             }
 
-            pub fn sqrt_x_adj(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn sqrt_x_adj(&mut self, addr0: usize, truncate: bool) {
+                let _ = truncate;
                 self.inner.sqrt_x_adj(addr0);
             }
 
-            pub fn sqrt_y(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn sqrt_y(&mut self, addr0: usize, truncate: bool) {
+                let _ = truncate;
                 self.inner.sqrt_y(addr0);
             }
 
-            pub fn sqrt_y_adj(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn sqrt_y_adj(&mut self, addr0: usize, truncate: bool) {
+                let _ = truncate;
                 self.inner.sqrt_y_adj(addr0);
             }
 
-            pub fn cnot(&mut self, addr0: usize, addr1: usize) {
+            #[pyo3(signature = (addr0, addr1, truncate = true))]
+            pub fn cnot(&mut self, addr0: usize, addr1: usize, truncate: bool) {
+                let _ = truncate;
                 self.inner.cnot(addr0, addr1);
             }
 
-            pub fn cy(&mut self, addr0: usize, addr1: usize) {
+            #[pyo3(signature = (addr0, addr1, truncate = true))]
+            pub fn cy(&mut self, addr0: usize, addr1: usize, truncate: bool) {
+                let _ = truncate;
                 self.inner.cy(addr0, addr1);
             }
 
-            pub fn cz(&mut self, addr0: usize, addr1: usize) {
+            #[pyo3(signature = (addr0, addr1, truncate = true))]
+            pub fn cz(&mut self, addr0: usize, addr1: usize, truncate: bool) {
+                let _ = truncate;
                 self.inner.cz(addr0, addr1);
             }
 
@@ -108,15 +142,21 @@ macro_rules! create_interface {
             }
 
             // rot1
-            pub fn rx(&mut self, addr0: usize, theta: f64) {
+            #[pyo3(signature = (addr0, theta, truncate = true))]
+            pub fn rx(&mut self, addr0: usize, theta: f64, truncate: bool) {
+                let _ = truncate;
                 self.inner.rx(addr0, theta);
             }
 
-            pub fn ry(&mut self, addr0: usize, theta: f64) {
+            #[pyo3(signature = (addr0, theta, truncate = true))]
+            pub fn ry(&mut self, addr0: usize, theta: f64, truncate: bool) {
+                let _ = truncate;
                 self.inner.ry(addr0, theta);
             }
 
-            pub fn rz(&mut self, addr0: usize, theta: f64) {
+            #[pyo3(signature = (addr0, theta, truncate = true))]
+            pub fn rz(&mut self, addr0: usize, theta: f64, truncate: bool) {
+                let _ = truncate;
                 self.inner.rz(addr0, theta);
             }
 
@@ -125,44 +165,76 @@ macro_rules! create_interface {
             }
 
             // rot2
-            pub fn rxx(&mut self, addr0: usize, addr1: usize, theta: f64) {
+            #[pyo3(signature = (addr0, addr1, theta, truncate = true))]
+            pub fn rxx(&mut self, addr0: usize, addr1: usize, theta: f64, truncate: bool) {
+                let _ = truncate;
                 self.inner.rxx(addr0, addr1, theta);
             }
 
-            pub fn ryy(&mut self, addr0: usize, addr1: usize, theta: f64) {
+            #[pyo3(signature = (addr0, addr1, theta, truncate = true))]
+            pub fn ryy(&mut self, addr0: usize, addr1: usize, theta: f64, truncate: bool) {
+                let _ = truncate;
                 self.inner.ryy(addr0, addr1, theta);
             }
 
-            pub fn rzz(&mut self, addr0: usize, addr1: usize, theta: f64) {
+            #[pyo3(signature = (addr0, addr1, theta, truncate = true))]
+            pub fn rzz(&mut self, addr0: usize, addr1: usize, theta: f64, truncate: bool) {
+                let _ = truncate;
                 self.inner.rzz(addr0, addr1, theta);
             }
 
             // noise
-            pub fn pauli_error(&mut self, addr0: usize, p: [f64; 3]) {
+            #[pyo3(signature = (addr0, p, truncate = true))]
+            pub fn pauli_error(&mut self, addr0: usize, p: [f64; 3], truncate: bool) {
+                let _ = truncate;
                 self.inner.pauli_error(addr0, p);
             }
 
-            pub fn depolarize(&mut self, addr0: usize, p: f64) {
+            #[pyo3(signature = (addr0, p, truncate = true))]
+            pub fn depolarize(&mut self, addr0: usize, p: f64, truncate: bool) {
+                let _ = truncate;
                 self.inner.depolarize(addr0, p);
             }
 
-            pub fn depolarize2(&mut self, addr0: usize, addr1: usize, p: f64) {
+            #[pyo3(signature = (addr0, addr1, p, truncate = true))]
+            pub fn depolarize2(&mut self, addr0: usize, addr1: usize, p: f64, truncate: bool) {
+                let _ = truncate;
                 self.inner.depolarize2(addr0, addr1, p);
             }
 
-            pub fn two_qubit_pauli_error(&mut self, addr0: usize, addr1: usize, p: [f64; 15]) {
+            #[pyo3(signature = (addr0, addr1, p, truncate = true))]
+            pub fn two_qubit_pauli_error(
+                &mut self,
+                addr0: usize,
+                addr1: usize,
+                p: [f64; 15],
+                truncate: bool,
+            ) {
+                let _ = truncate;
                 self.inner.two_qubit_pauli_error(addr0, addr1, p);
             }
 
-            pub fn loss_channel(&mut self, addr0: usize, p: f64) {
+            #[pyo3(signature = (addr0, p, truncate = true))]
+            pub fn loss_channel(&mut self, addr0: usize, p: f64, truncate: bool) {
+                let _ = truncate;
                 self.inner.loss_channel(addr0, p);
             }
 
-            pub fn correlated_loss_channel(&mut self, addr0: usize, addr1: usize, p: [f64; 3]) {
+            #[pyo3(signature = (addr0, addr1, p, truncate = true))]
+            pub fn correlated_loss_channel(
+                &mut self,
+                addr0: usize,
+                addr1: usize,
+                p: [f64; 3],
+                truncate: bool,
+            ) {
+                let _ = truncate;
                 self.inner.correlated_loss_channel(addr0, addr1, p);
             }
 
-            pub fn reset_loss_channel(&mut self, addr0: usize) {
+            #[pyo3(signature = (addr0, truncate = true))]
+            pub fn reset_loss_channel(&mut self, addr0: usize, truncate: bool) {
+                let _ = truncate;
                 self.inner.reset_loss_channel(addr0);
             }
 

--- a/ppvm-python/src/ppvm/mixins.py
+++ b/ppvm-python/src/ppvm/mixins.py
@@ -4,76 +4,94 @@
 from collections.abc import Sequence
 from typing import Any
 
+# Every gate method below takes an optional ``truncate: bool = True`` kwarg.
+# When ``True`` (the default), the configured truncation strategy fires
+# immediately after the gate — historical behaviour. Pass ``truncate=False``
+# to defer the cut; the user is then responsible for calling
+# :meth:`PauliSum.truncate` explicitly when the next truncation point is
+# reached. This is the supported way to chain commuting gates (e.g.
+# ``rxx + ryy`` on the same edge for a U(1)-conserving exchange step)
+# without losing a conserved-charge component to intermediate truncation.
+
 
 # TODO: also use this in PauliSum
 class CliffordMixin:
     _interface: Any
 
     # Clifford operations
-    def x(self, addr0: int) -> None:
+    def x(self, addr0: int, *, truncate: bool = True) -> None:
         """Apply a Pauli X gate to the specified qubit.
 
         Args:
             addr0: The index of the target qubit.
+            truncate: If ``True`` (default), run the configured truncation
+                strategy after the gate; if ``False``, leave the map
+                untruncated so the next gate sees the full unpruned state.
         """
-        self._interface.x(addr0)
+        self._interface.x(addr0, truncate=truncate)
 
-    def y(self, addr0: int) -> None:
+    def y(self, addr0: int, *, truncate: bool = True) -> None:
         """Apply a Pauli Y gate to the specified qubit.
 
         Args:
             addr0: The index of the target qubit.
+            truncate: See :meth:`x`.
         """
-        self._interface.y(addr0)
+        self._interface.y(addr0, truncate=truncate)
 
-    def z(self, addr0: int) -> None:
+    def z(self, addr0: int, *, truncate: bool = True) -> None:
         """Apply a Pauli Z gate to the specified qubit.
 
         Args:
             addr0: The index of the target qubit.
+            truncate: See :meth:`x`.
         """
-        self._interface.z(addr0)
+        self._interface.z(addr0, truncate=truncate)
 
-    def h(self, addr0: int) -> None:
+    def h(self, addr0: int, *, truncate: bool = True) -> None:
         """Apply a Hadamard gate to the specified qubit.
 
         Args:
             addr0: The index of the target qubit.
+            truncate: See :meth:`x`.
         """
-        self._interface.h(addr0)
+        self._interface.h(addr0, truncate=truncate)
 
-    def s(self, addr0: int) -> None:
+    def s(self, addr0: int, *, truncate: bool = True) -> None:
         """Apply an S gate (sqrt(Z)) to the specified qubit.
 
         Args:
             addr0: The index of the target qubit.
+            truncate: See :meth:`x`.
         """
-        self._interface.s(addr0)
+        self._interface.s(addr0, truncate=truncate)
 
-    def cnot(self, addr0: int, addr1: int) -> None:
+    def cnot(self, addr0: int, addr1: int, *, truncate: bool = True) -> None:
         """Apply a CNOT (controlled-X) gate.
 
         Args:
             addr0: The index of the control qubit.
             addr1: The index of the target qubit.
+            truncate: See :meth:`x`.
         """
-        self._interface.cnot(addr0, addr1)
+        self._interface.cnot(addr0, addr1, truncate=truncate)
 
-    def cz(self, addr0: int, addr1: int) -> None:
+    def cz(self, addr0: int, addr1: int, *, truncate: bool = True) -> None:
         """Apply a CZ (controlled-Z) gate.
 
         Args:
             addr0: The index of the first qubit.
             addr1: The index of the second qubit.
+            truncate: See :meth:`x`.
         """
-        self._interface.cz(addr0, addr1)
+        self._interface.cz(addr0, addr1, truncate=truncate)
 
 
 class RotationsMixin:
     _interface: Any
 
     # Rotations
-    def rx(self, addr0: int, theta: float) -> None:
+    def rx(self, addr0: int, theta: float, *, truncate: bool = True) -> None:
         """Apply an RX rotation gate to the specified qubit.
 
         ```math
@@ -83,10 +101,12 @@ class RotationsMixin:
         Args:
             addr0: The index of the target qubit.
             theta: The rotation angle in radians.
+            truncate: If ``True`` (default), run the configured truncation
+                strategy after the gate; if ``False``, defer it.
         """
-        self._interface.rx(addr0, theta)
+        self._interface.rx(addr0, theta, truncate=truncate)
 
-    def ry(self, addr0: int, theta: float) -> None:
+    def ry(self, addr0: int, theta: float, *, truncate: bool = True) -> None:
         """Apply an RY rotation gate to the specified qubit.
 
         ```math
@@ -96,10 +116,11 @@ class RotationsMixin:
         Args:
             addr0: The index of the target qubit.
             theta: The rotation angle in radians.
+            truncate: See :meth:`rx`.
         """
-        self._interface.ry(addr0, theta)
+        self._interface.ry(addr0, theta, truncate=truncate)
 
-    def rz(self, addr0: int, theta: float) -> None:
+    def rz(self, addr0: int, theta: float, *, truncate: bool = True) -> None:
         """Apply an RZ rotation gate to the specified qubit.
 
         ```math
@@ -109,11 +130,12 @@ class RotationsMixin:
         Args:
             addr0: The index of the target qubit.
             theta: The rotation angle in radians.
+            truncate: See :meth:`rx`.
         """
-        self._interface.rz(addr0, theta)
+        self._interface.rz(addr0, theta, truncate=truncate)
 
     # Two qubit rotations
-    def rxx(self, addr0: int, addr1: int, theta: float) -> None:
+    def rxx(self, addr0: int, addr1: int, theta: float, *, truncate: bool = True) -> None:
         """Apply an RXX (Ising XX) rotation gate to two qubits.
 
         ```math
@@ -124,10 +146,16 @@ class RotationsMixin:
             addr0: The index of the first qubit.
             addr1: The index of the second qubit.
             theta: The rotation angle in radians.
+            truncate: If ``True`` (default), run the configured truncation
+                strategy after the gate. Set to ``False`` to compose a
+                U(1)-conserving step like ``rxx + ryy`` on the same edge
+                without dropping the conserved-charge component between
+                them — then call :meth:`PauliSum.truncate` once at the
+                end of the composition.
         """
-        self._interface.rxx(addr0, addr1, theta)
+        self._interface.rxx(addr0, addr1, theta, truncate=truncate)
 
-    def ryy(self, addr0: int, addr1: int, theta: float) -> None:
+    def ryy(self, addr0: int, addr1: int, theta: float, *, truncate: bool = True) -> None:
         """Apply an RYY (Ising YY) rotation gate to two qubits.
 
         ```math
@@ -138,10 +166,11 @@ class RotationsMixin:
             addr0: The index of the first qubit.
             addr1: The index of the second qubit.
             theta: The rotation angle in radians.
+            truncate: See :meth:`rxx`.
         """
-        self._interface.ryy(addr0, addr1, theta)
+        self._interface.ryy(addr0, addr1, theta, truncate=truncate)
 
-    def rzz(self, addr0: int, addr1: int, theta: float) -> None:
+    def rzz(self, addr0: int, addr1: int, theta: float, *, truncate: bool = True) -> None:
         """Apply an RZZ (Ising ZZ) rotation gate to two qubits.
 
         ```math
@@ -152,52 +181,58 @@ class RotationsMixin:
             addr0: The index of the first qubit.
             addr1: The index of the second qubit.
             theta: The rotation angle in radians.
+            truncate: See :meth:`rxx`.
         """
-        self._interface.rzz(addr0, addr1, theta)
+        self._interface.rzz(addr0, addr1, theta, truncate=truncate)
 
 
 class CliffordExtensionMixin:
     _interface: Any
 
-    def s_adj(self, addr0: int) -> None:
+    def s_adj(self, addr0: int, *, truncate: bool = True) -> None:
         """Apply an S adjoint gate (sqrt(Z) dagger) to the specified qubit.
 
         Args:
             addr0: The index of the target qubit.
+            truncate: See :meth:`CliffordMixin.x`.
         """
-        self._interface.s_adj(addr0)
+        self._interface.s_adj(addr0, truncate=truncate)
 
-    def sqrt_x(self, addr0: int) -> None:
+    def sqrt_x(self, addr0: int, *, truncate: bool = True) -> None:
         """Apply a sqrt(X) gate to the specified qubit.
 
         Args:
             addr0: The index of the target qubit.
+            truncate: See :meth:`CliffordMixin.x`.
         """
-        self._interface.sqrt_x(addr0)
+        self._interface.sqrt_x(addr0, truncate=truncate)
 
-    def sqrt_y(self, addr0: int) -> None:
+    def sqrt_y(self, addr0: int, *, truncate: bool = True) -> None:
         """Apply a sqrt(Y) gate to the specified qubit.
 
         Args:
             addr0: The index of the target qubit.
+            truncate: See :meth:`CliffordMixin.x`.
         """
-        self._interface.sqrt_y(addr0)
+        self._interface.sqrt_y(addr0, truncate=truncate)
 
-    def sqrt_x_adj(self, addr0: int) -> None:
+    def sqrt_x_adj(self, addr0: int, *, truncate: bool = True) -> None:
         """Apply a sqrt(X) adjoint gate to the specified qubit.
 
         Args:
             addr0: The index of the target qubit.
+            truncate: See :meth:`CliffordMixin.x`.
         """
-        self._interface.sqrt_x_adj(addr0)
+        self._interface.sqrt_x_adj(addr0, truncate=truncate)
 
-    def sqrt_y_adj(self, addr0: int) -> None:
+    def sqrt_y_adj(self, addr0: int, *, truncate: bool = True) -> None:
         """Apply a sqrt(Y) adjoint gate to the specified qubit.
 
         Args:
             addr0: The index of the target qubit.
+            truncate: See :meth:`CliffordMixin.x`.
         """
-        self._interface.sqrt_y_adj(addr0)
+        self._interface.sqrt_y_adj(addr0, truncate=truncate)
 
     def cy(self, addr0: int, addr1: int) -> None:
         """Apply a controlled-Y gate.
@@ -213,15 +248,19 @@ class NoiseMixin:
     _interface: Any
 
     # Noise operations
-    def pauli_error(self, addr0: int, p: Sequence[float]) -> None:
+    def pauli_error(
+        self, addr0: int, p: Sequence[float], *, truncate: bool = True
+    ) -> None:
         """Apply a single-qubit Pauli error channel.
 
         Args:
             addr0: The index of the target qubit.
             p: Error probabilities [p_x, p_y, p_z] for X, Y, Z errors.
                 The identity probability is implicitly 1 - sum(p).
+            truncate: If ``True`` (default), run the configured truncation
+                strategy after the channel; if ``False``, defer it.
         """
-        self._interface.pauli_error(addr0, p)
+        self._interface.pauli_error(addr0, p, truncate=truncate)
 
     @staticmethod
     def two_qubit_pauli_error_probabilities(
@@ -259,7 +298,14 @@ class NoiseMixin:
         )
         return [error_probabilities.get(key, 0.0) for key in keys]
 
-    def two_qubit_pauli_error(self, addr0: int, addr1: int, p: Sequence[float]) -> None:
+    def two_qubit_pauli_error(
+        self,
+        addr0: int,
+        addr1: int,
+        p: Sequence[float],
+        *,
+        truncate: bool = True,
+    ) -> None:
         """Apply a two-qubit Pauli error channel.
 
         Args:
@@ -268,43 +314,57 @@ class NoiseMixin:
             p: Error probabilities for the 15 non-identity two-qubit Pauli
                 operators. Use two_qubit_pauli_error_probabilities to convert
                 from a dictionary format.
+            truncate: See :meth:`pauli_error`.
         """
-        self._interface.two_qubit_pauli_error(addr0, addr1, p)
+        self._interface.two_qubit_pauli_error(addr0, addr1, p, truncate=truncate)
 
     # additional noise methods
-    def depolarize(self, addr0: int, p: float) -> None:
+    def depolarize(self, addr0: int, p: float, *, truncate: bool = True) -> None:
         """Apply a depolarizing channel to the specified qubit.
 
         Args:
             addr0: The index of the target qubit.
             p: The depolarizing probability.
+            truncate: See :meth:`pauli_error`.
         """
-        self._interface.depolarize(addr0, p)
+        self._interface.depolarize(addr0, p, truncate=truncate)
 
-    def depolarize2(self, addr0: int, addr1: int, p: float) -> None:
+    def depolarize2(
+        self, addr0: int, addr1: int, p: float, *, truncate: bool = True
+    ) -> None:
         """Apply a two-qubit depolarizing channel to the specified qubits.
 
         Args:
             addr0: The index of the first target qubit.
             addr1: The index of the second target qubit.
             p: The depolarizing probability.
+            truncate: See :meth:`pauli_error`.
         """
-        self._interface.depolarize2(addr0, addr1, p)
+        self._interface.depolarize2(addr0, addr1, p, truncate=truncate)
 
 
 class LossMixin:
     _interface: Any
 
-    def loss_channel(self, addr0: int, p: float) -> None:
+    def loss_channel(self, addr0: int, p: float, *, truncate: bool = True) -> None:
         """Apply a loss channel to the specified qubit.
 
         Args:
             addr0: The index of the target qubit.
             p: The loss probability.
+            truncate: If ``True`` (default), run the configured truncation
+                strategy after the channel; if ``False``, defer it.
         """
-        self._interface.loss_channel(addr0, p)
+        self._interface.loss_channel(addr0, p, truncate=truncate)
 
-    def correlated_loss_channel(self, addr0: int, addr1: int, p: Sequence[float]) -> None:
+    def correlated_loss_channel(
+        self,
+        addr0: int,
+        addr1: int,
+        p: Sequence[float],
+        *,
+        truncate: bool = True,
+    ) -> None:
         """Apply a correlated loss channel to two qubits.
 
         Args:
@@ -318,5 +378,6 @@ class LossMixin:
                   are in the qubit subspace (which qubit is lost is 50/50 random).
                 - ``p[2]``: probability of losing the remaining active qubit
                   when the other has already been lost prior to this channel.
+            truncate: See :meth:`loss_channel`.
         """
-        self._interface.correlated_loss_channel(addr0, addr1, p)
+        self._interface.correlated_loss_channel(addr0, addr1, p, truncate=truncate)

--- a/ppvm-python/src/ppvm/paulisum.py
+++ b/ppvm-python/src/ppvm/paulisum.py
@@ -366,18 +366,34 @@ class PauliSum(
         """
         return self._interface.trace(pattern)
 
-    def amplitude_damping(self, addr0: int, gamma: float):
+    def amplitude_damping(self, addr0: int, gamma: float, *, truncate: bool = True):
         """Apply an amplitude-damping channel.
 
         Args:
             addr0: The index of the target qubit.
             gamma: The damping rate. `X` and `Y` are damped with `sqrt(1 - gamma)`,
                 whereas `Z` branches into `gamma * I + (1 - gamma) * Z`.
+            truncate: If ``True`` (default), run the configured truncation
+                strategy after the channel; if ``False``, defer it (use
+                :meth:`truncate` to fire the cut later).
         """
 
         # TODO: move to mixins once also implemented for GeneralizedTableau
 
-        self._interface.amplitude_damping(addr0, gamma)
+        self._interface.amplitude_damping(addr0, gamma, truncate=truncate)
+
+    def truncate(self) -> None:
+        """Run the configured truncation strategy (``min_abs_coeff`` and/or
+        ``max_pauli_weight``) on the current state.
+
+        Useful when gates were called with ``truncate=False`` to chain a
+        composition of commuting operations (e.g. ``rxx + ryy`` on the
+        same edge, an exchange-like step that conserves total ``Z``), so
+        that intermediate truncation does not drop conserved-charge
+        components. Call :meth:`truncate` once at the end of the
+        composition to apply the cut to the combined result.
+        """
+        self._interface.truncate()
 
 
 @dataclass(frozen=True)
@@ -404,7 +420,7 @@ class LossyPauliSum(PauliSum):
 
     # NOTE: purposely not using mixin for better docstrings here
 
-    def loss_channel(self, addr0: int, p: float) -> None:
+    def loss_channel(self, addr0: int, p: float, *, truncate: bool = True) -> None:
         """Apply a single-qubit loss channel.
 
         Reduces the trace of qubit-subspace operators by `(1 - p)`.
@@ -416,10 +432,19 @@ class LossyPauliSum(PauliSum):
         Args:
             addr0: The index of the target qubit.
             p: Loss probability in [0, 1].
+            truncate: If ``True`` (default), run the configured truncation
+                strategy after the channel; if ``False``, defer it.
         """
-        self._interface.loss_channel(addr0, p)
+        self._interface.loss_channel(addr0, p, truncate=truncate)
 
-    def correlated_loss_channel(self, addr0: int, addr1: int, p: Sequence[float]) -> None:
+    def correlated_loss_channel(
+        self,
+        addr0: int,
+        addr1: int,
+        p: Sequence[float],
+        *,
+        truncate: bool = True,
+    ) -> None:
         """Apply a correlated loss channel.
 
         This applies a correlated loss channel to the qubits at `addr0` and `addr1`.
@@ -433,10 +458,12 @@ class LossyPauliSum(PauliSum):
                 account for the fact that when one qubit is missing during e.g.
                 a controlled gate, the remaining qubit undergoes a different dynamic.
                 We account for this difference with this distinct probability.
+            truncate: If ``True`` (default), run the configured truncation
+                strategy after the channel; if ``False``, defer it.
         """
-        self._interface.correlated_loss_channel(addr0, addr1, p)
+        self._interface.correlated_loss_channel(addr0, addr1, p, truncate=truncate)
 
-    def reset_loss_channel(self, addr0: int) -> None:
+    def reset_loss_channel(self, addr0: int, *, truncate: bool = True) -> None:
         """Reset a lost qubit to the 0 state. Usually, you want to apply
         this channel at the end of the circuit, i.e. at the beginning when
         propagating backwards.
@@ -446,5 +473,7 @@ class LossyPauliSum(PauliSum):
 
         Args:
             addr0: The index of the qubit to reset.
+            truncate: If ``True`` (default), run the configured truncation
+                strategy after the channel; if ``False``, defer it.
         """
-        self._interface.reset_loss_channel(addr0)
+        self._interface.reset_loss_channel(addr0, truncate=truncate)

--- a/ppvm-python/test/test_truncate_kwarg.py
+++ b/ppvm-python/test/test_truncate_kwarg.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2026 The PPVM Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the per-gate ``truncate: bool`` kwarg and explicit
+``PauliSum.truncate()``.
+
+The kwarg lets a user defer truncation across a sequence of commuting
+gates so that small intermediate coefficients survive long enough to
+contribute to a downstream gate's output. Default ``truncate=True``
+preserves the historical behaviour.
+"""
+
+import math
+
+from ppvm import PauliSum
+
+
+def _total_z(ps: PauliSum, n: int) -> float:
+    """Sum of expectation values of every single-Z observable."""
+    return sum(ps.overlap(PauliSum.new(n, f"Z{j}")) for j in range(n))
+
+
+# =============================================================================
+# Backward compatibility: gates without the kwarg behave exactly as before.
+# =============================================================================
+
+
+def test_default_truncate_kwarg_is_true():
+    """Calling gates with no ``truncate=`` kwarg matches the historical
+    behaviour (truncate after every gate)."""
+    n = 3
+    ps = PauliSum.new(n, "Z1", min_abs_coeff=1e-12)
+    ps.rxx(0, 1, 0.5)
+    ps.ryy(0, 1, 0.5)
+    ps_explicit = PauliSum.new(n, "Z1", min_abs_coeff=1e-12)
+    ps_explicit.rxx(0, 1, 0.5, truncate=True)
+    ps_explicit.ryy(0, 1, 0.5, truncate=True)
+    assert dict(ps.terms) == dict(ps_explicit.terms)
+
+
+# =============================================================================
+# `truncate=False` defers the cut; `ps.truncate()` then applies it.
+# =============================================================================
+
+
+def test_truncate_false_then_explicit_matches_implicit():
+    """A pair of gates with ``truncate=False`` followed by an explicit
+    ``ps.truncate()`` yields the same final state as truncating between
+    the gates — when the threshold is small enough that nothing actually
+    gets dropped at either intermediate point."""
+    n = 3
+    ps_a = PauliSum.new(n, "Z1", min_abs_coeff=1e-12)
+    ps_a.rxx(0, 1, 0.5, truncate=False)
+    ps_a.ryy(0, 1, 0.5, truncate=False)
+    ps_a.truncate()
+
+    ps_b = PauliSum.new(n, "Z1", min_abs_coeff=1e-12)
+    ps_b.rxx(0, 1, 0.5)
+    ps_b.ryy(0, 1, 0.5)
+    assert dict(ps_a.terms) == dict(ps_b.terms)
+
+
+def test_truncate_false_keeps_intermediate_terms_alive():
+    """``truncate=False`` leaves the post-gate state untruncated; the
+    plain call (default ``truncate=True``) immediately runs the strategy
+    and may drop terms. Checked here mid-sequence (before any explicit
+    final truncate) so the difference is visible."""
+    n = 3
+    threshold = 0.5  # sits between sin(0.4)≈0.39 and cos(0.4)≈0.92
+
+    ps_plain = PauliSum.new(n, "Z1", min_abs_coeff=threshold)
+    ps_plain.rxx(0, 1, 0.4)
+    # The w=2 cross term `XYI` has coefficient sin(0.4) ≈ 0.39 < 0.5 and
+    # is dropped by the immediate strategy run; only `IZI` survives.
+    assert dict(ps_plain.terms) == {"IZI": math.cos(0.4)}
+
+    ps_def = PauliSum.new(n, "Z1", min_abs_coeff=threshold)
+    ps_def.rxx(0, 1, 0.4, truncate=False)
+    # The same call with truncate deferred leaves both `IZI` and the
+    # w=2 cross term in place — they would only get dropped on a
+    # subsequent explicit `truncate()`.
+    keys = {k for k, _ in ps_def.terms}
+    assert "IZI" in keys and len(keys) > 1, (
+        "deferred-truncate state should contain more than just IZI"
+    )
+
+
+# =============================================================================
+# Headline: `rxx(truncate=False) + ryy(truncate=False) + truncate()` is
+# semantically equivalent to the (now-deleted) `exchange` gate, which
+# called rxx and ryy back-to-back in Rust and let the PyO3 wrapper
+# truncate once at the end.
+# =============================================================================
+
+
+def test_truncate_false_pair_reproduces_old_exchange():
+    """The new idiom replaces the bespoke `exchange` gate. Build it both
+    ways: (1) rxx + ryy with intermediate truncate disabled, (2) what
+    `exchange` did internally (which is exactly that). Identical state."""
+    n = 4
+    threshold = 0.5
+
+    # Path 1: rxx(truncate=False) + ryy(truncate=False) + truncate()
+    ps1 = PauliSum.new(n, "Z2", min_abs_coeff=threshold)
+    ps1.rxx(1, 2, 0.4, truncate=False)
+    ps1.ryy(1, 2, 0.4, truncate=False)
+    ps1.truncate()
+
+    # Path 2: the same primitives at the PyO3 level — what exchange did
+    # in Rust was rxx then ryy with the single PyO3-level truncate at the
+    # end. We replicate it here via the kwarg.
+    ps2 = PauliSum.new(n, "Z2", min_abs_coeff=threshold)
+    ps2.rxx(1, 2, 0.4, truncate=False)
+    ps2.ryy(1, 2, 0.4)  # default truncate=True ⇒ single truncate at end
+
+    assert dict(ps1.terms) == dict(ps2.terms)
+
+
+# =============================================================================
+# Sanity: with a loose enough threshold, deferred truncate preserves
+# total Σ Z exactly through an XY-exchange chain (because no Pauli is
+# ever near the threshold).
+# =============================================================================
+
+
+def test_deferred_truncate_preserves_total_z_with_loose_threshold():
+    """Apply rxx+ryy on each edge with the truncate deferred until the
+    end of the pair. With a non-aggressive threshold, total Σ Z is
+    conserved to FP precision."""
+    n = 4
+    ps = PauliSum.new(n, "Z2", min_abs_coeff=1e-12)
+    for a in range(n - 1):
+        ps.rxx(a, a + 1, 0.3, truncate=False)
+        ps.ryy(a, a + 1, 0.3, truncate=False)
+        ps.truncate()
+    drift = abs(1.0 - _total_z(ps, n))
+    assert drift < 1e-10, f"Σ Z conservation broken: drift={drift:.3e}"
+
+
+# =============================================================================
+# `truncate()` is callable on its own.
+# =============================================================================
+
+
+def test_truncate_method_drops_below_threshold_keys():
+    """Explicit ``ps.truncate()`` drops keys below the configured cutoff.
+    (The constructor does not auto-truncate, so this is the only way to
+    apply the strategy to the initial state.)"""
+    n = 2
+    ps = PauliSum.new(n, [("ZI", 0.5), ("XI", 1e-8)], min_abs_coeff=1e-3)
+    before = dict(ps.terms)
+    assert "XI" in before, "constructor leaves below-threshold entries in place"
+    ps.truncate()
+    after = dict(ps.terms)
+    assert "XI" not in after, "truncate() should drop XI below 1e-3"
+    assert after["ZI"] == 0.5
+
+
+# =============================================================================
+# Sanity: noise channels also take the kwarg.
+# =============================================================================
+
+
+def test_noise_channels_accept_truncate_kwarg():
+    """`pauli_error` accepts the kwarg; defaults match the previous
+    behaviour."""
+    n = 3
+    p_z = (1 - math.exp(-2 * 0.5 * 0.1)) / 2
+    ps = PauliSum.new(n, "Z1", min_abs_coeff=1e-10)
+    ps.pauli_error(0, [0.0, 0.0, p_z])
+    ps.pauli_error(1, [0.0, 0.0, p_z], truncate=False)
+    ps.pauli_error(2, [0.0, 0.0, p_z], truncate=False)
+    ps.truncate()
+    ps_ref = PauliSum.new(n, "Z1", min_abs_coeff=1e-10)
+    for q in range(n):
+        ps_ref.pauli_error(q, [0.0, 0.0, p_z])
+    assert dict(ps.terms) == dict(ps_ref.terms)


### PR DESCRIPTION
## Summary

Replaces the per-gate auto-truncate with an opt-out: every gate method on `PauliSum` / `LossyPauliSum` (and `GeneralizedTableau`, for signature symmetry) gains a `truncate: bool = True` kwarg, and `PauliSum` gains a top-level `truncate()` method. Default behaviour is **exactly** unchanged; existing user code is unaffected.

```python
ps.rxx(a, b, theta, truncate=False)
ps.ryy(a, b, theta, truncate=False)
ps.truncate()        # one strategy run at the end of the commuting pair
```

## Why

Supersedes #94 (`u1-conserving`). That branch added a dedicated `exchange` (and `xyzz`) gate whose only job was to call `rxx + ryy` back-to-back in Rust so the PyO3-level auto-truncate fired once instead of twice — the U(1) charge structure is preserved by the single PyO3 truncate, not by `rxx + ryy`'s two truncates.

Letting the Python caller control `truncate` directly subsumes `exchange` and generalises to any sequence of commuting gates (`xyzz = rxx + ryy + rzz`, longer fusions, mixed Clifford-rotation blocks). No new dedicated gates needed, no new Rust traits, smaller API surface.

## Design

- The PyO3 `PauliSum` interface auto-truncate now lives behind `if truncate { self.inner.truncate(); }` on every gate. The kwarg defaults to `true`, so callers that don't pass it see no change.
- A new `PauliSum.truncate()` calls the configured strategy explicitly.
- The Python mixins (`CliffordMixin`, `RotationsMixin`, `CliffordExtensionMixin`, `NoiseMixin`, `LossMixin`) forward `truncate=truncate` to the PyO3 layer.
- `GeneralizedTableau`'s PyO3 binding also accepts the kwarg and silently ignores it — the tableau backend doesn't auto-truncate, so there's nothing to defer, but the parallel signature lets the mixins serve both backends uniformly.

## Tests

`ppvm-python/test/test_truncate_kwarg.py` (7 cases):

- `test_default_truncate_kwarg_is_true` — backward-compat: no kwarg ≡ explicit `truncate=True`.
- `test_truncate_false_then_explicit_matches_implicit` — at a threshold that doesn't actually drop anything, deferred ≡ immediate.
- `test_truncate_false_keeps_intermediate_terms_alive` — at a threshold where the immediate strategy *would* drop intermediates, `truncate=False` keeps them visible in the post-gate state.
- `test_truncate_false_pair_reproduces_old_exchange` — the new idiom produces the same state as what `exchange` did internally.
- `test_deferred_truncate_preserves_total_z_with_loose_threshold` — sanity: rxx+ryy chain with deferred truncate conserves Σ Z exactly.
- `test_truncate_method_drops_below_threshold_keys` — explicit `truncate()` is wired through and runs the configured strategy.
- `test_noise_channels_accept_truncate_kwarg` — the kwarg works on `pauli_error` too, not only on rotations.

## Test plan
- [x] `cargo test -p ppvm-runtime --lib` (78 pass)
- [x] `uv run --project ppvm-python --group dev pytest ppvm-python/test/` (109 pass)
- [x] `cargo fmt`, `cargo clippy --no-deps`, `ruff check ppvm-python/`

## Notes

- Closes #94: the `u1-conserving` branch and `exchange` / `xyzz` gates are no longer needed. The deferred-truncate idiom in this PR replaces them; see `test_truncate_false_pair_reproduces_old_exchange` for the one-line migration.
- The `u1-conserving` branch will be deleted from the remote once this PR lands.