### PR TITLE
perf(ppvm-python-native): use mimalloc as the global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +680,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "num"
@@ -844,6 +862,7 @@ name = "ppvm-python-native"
 version = "0.1.0"
 dependencies = [
  "bnum",
+ "mimalloc",
  "num",
  "paste",
  "ppvm-runtime",

--- a/crates/ppvm-python-native/Cargo.toml
+++ b/crates/ppvm-python-native/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bnum = "0.13.0"
+mimalloc = { version = "0.1", default-features = false }
 num = "0.4.3"
 paste = "1.0.15"
 ppvm-runtime = { version = "0.1.0", path = "../ppvm-runtime" }

--- a/crates/ppvm-python-native/src/lib.rs
+++ b/crates/ppvm-python-native/src/lib.rs
@@ -1,6 +1,13 @@
 // SPDX-FileCopyrightText: 2026 The PPVM Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// Use mimalloc as the global allocator. It returns freed pages to the OS
+// more aggressively than the default system allocator, which materially
+// reduces peak RSS on the allocation-heavy Pauli-propagation paths — each
+// gate / truncation step churns large transient `Vec` / `HashMap` buffers.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use pyo3::prelude::*;
 
 pub mod interface;


### PR DESCRIPTION
## What

Sets [`mimalloc`](https://github.com/microsoft/mimalloc) as the `#[global_allocator]` for the `ppvm_python_native` extension module.

## Why

mimalloc returns freed pages to the OS more aggressively than the default system allocator. This materially reduces **peak RSS** on the allocation-heavy Pauli-propagation paths, where each gate / truncation step churns large transient `Vec` / `HashMap` buffers that the system allocator tends to retain.

Split out of #98 per review feedback (@Roger-luo): the allocator is an independent optimization and shouldn't be bundled into a feature PR — this lets it be reviewed and benchmarked on its own.

## Changes
- `crates/ppvm-python-native/Cargo.toml`: add `mimalloc = { version = "0.1", default-features = false }`.
- `crates/ppvm-python-native/src/lib.rs`: declare the global allocator (with a justifying comment).

## Validation
- `maturin develop --release` builds and links cleanly.
- `pytest ppvm-python/test/test_basics.py` green (smoke).

No API or behavior change — allocator only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)