### PR TITLE
Split up mixins so we separate truncate kwarg

### DIFF
--- a/crates/ppvm-python-native/src/interface_tableau.rs
+++ b/crates/ppvm-python-native/src/interface_tableau.rs
@@ -45,91 +45,57 @@ macro_rules! create_interface {
                 self.inner.measure(addr0)
             }
 
-            // All gate methods take a `truncate: bool = true` kwarg
-            // purely for API symmetry with `PauliSum` (which uses it to
-            // defer the auto-truncate). `GeneralizedTableau` has no
-            // analogous truncation step — the tableau representation is
-            // exact — so the kwarg is silently ignored here. Keeping the
-            // signature parallel lets the Python `RotationsMixin` /
-            // `CliffordMixin` / etc. work uniformly across both backends.
-
             // clifford
-            #[pyo3(signature = (addr0, truncate = true))]
-            pub fn x(&mut self, addr0: usize, truncate: bool) {
-                let _ = truncate;
+            pub fn x(&mut self, addr0: usize) {
                 self.inner.x(addr0);
             }
 
-            #[pyo3(signature = (addr0, truncate = true))]
-            pub fn y(&mut self, addr0: usize, truncate: bool) {
-                let _ = truncate;
+            pub fn y(&mut self, addr0: usize) {
                 self.inner.y(addr0);
             }
 
-            #[pyo3(signature = (addr0, truncate = true))]
-            pub fn z(&mut self, addr0: usize, truncate: bool) {
-                let _ = truncate;
+            pub fn z(&mut self, addr0: usize) {
                 self.inner.z(addr0);
             }
 
-            #[pyo3(signature = (addr0, truncate = true))]
-            pub fn h(&mut self, addr0: usize, truncate: bool) {
-                let _ = truncate;
+            pub fn h(&mut self, addr0: usize) {
                 self.inner.h(addr0);
             }
 
-            #[pyo3(signature = (addr0, truncate = true))]
-            pub fn s(&mut self, addr0: usize, truncate: bool) {
-                let _ = truncate;
+            pub fn s(&mut self, addr0: usize) {
                 self.inner.s(addr0);
             }
 
-            #[pyo3(signature = (addr0, truncate = true))]
-            pub fn s_adj(&mut self, addr0: usize, truncate: bool) {
-                let _ = truncate;
+            pub fn s_adj(&mut self, addr0: usize) {
                 self.inner.s_adj(addr0);
             }
 
             // clifford extensions
-            #[pyo3(signature = (addr0, truncate = true))]
-            pub fn sqrt_x(&mut self, addr0: usize, truncate: bool) {
-                let _ = truncate;
+            pub fn sqrt_x(&mut self, addr0: usize) {
                 self.inner.sqrt_x(addr0);
             }
 
-            #[pyo3(signature = (addr0, truncate = true))]
-            pub fn sqrt_x_adj(&mut self, addr0: usize, truncate: bool) {
-                let _ = truncate;
+            pub fn sqrt_x_adj(&mut self, addr0: usize) {
                 self.inner.sqrt_x_adj(addr0);
             }
 
-            #[pyo3(signature = (addr0, truncate = true))]
-            pub fn sqrt_y(&mut self, addr0: usize, truncate: bool) {
-                let _ = truncate;
+            pub fn sqrt_y(&mut self, addr0: usize) {
                 self.inner.sqrt_y(addr0);
             }
 
-            #[pyo3(signature = (addr0, truncate = true))]
-            pub fn sqrt_y_adj(&mut self, addr0: usize, truncate: bool) {
-                let _ = truncate;
+            pub fn sqrt_y_adj(&mut self, addr0: usize) {
                 self.inner.sqrt_y_adj(addr0);
             }
 
-            #[pyo3(signature = (addr0, addr1, truncate = true))]
-            pub fn cnot(&mut self, addr0: usize, addr1: usize, truncate: bool) {
-                let _ = truncate;
+            pub fn cnot(&mut self, addr0: usize, addr1: usize) {
                 self.inner.cnot(addr0, addr1);
             }
 
-            #[pyo3(signature = (addr0, addr1, truncate = true))]
-            pub fn cy(&mut self, addr0: usize, addr1: usize, truncate: bool) {
-                let _ = truncate;
+            pub fn cy(&mut self, addr0: usize, addr1: usize) {
                 self.inner.cy(addr0, addr1);
             }
 
-            #[pyo3(signature = (addr0, addr1, truncate = true))]
-            pub fn cz(&mut self, addr0: usize, addr1: usize, truncate: bool) {
-                let _ = truncate;
+            pub fn cz(&mut self, addr0: usize, addr1: usize) {
                 self.inner.cz(addr0, addr1);
             }
 
@@ -142,21 +108,15 @@ macro_rules! create_interface {
             }
 
             // rot1
-            #[pyo3(signature = (addr0, theta, truncate = true))]
-            pub fn rx(&mut self, addr0: usize, theta: f64, truncate: bool) {
-                let _ = truncate;
+            pub fn rx(&mut self, addr0: usize, theta: f64) {
                 self.inner.rx(addr0, theta);
             }
 
-            #[pyo3(signature = (addr0, theta, truncate = true))]
-            pub fn ry(&mut self, addr0: usize, theta: f64, truncate: bool) {
-                let _ = truncate;
+            pub fn ry(&mut self, addr0: usize, theta: f64) {
                 self.inner.ry(addr0, theta);
             }
 
-            #[pyo3(signature = (addr0, theta, truncate = true))]
-            pub fn rz(&mut self, addr0: usize, theta: f64, truncate: bool) {
-                let _ = truncate;
+            pub fn rz(&mut self, addr0: usize, theta: f64) {
                 self.inner.rz(addr0, theta);
             }
 
@@ -165,76 +125,44 @@ macro_rules! create_interface {
             }
 
             // rot2
-            #[pyo3(signature = (addr0, addr1, theta, truncate = true))]
-            pub fn rxx(&mut self, addr0: usize, addr1: usize, theta: f64, truncate: bool) {
-                let _ = truncate;
+            pub fn rxx(&mut self, addr0: usize, addr1: usize, theta: f64) {
                 self.inner.rxx(addr0, addr1, theta);
             }
 
-            #[pyo3(signature = (addr0, addr1, theta, truncate = true))]
-            pub fn ryy(&mut self, addr0: usize, addr1: usize, theta: f64, truncate: bool) {
-                let _ = truncate;
+            pub fn ryy(&mut self, addr0: usize, addr1: usize, theta: f64) {
                 self.inner.ryy(addr0, addr1, theta);
             }
 
-            #[pyo3(signature = (addr0, addr1, theta, truncate = true))]
-            pub fn rzz(&mut self, addr0: usize, addr1: usize, theta: f64, truncate: bool) {
-                let _ = truncate;
+            pub fn rzz(&mut self, addr0: usize, addr1: usize, theta: f64) {
                 self.inner.rzz(addr0, addr1, theta);
             }
 
             // noise
-            #[pyo3(signature = (addr0, p, truncate = true))]
-            pub fn pauli_error(&mut self, addr0: usize, p: [f64; 3], truncate: bool) {
-                let _ = truncate;
+            pub fn pauli_error(&mut self, addr0: usize, p: [f64; 3]) {
                 self.inner.pauli_error(addr0, p);
             }
 
-            #[pyo3(signature = (addr0, p, truncate = true))]
-            pub fn depolarize(&mut self, addr0: usize, p: f64, truncate: bool) {
-                let _ = truncate;
+            pub fn depolarize(&mut self, addr0: usize, p: f64) {
                 self.inner.depolarize(addr0, p);
             }
 
-            #[pyo3(signature = (addr0, addr1, p, truncate = true))]
-            pub fn depolarize2(&mut self, addr0: usize, addr1: usize, p: f64, truncate: bool) {
-                let _ = truncate;
+            pub fn depolarize2(&mut self, addr0: usize, addr1: usize, p: f64) {
                 self.inner.depolarize2(addr0, addr1, p);
             }
 
-            #[pyo3(signature = (addr0, addr1, p, truncate = true))]
-            pub fn two_qubit_pauli_error(
-                &mut self,
-                addr0: usize,
-                addr1: usize,
-                p: [f64; 15],
-                truncate: bool,
-            ) {
-                let _ = truncate;
+            pub fn two_qubit_pauli_error(&mut self, addr0: usize, addr1: usize, p: [f64; 15]) {
                 self.inner.two_qubit_pauli_error(addr0, addr1, p);
             }
 
-            #[pyo3(signature = (addr0, p, truncate = true))]
-            pub fn loss_channel(&mut self, addr0: usize, p: f64, truncate: bool) {
-                let _ = truncate;
+            pub fn loss_channel(&mut self, addr0: usize, p: f64) {
                 self.inner.loss_channel(addr0, p);
             }
 
-            #[pyo3(signature = (addr0, addr1, p, truncate = true))]
-            pub fn correlated_loss_channel(
-                &mut self,
-                addr0: usize,
-                addr1: usize,
-                p: [f64; 3],
-                truncate: bool,
-            ) {
-                let _ = truncate;
+            pub fn correlated_loss_channel(&mut self, addr0: usize, addr1: usize, p: [f64; 3]) {
                 self.inner.correlated_loss_channel(addr0, addr1, p);
             }
 
-            #[pyo3(signature = (addr0, truncate = true))]
-            pub fn reset_loss_channel(&mut self, addr0: usize, truncate: bool) {
-                let _ = truncate;
+            pub fn reset_loss_channel(&mut self, addr0: usize) {
                 self.inner.reset_loss_channel(addr0);
             }
 

--- a/ppvm-python/src/ppvm/mixins.py
+++ b/ppvm-python/src/ppvm/mixins.py
@@ -4,21 +4,368 @@
 from collections.abc import Sequence
 from typing import Any
 
-# Every gate method below takes an optional ``truncate: bool = True`` kwarg.
-# When ``True`` (the default), the configured truncation strategy fires
-# immediately after the gate — historical behaviour. Pass ``truncate=False``
-# to defer the cut; the user is then responsible for calling
-# :meth:`PauliSum.truncate` explicitly when the next truncation point is
-# reached. This is the supported way to chain commuting gates (e.g.
-# ``rxx + ryy`` on the same edge for a U(1)-conserving exchange step)
-# without losing a conserved-charge component to intermediate truncation.
+# Gate vocabulary shared across backends comes in two flavours:
+#
+# * The plain mixins below (``CliffordMixin``, ``RotationsMixin``, ...) forward
+#   straight to the native interface with no ``truncate`` kwarg. Truncation is
+#   not a per-gate concept for the generalized stabilizer tableau — that
+#   representation is exact — so ``GeneralizedTableau`` uses these directly.
+# * The ``Truncating*`` variants further down add an optional
+#   ``truncate: bool = True`` kwarg and are used by ``PauliSum``. When ``True``
+#   (the default), the configured truncation strategy fires immediately after
+#   the gate — historical behaviour. Pass ``truncate=False`` to defer the cut;
+#   the user is then responsible for calling :meth:`PauliSum.truncate`
+#   explicitly when the next truncation point is reached. This is the supported
+#   way to chain commuting gates (e.g. ``rxx + ryy`` on the same edge for a
+#   U(1)-conserving exchange step) without losing a conserved-charge component
+#   to intermediate truncation.
 
 
-# TODO: also use this in PauliSum
 class CliffordMixin:
+    """Clifford gates without per-gate truncation control."""
+
     _interface: Any
 
     # Clifford operations
+    def x(self, addr0: int) -> None:
+        """Apply a Pauli X gate to the specified qubit.
+
+        Args:
+            addr0: The index of the target qubit.
+        """
+        self._interface.x(addr0)
+
+    def y(self, addr0: int) -> None:
+        """Apply a Pauli Y gate to the specified qubit.
+
+        Args:
+            addr0: The index of the target qubit.
+        """
+        self._interface.y(addr0)
+
+    def z(self, addr0: int) -> None:
+        """Apply a Pauli Z gate to the specified qubit.
+
+        Args:
+            addr0: The index of the target qubit.
+        """
+        self._interface.z(addr0)
+
+    def h(self, addr0: int) -> None:
+        """Apply a Hadamard gate to the specified qubit.
+
+        Args:
+            addr0: The index of the target qubit.
+        """
+        self._interface.h(addr0)
+
+    def s(self, addr0: int) -> None:
+        """Apply an S gate (sqrt(Z)) to the specified qubit.
+
+        Args:
+            addr0: The index of the target qubit.
+        """
+        self._interface.s(addr0)
+
+    def cnot(self, addr0: int, addr1: int) -> None:
+        """Apply a CNOT (controlled-X) gate.
+
+        Args:
+            addr0: The index of the control qubit.
+            addr1: The index of the target qubit.
+        """
+        self._interface.cnot(addr0, addr1)
+
+    def cz(self, addr0: int, addr1: int) -> None:
+        """Apply a CZ (controlled-Z) gate.
+
+        Args:
+            addr0: The index of the first qubit.
+            addr1: The index of the second qubit.
+        """
+        self._interface.cz(addr0, addr1)
+
+
+class RotationsMixin:
+    """Rotation gates without per-gate truncation control."""
+
+    _interface: Any
+
+    # Rotations
+    def rx(self, addr0: int, theta: float) -> None:
+        """Apply an RX rotation gate to the specified qubit.
+
+        ```math
+        R_X(\\theta) = e^{-i \\frac{\\theta}{2} X} = \\cos\\frac{\\theta}{2} I - i \\sin\\frac{\\theta}{2} X
+        ```
+
+        Args:
+            addr0: The index of the target qubit.
+            theta: The rotation angle in radians.
+        """
+        self._interface.rx(addr0, theta)
+
+    def ry(self, addr0: int, theta: float) -> None:
+        """Apply an RY rotation gate to the specified qubit.
+
+        ```math
+        R_Y(\\theta) = e^{-i \\frac{\\theta}{2} Y} = \\cos\\frac{\\theta}{2} I - i \\sin\\frac{\\theta}{2} Y
+        ```
+
+        Args:
+            addr0: The index of the target qubit.
+            theta: The rotation angle in radians.
+        """
+        self._interface.ry(addr0, theta)
+
+    def rz(self, addr0: int, theta: float) -> None:
+        """Apply an RZ rotation gate to the specified qubit.
+
+        ```math
+        R_Z(\\theta) = e^{-i \\frac{\\theta}{2} Z} = \\cos\\frac{\\theta}{2} I - i \\sin\\frac{\\theta}{2} Z
+        ```
+
+        Args:
+            addr0: The index of the target qubit.
+            theta: The rotation angle in radians.
+        """
+        self._interface.rz(addr0, theta)
+
+    # Two qubit rotations
+    def rxx(self, addr0: int, addr1: int, theta: float) -> None:
+        """Apply an RXX (Ising XX) rotation gate to two qubits.
+
+        ```math
+        R_{XX}(\\theta) = e^{-i \\frac{\\theta}{2} X \\otimes X}
+        ```
+
+        Args:
+            addr0: The index of the first qubit.
+            addr1: The index of the second qubit.
+            theta: The rotation angle in radians.
+        """
+        self._interface.rxx(addr0, addr1, theta)
+
+    def ryy(self, addr0: int, addr1: int, theta: float) -> None:
+        """Apply an RYY (Ising YY) rotation gate to two qubits.
+
+        ```math
+        R_{YY}(\\theta) = e^{-i \\frac{\\theta}{2} Y \\otimes Y}
+        ```
+
+        Args:
+            addr0: The index of the first qubit.
+            addr1: The index of the second qubit.
+            theta: The rotation angle in radians.
+        """
+        self._interface.ryy(addr0, addr1, theta)
+
+    def rzz(self, addr0: int, addr1: int, theta: float) -> None:
+        """Apply an RZZ (Ising ZZ) rotation gate to two qubits.
+
+        ```math
+        R_{ZZ}(\\theta) = e^{-i \\frac{\\theta}{2} Z \\otimes Z}
+        ```
+
+        Args:
+            addr0: The index of the first qubit.
+            addr1: The index of the second qubit.
+            theta: The rotation angle in radians.
+        """
+        self._interface.rzz(addr0, addr1, theta)
+
+
+class CliffordExtensionMixin:
+    """Additional Clifford gates without per-gate truncation control."""
+
+    _interface: Any
+
+    def s_adj(self, addr0: int) -> None:
+        """Apply an S adjoint gate (sqrt(Z) dagger) to the specified qubit.
+
+        Args:
+            addr0: The index of the target qubit.
+        """
+        self._interface.s_adj(addr0)
+
+    def sqrt_x(self, addr0: int) -> None:
+        """Apply a sqrt(X) gate to the specified qubit.
+
+        Args:
+            addr0: The index of the target qubit.
+        """
+        self._interface.sqrt_x(addr0)
+
+    def sqrt_y(self, addr0: int) -> None:
+        """Apply a sqrt(Y) gate to the specified qubit.
+
+        Args:
+            addr0: The index of the target qubit.
+        """
+        self._interface.sqrt_y(addr0)
+
+    def sqrt_x_adj(self, addr0: int) -> None:
+        """Apply a sqrt(X) adjoint gate to the specified qubit.
+
+        Args:
+            addr0: The index of the target qubit.
+        """
+        self._interface.sqrt_x_adj(addr0)
+
+    def sqrt_y_adj(self, addr0: int) -> None:
+        """Apply a sqrt(Y) adjoint gate to the specified qubit.
+
+        Args:
+            addr0: The index of the target qubit.
+        """
+        self._interface.sqrt_y_adj(addr0)
+
+    def cy(self, addr0: int, addr1: int) -> None:
+        """Apply a controlled-Y gate.
+
+        Args:
+            addr0: The index of the control qubit.
+            addr1: The index of the target qubit.
+        """
+        self._interface.cy(addr0, addr1)
+
+
+class NoiseMixin:
+    """Noise channels without per-gate truncation control."""
+
+    _interface: Any
+
+    # Noise operations
+    def pauli_error(self, addr0: int, p: Sequence[float]) -> None:
+        """Apply a single-qubit Pauli error channel.
+
+        Args:
+            addr0: The index of the target qubit.
+            p: Error probabilities [p_x, p_y, p_z] for X, Y, Z errors.
+                The identity probability is implicitly 1 - sum(p).
+        """
+        self._interface.pauli_error(addr0, p)
+
+    @staticmethod
+    def two_qubit_pauli_error_probabilities(
+        error_probabilities: dict[str, float],
+    ) -> list[float]:
+        """Convert a dictionary of two-qubit Pauli error probabilities to a list.
+
+        Convenience method to convert a dictionary mapping two-qubit Pauli
+        strings (e.g., "IX", "ZZ") to their probabilities into the ordered
+        list format required by two_qubit_pauli_error.
+
+        Args:
+            error_probabilities: Dictionary mapping two-qubit Pauli strings
+                to their error probabilities. Missing keys default to 0.0.
+
+        Returns:
+            A list of 15 probabilities in the canonical order (excludes "II").
+        """
+        keys = (
+            "IX",
+            "IT",
+            "IZ",
+            "XI",
+            "XX",
+            "XY",
+            "XZ",
+            "YI",
+            "YX",
+            "YY",
+            "YZ",
+            "ZI",
+            "ZX",
+            "ZY",
+            "ZZ",
+        )
+        return [error_probabilities.get(key, 0.0) for key in keys]
+
+    def two_qubit_pauli_error(
+        self,
+        addr0: int,
+        addr1: int,
+        p: Sequence[float],
+    ) -> None:
+        """Apply a two-qubit Pauli error channel.
+
+        Args:
+            addr0: The index of the first qubit.
+            addr1: The index of the second qubit.
+            p: Error probabilities for the 15 non-identity two-qubit Pauli
+                operators. Use two_qubit_pauli_error_probabilities to convert
+                from a dictionary format.
+        """
+        self._interface.two_qubit_pauli_error(addr0, addr1, p)
+
+    # additional noise methods
+    def depolarize(self, addr0: int, p: float) -> None:
+        """Apply a depolarizing channel to the specified qubit.
+
+        Args:
+            addr0: The index of the target qubit.
+            p: The depolarizing probability.
+        """
+        self._interface.depolarize(addr0, p)
+
+    def depolarize2(self, addr0: int, addr1: int, p: float) -> None:
+        """Apply a two-qubit depolarizing channel to the specified qubits.
+
+        Args:
+            addr0: The index of the first target qubit.
+            addr1: The index of the second target qubit.
+            p: The depolarizing probability.
+        """
+        self._interface.depolarize2(addr0, addr1, p)
+
+
+class LossMixin:
+    """Loss channels without per-gate truncation control."""
+
+    _interface: Any
+
+    def loss_channel(self, addr0: int, p: float) -> None:
+        """Apply a loss channel to the specified qubit.
+
+        Args:
+            addr0: The index of the target qubit.
+            p: The loss probability.
+        """
+        self._interface.loss_channel(addr0, p)
+
+    def correlated_loss_channel(
+        self,
+        addr0: int,
+        addr1: int,
+        p: Sequence[float],
+    ) -> None:
+        """Apply a correlated loss channel to two qubits.
+
+        Args:
+            addr0: The index of the first target qubit.
+            addr1: The index of the second target qubit.
+            p: A list of three probabilities:
+
+                - ``p[0]``: probability of losing both qubits simultaneously
+                  when both are in the qubit subspace.
+                - ``p[1]``: probability of losing exactly one qubit when both
+                  are in the qubit subspace (which qubit is lost is 50/50 random).
+                - ``p[2]``: probability of losing the remaining active qubit
+                  when the other has already been lost prior to this channel.
+        """
+        self._interface.correlated_loss_channel(addr0, addr1, p)
+
+
+# Truncating variants used by ``PauliSum``: same gates, plus a per-gate
+# ``truncate`` kwarg. Each subclasses its plain counterpart, so members that
+# have no truncation concept (``cy``, ``two_qubit_pauli_error_probabilities``)
+# are inherited unchanged and only the branching gates are overridden.
+
+
+class TruncatingCliffordMixin(CliffordMixin):
+    """Clifford gates with a per-gate ``truncate`` kwarg (used by PauliSum)."""
+
     def x(self, addr0: int, *, truncate: bool = True) -> None:
         """Apply a Pauli X gate to the specified qubit.
 
@@ -87,16 +434,13 @@ class CliffordMixin:
         self._interface.cz(addr0, addr1, truncate=truncate)
 
 
-class RotationsMixin:
-    _interface: Any
+class TruncatingRotationsMixin(RotationsMixin):
+    """Rotation gates with a per-gate ``truncate`` kwarg (used by PauliSum)."""
 
-    # Rotations
     def rx(self, addr0: int, theta: float, *, truncate: bool = True) -> None:
         """Apply an RX rotation gate to the specified qubit.
 
-        ```math
-        R_X(\\theta) = e^{-i \\frac{\\theta}{2} X} = \\cos\\frac{\\theta}{2} I - i \\sin\\frac{\\theta}{2} X
-        ```
+        See :meth:`RotationsMixin.rx` for the gate definition.
 
         Args:
             addr0: The index of the target qubit.
@@ -109,9 +453,7 @@ class RotationsMixin:
     def ry(self, addr0: int, theta: float, *, truncate: bool = True) -> None:
         """Apply an RY rotation gate to the specified qubit.
 
-        ```math
-        R_Y(\\theta) = e^{-i \\frac{\\theta}{2} Y} = \\cos\\frac{\\theta}{2} I - i \\sin\\frac{\\theta}{2} Y
-        ```
+        See :meth:`RotationsMixin.ry` for the gate definition.
 
         Args:
             addr0: The index of the target qubit.
@@ -123,9 +465,7 @@ class RotationsMixin:
     def rz(self, addr0: int, theta: float, *, truncate: bool = True) -> None:
         """Apply an RZ rotation gate to the specified qubit.
 
-        ```math
-        R_Z(\\theta) = e^{-i \\frac{\\theta}{2} Z} = \\cos\\frac{\\theta}{2} I - i \\sin\\frac{\\theta}{2} Z
-        ```
+        See :meth:`RotationsMixin.rz` for the gate definition.
 
         Args:
             addr0: The index of the target qubit.
@@ -134,13 +474,10 @@ class RotationsMixin:
         """
         self._interface.rz(addr0, theta, truncate=truncate)
 
-    # Two qubit rotations
     def rxx(self, addr0: int, addr1: int, theta: float, *, truncate: bool = True) -> None:
         """Apply an RXX (Ising XX) rotation gate to two qubits.
 
-        ```math
-        R_{XX}(\\theta) = e^{-i \\frac{\\theta}{2} X \\otimes X}
-        ```
+        See :meth:`RotationsMixin.rxx` for the gate definition.
 
         Args:
             addr0: The index of the first qubit.
@@ -158,9 +495,7 @@ class RotationsMixin:
     def ryy(self, addr0: int, addr1: int, theta: float, *, truncate: bool = True) -> None:
         """Apply an RYY (Ising YY) rotation gate to two qubits.
 
-        ```math
-        R_{YY}(\\theta) = e^{-i \\frac{\\theta}{2} Y \\otimes Y}
-        ```
+        See :meth:`RotationsMixin.ryy` for the gate definition.
 
         Args:
             addr0: The index of the first qubit.
@@ -173,9 +508,7 @@ class RotationsMixin:
     def rzz(self, addr0: int, addr1: int, theta: float, *, truncate: bool = True) -> None:
         """Apply an RZZ (Ising ZZ) rotation gate to two qubits.
 
-        ```math
-        R_{ZZ}(\\theta) = e^{-i \\frac{\\theta}{2} Z \\otimes Z}
-        ```
+        See :meth:`RotationsMixin.rzz` for the gate definition.
 
         Args:
             addr0: The index of the first qubit.
@@ -186,15 +519,19 @@ class RotationsMixin:
         self._interface.rzz(addr0, addr1, theta, truncate=truncate)
 
 
-class CliffordExtensionMixin:
-    _interface: Any
+class TruncatingCliffordExtensionMixin(CliffordExtensionMixin):
+    """Additional Clifford gates with a per-gate ``truncate`` kwarg.
+
+    ``cy`` is inherited unchanged from :class:`CliffordExtensionMixin` (it does
+    not branch the Pauli sum, so it takes no ``truncate`` kwarg).
+    """
 
     def s_adj(self, addr0: int, *, truncate: bool = True) -> None:
         """Apply an S adjoint gate (sqrt(Z) dagger) to the specified qubit.
 
         Args:
             addr0: The index of the target qubit.
-            truncate: See :meth:`CliffordMixin.x`.
+            truncate: See :meth:`TruncatingCliffordMixin.x`.
         """
         self._interface.s_adj(addr0, truncate=truncate)
 
@@ -203,7 +540,7 @@ class CliffordExtensionMixin:
 
         Args:
             addr0: The index of the target qubit.
-            truncate: See :meth:`CliffordMixin.x`.
+            truncate: See :meth:`TruncatingCliffordMixin.x`.
         """
         self._interface.sqrt_x(addr0, truncate=truncate)
 
@@ -212,7 +549,7 @@ class CliffordExtensionMixin:
 
         Args:
             addr0: The index of the target qubit.
-            truncate: See :meth:`CliffordMixin.x`.
+            truncate: See :meth:`TruncatingCliffordMixin.x`.
         """
         self._interface.sqrt_y(addr0, truncate=truncate)
 
@@ -221,7 +558,7 @@ class CliffordExtensionMixin:
 
         Args:
             addr0: The index of the target qubit.
-            truncate: See :meth:`CliffordMixin.x`.
+            truncate: See :meth:`TruncatingCliffordMixin.x`.
         """
         self._interface.sqrt_x_adj(addr0, truncate=truncate)
 
@@ -230,24 +567,18 @@ class CliffordExtensionMixin:
 
         Args:
             addr0: The index of the target qubit.
-            truncate: See :meth:`CliffordMixin.x`.
+            truncate: See :meth:`TruncatingCliffordMixin.x`.
         """
         self._interface.sqrt_y_adj(addr0, truncate=truncate)
 
-    def cy(self, addr0: int, addr1: int) -> None:
-        """Apply a controlled-Y gate.
 
-        Args:
-            addr0: The index of the control qubit.
-            addr1: The index of the target qubit.
-        """
-        self._interface.cy(addr0, addr1)
+class TruncatingNoiseMixin(NoiseMixin):
+    """Noise channels with a per-gate ``truncate`` kwarg (used by PauliSum).
 
+    ``two_qubit_pauli_error_probabilities`` is inherited unchanged from
+    :class:`NoiseMixin`.
+    """
 
-class NoiseMixin:
-    _interface: Any
-
-    # Noise operations
     def pauli_error(
         self, addr0: int, p: Sequence[float], *, truncate: bool = True
     ) -> None:
@@ -261,42 +592,6 @@ class NoiseMixin:
                 strategy after the channel; if ``False``, defer it.
         """
         self._interface.pauli_error(addr0, p, truncate=truncate)
-
-    @staticmethod
-    def two_qubit_pauli_error_probabilities(
-        error_probabilities: dict[str, float],
-    ) -> list[float]:
-        """Convert a dictionary of two-qubit Pauli error probabilities to a list.
-
-        Convenience method to convert a dictionary mapping two-qubit Pauli
-        strings (e.g., "IX", "ZZ") to their probabilities into the ordered
-        list format required by two_qubit_pauli_error.
-
-        Args:
-            error_probabilities: Dictionary mapping two-qubit Pauli strings
-                to their error probabilities. Missing keys default to 0.0.
-
-        Returns:
-            A list of 15 probabilities in the canonical order (excludes "II").
-        """
-        keys = (
-            "IX",
-            "IT",
-            "IZ",
-            "XI",
-            "XX",
-            "XY",
-            "XZ",
-            "YI",
-            "YX",
-            "YY",
-            "YZ",
-            "ZI",
-            "ZX",
-            "ZY",
-            "ZZ",
-        )
-        return [error_probabilities.get(key, 0.0) for key in keys]
 
     def two_qubit_pauli_error(
         self,
@@ -318,7 +613,6 @@ class NoiseMixin:
         """
         self._interface.two_qubit_pauli_error(addr0, addr1, p, truncate=truncate)
 
-    # additional noise methods
     def depolarize(self, addr0: int, p: float, *, truncate: bool = True) -> None:
         """Apply a depolarizing channel to the specified qubit.
 
@@ -341,43 +635,3 @@ class NoiseMixin:
             truncate: See :meth:`pauli_error`.
         """
         self._interface.depolarize2(addr0, addr1, p, truncate=truncate)
-
-
-class LossMixin:
-    _interface: Any
-
-    def loss_channel(self, addr0: int, p: float, *, truncate: bool = True) -> None:
-        """Apply a loss channel to the specified qubit.
-
-        Args:
-            addr0: The index of the target qubit.
-            p: The loss probability.
-            truncate: If ``True`` (default), run the configured truncation
-                strategy after the channel; if ``False``, defer it.
-        """
-        self._interface.loss_channel(addr0, p, truncate=truncate)
-
-    def correlated_loss_channel(
-        self,
-        addr0: int,
-        addr1: int,
-        p: Sequence[float],
-        *,
-        truncate: bool = True,
-    ) -> None:
-        """Apply a correlated loss channel to two qubits.
-
-        Args:
-            addr0: The index of the first target qubit.
-            addr1: The index of the second target qubit.
-            p: A list of three probabilities:
-
-                - ``p[0]``: probability of losing both qubits simultaneously
-                  when both are in the qubit subspace.
-                - ``p[1]``: probability of losing exactly one qubit when both
-                  are in the qubit subspace (which qubit is lost is 50/50 random).
-                - ``p[2]``: probability of losing the remaining active qubit
-                  when the other has already been lost prior to this channel.
-            truncate: See :meth:`loss_channel`.
-        """
-        self._interface.correlated_loss_channel(addr0, addr1, p, truncate=truncate)

--- a/ppvm-python/src/ppvm/paulisum.py
+++ b/ppvm-python/src/ppvm/paulisum.py
@@ -9,7 +9,12 @@ from typing import Self, Union
 
 import ppvm_python_native
 
-from .mixins import CliffordExtensionMixin, CliffordMixin, NoiseMixin, RotationsMixin
+from .mixins import (
+    TruncatingCliffordExtensionMixin,
+    TruncatingCliffordMixin,
+    TruncatingNoiseMixin,
+    TruncatingRotationsMixin,
+)
 
 _COMPACT_RE = re.compile(r"^([IXYZ]\d+)+$")
 _COMPACT_TOKEN_RE = re.compile(r"([IXYZ])(\d+)")
@@ -74,10 +79,10 @@ LossyPauliSumInterface = Union[
 
 @dataclass(frozen=True)
 class PauliSum(
-    CliffordExtensionMixin,
-    CliffordMixin,
-    NoiseMixin,
-    RotationsMixin,
+    TruncatingCliffordExtensionMixin,
+    TruncatingCliffordMixin,
+    TruncatingNoiseMixin,
+    TruncatingRotationsMixin,
 ):
     """A weighted sum of Pauli strings for quantum simulation.
 

--- a/ppvm-python/test/test_truncate_kwarg.py
+++ b/ppvm-python/test/test_truncate_kwarg.py
@@ -12,7 +12,9 @@ preserves the historical behaviour.
 
 import math
 
-from ppvm import PauliSum
+import pytest
+
+from ppvm import GeneralizedTableau, PauliSum
 
 
 def _total_z(ps: PauliSum, n: int) -> float:
@@ -175,3 +177,55 @@ def test_noise_channels_accept_truncate_kwarg():
     for q in range(n):
         ps_ref.pauli_error(q, [0.0, 0.0, p_z])
     assert dict(ps.terms) == dict(ps_ref.terms)
+
+
+# =============================================================================
+# The `truncate` kwarg is a PauliSum-only feature. The generalized stabilizer
+# tableau is an exact representation with no per-gate truncation, so its gates
+# do not accept the kwarg.
+# =============================================================================
+
+
+def test_pauli_sum_gates_accept_truncate_kwarg():
+    """Every truncating gate on ``PauliSum`` accepts ``truncate=`` and the
+    Clifford gates are a no-op so far as the kwarg's effect goes."""
+    ps = PauliSum.new(2, "ZZ", min_abs_coeff=1e-10)
+    ps.x(0, truncate=False)
+    ps.cnot(0, 1, truncate=True)
+    ps.rx(0, 0.3, truncate=False)
+    ps.rxx(0, 1, 0.2, truncate=False)
+    ps.depolarize(0, 1e-3, truncate=False)
+    ps.truncate()
+
+
+def test_generalized_tableau_gates_reject_truncate_kwarg():
+    """The tableau backend exposes the same gate names without ``truncate``.
+
+    Passing it is a ``TypeError`` rather than a silently-ignored no-op, so the
+    kwarg cannot be mistaken for having an effect on the tableau.
+    """
+    tab = GeneralizedTableau(n_qubits=2)
+    for call in (
+        lambda: tab.x(0, truncate=False),
+        lambda: tab.cnot(0, 1, truncate=True),
+        lambda: tab.rx(0, 0.3, truncate=False),
+        lambda: tab.rxx(0, 1, 0.2, truncate=False),
+        lambda: tab.depolarize(0, 1e-3, truncate=False),
+    ):
+        with pytest.raises(TypeError):
+            call()
+
+
+def test_generalized_tableau_gates_still_work_without_kwarg():
+    """The plain gate calls (no ``truncate``) keep working on the tableau."""
+    # Non-Clifford / noise gates run without error.
+    tab = GeneralizedTableau(n_qubits=2)
+    tab.rx(0, 0.3)
+    tab.rxx(0, 1, 0.2)
+    tab.depolarize(0, 1e-3)
+
+    # A Bell pair still yields correlated measurements.
+    bell = GeneralizedTableau(n_qubits=2)
+    bell.h(0)
+    bell.cnot(0, 1)
+    assert bell.measure(0) == bell.measure(1)


### PR DESCRIPTION
This slipped through my review of #100. That PR added a dead truncate kwarg on the `GeneralizedTableau`, which was part of the public method, but didn't do anything. This would be quite surprising to users.

Also, this currently breaks CI for #101.