### PR TITLE
fix: green the Rust pre-commit hooks (rustfmt, clippy)

### DIFF
--- a/crates/ppvm-pauli-sum/benches/trotter.rs
+++ b/crates/ppvm-pauli-sum/benches/trotter.rs
@@ -102,22 +102,40 @@ pub fn trotter_benchmarks(c: &mut Criterion) {
     println!("Using {} threads", current_num_threads());
     benchmark_suite_trotter::<
         config::gxhash::ByteF64<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>,
-    >(c, "ByteF64GxHashMap<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>");
+    >(
+        c,
+        "ByteF64GxHashMap<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>",
+    );
     benchmark_suite_trotter::<
         config::fxhash::ByteF64<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>,
-    >(c, "ByteF64FxHashMap<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>");
+    >(
+        c,
+        "ByteF64FxHashMap<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>",
+    );
     benchmark_suite_trotter::<
         config::dashmap::ByteFxHashF64<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>,
-    >(c, "ByteF64FxDashMap<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>");
+    >(
+        c,
+        "ByteF64FxDashMap<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>",
+    );
     benchmark_suite_trotter::<
         config::dashmap::ByteGxHashF64<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>,
-    >(c, "ByteF64GxDashMap<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>");
+    >(
+        c,
+        "ByteF64GxDashMap<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>",
+    );
     benchmark_suite_trotter::<
         config::indexmap::ByteFxHashF64<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>,
-    >(c, "ByteF64FxIndexMap<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>");
+    >(
+        c,
+        "ByteF64FxIndexMap<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>",
+    );
     benchmark_suite_trotter::<
         config::indexmap::ByteGxHashF64<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>,
-    >(c, "ByteF64GxIndexMap<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>");
+    >(
+        c,
+        "ByteF64GxIndexMap<2, CombinedStrategy<CoefficientThreshold, MaxPauliWeight>>",
+    );
 }
 
 criterion_group!(benches, trotter_benchmarks);

--- a/crates/ppvm-pauli-sum/benches/truncation-weight.rs
+++ b/crates/ppvm-pauli-sum/benches/truncation-weight.rs
@@ -69,11 +69,7 @@ where
     state
 }
 
-const PROFILES: &[(&str, usize)] = &[
-    ("w3", 3),
-    ("w50", 50),
-    ("w120", 120),
-];
+const PROFILES: &[(&str, usize)] = &[("w3", 3), ("w50", 50), ("w120", 120)];
 
 const CUTOFFS: &[(&str, usize)] = &[
     ("10", 10),

--- a/crates/ppvm-pauli-sum/examples/hash_quality.rs
+++ b/crates/ppvm-pauli-sum/examples/hash_quality.rs
@@ -99,7 +99,10 @@ where
     let mean_load = n as f64 / (1u64 << bucket_bits) as f64;
     let variance: f64 = {
         let m = mean_load;
-        let v: f64 = bucket_counts.values().map(|c| (*c as f64 - m).powi(2)).sum();
+        let v: f64 = bucket_counts
+            .values()
+            .map(|c| (*c as f64 - m).powi(2))
+            .sum();
         let unfilled = (1u64 << bucket_bits) as usize - bucket_counts.len();
         let zero_term = unfilled as f64 * m * m;
         (v + zero_term) / (1u64 << bucket_bits) as f64

--- a/crates/ppvm-pauli-word/src/phase/mul.rs
+++ b/crates/ppvm-pauli-word/src/phase/mul.rs
@@ -80,7 +80,7 @@ where
     // 11 11 00
     type Output = PhasedPauliWord<A, S, PauliWord<A, S, REHASH>>;
     fn mul(self, rhs: Self) -> Self::Output {
-        let mut output = self.clone();
+        let mut output = self;
         output *= rhs;
         output
     }

--- a/crates/ppvm-pauli-word/src/word/mul.rs
+++ b/crates/ppvm-pauli-word/src/word/mul.rs
@@ -14,7 +14,7 @@ where
 {
     type Output = PauliWord<A, S>;
     fn mul(self, rhs: Self) -> Self::Output {
-        let mut output = self.clone();
+        let mut output = self;
         output *= rhs;
         output
     }

--- a/crates/ppvm-python-native/src/interface_tableau_sum.rs
+++ b/crates/ppvm-python-native/src/interface_tableau_sum.rs
@@ -10,6 +10,10 @@ use pyo3::prelude::*;
 
 use crate::interface_tableau::measurement_to_u8;
 
+// rustfmt formats the `#[pyo3(signature = (...))]` attribute inside this macro
+// non-idempotently (it rewrites the indentation every pass), so `cargo fmt
+// --check` can never agree with `cargo fmt`. Skip formatting the macro body.
+#[rustfmt::skip]
 macro_rules! create_sum_interface {
     ($tab_name: ident, $sampler_name: ident, $type: ident, $indexType: ident) => {
         #[pyclass]
@@ -51,6 +55,10 @@ macro_rules! create_sum_interface {
 
             pub fn len(&self) -> usize {
                 self.inner.len()
+            }
+
+            pub fn is_empty(&self) -> bool {
+                self.inner.is_empty()
             }
 
             /// Mid-circuit measurement probabilities `(p_zero, p_one, p_lost)`.

--- a/crates/ppvm-tableau-sum/src/data.rs
+++ b/crates/ppvm-tableau-sum/src/data.rs
@@ -52,10 +52,10 @@ where
         let mut storage = S::with_capacity(1);
         storage.insert_or_merge_batch(vec![(g_tab, T::Coeff::one(), wfp, plh)], &sum_cutoff);
         Self {
-            n_qubits: n_qubits,
+            n_qubits,
             entries: storage,
-            rng: rng,
-            sum_cutoff: sum_cutoff,
+            rng,
+            sum_cutoff,
             _phantom: PhantomData,
         }
     }
@@ -75,16 +75,20 @@ where
         let mut storage = S::with_capacity(1);
         storage.insert_or_merge_batch(vec![(g_tab, T::Coeff::one(), wfp, plh)], &sum_cutoff);
         Self {
-            n_qubits: n_qubits,
+            n_qubits,
             entries: storage,
-            rng: rng,
-            sum_cutoff: sum_cutoff,
+            rng,
+            sum_cutoff,
             _phantom: PhantomData,
         }
     }
 
     pub fn len(&self) -> usize {
         self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
     }
 
     pub fn truncate(&mut self) {
@@ -136,8 +140,8 @@ where
 
         Sampler {
             p_cumulative: p_cum,
-            entries: entries,
-            rng: rng,
+            entries,
+            rng,
             scratch: ppvm_tableau::measure::MeasureScratch::new(),
         }
     }

--- a/crates/ppvm-tableau-sum/src/noise.rs
+++ b/crates/ppvm-tableau-sum/src/noise.rs
@@ -20,18 +20,19 @@ use rand::{RngExt, rngs::SmallRng};
 
 use crate::{
     data::GeneralizedTableauSum,
-    storage::{EntryStore, loss_mask, pauli_branch_phase_loss},
+    storage::{Branch, EntryStore, loss_mask, pauli_branch_phase_loss},
 };
 
 fn single_qubit_loss_branch<T, I, C>(
     addr0: usize,
     p: &T::Coeff,
     rng: &mut SmallRng,
-    branches: &mut Vec<(GeneralizedTableau<T, I, C>, T::Coeff, u64, u64)>,
+    branches: &mut Vec<Branch<T, I, C>>,
     tab: &mut GeneralizedTableau<T, I, C>,
     p_sum: &mut T::Coeff,
-    word_fp: u64,
-    phase_loss: u64,
+    // The branch inherits its parent's cached fingerprint halves:
+    // `(word_fingerprint, phase_loss_hash)`.
+    (word_fp, phase_loss): (u64, u64),
 ) where
     T: Config,
     <<T as Config>::Storage as BitView>::Store: PrimInt,
@@ -117,8 +118,7 @@ where
                     &mut branches,
                     tab,
                     p_sum,
-                    word_fp,
-                    phase_loss,
+                    (word_fp, phase_loss),
                 );
             });
 
@@ -407,8 +407,7 @@ where
                         &mut branches,
                         tab,
                         p_sum,
-                        word_fp,
-                        phase_loss,
+                        (word_fp, phase_loss),
                     );
                     return;
                 } else if tab.is_lost[addr1] {
@@ -419,8 +418,7 @@ where
                         &mut branches,
                         tab,
                         p_sum,
-                        word_fp,
-                        phase_loss,
+                        (word_fp, phase_loss),
                     );
                     return;
                 }

--- a/crates/ppvm-tableau-sum/src/sampler.rs
+++ b/crates/ppvm-tableau-sum/src/sampler.rs
@@ -85,13 +85,10 @@ where
 
         sample_inds_and_seeds
             .par_iter()
-            .map_init(
-                MeasureScratch::<I, T::Coeff>::new,
-                |mut scratch, &(i, seed)| {
-                    let mut tab = self.entries[i].0.fork(Some(seed));
-                    tab.measure_all_with_scratch(&mut scratch)
-                },
-            )
+            .map_init(MeasureScratch::<I, T::Coeff>::new, |scratch, &(i, seed)| {
+                let mut tab = self.entries[i].0.fork(Some(seed));
+                tab.measure_all_with_scratch(scratch)
+            })
             .collect()
     }
 

--- a/crates/ppvm-tableau-sum/src/storage/entry_store.rs
+++ b/crates/ppvm-tableau-sum/src/storage/entry_store.rs
@@ -5,9 +5,18 @@ use num::Complex;
 use ppvm_tableau::{data::GeneralizedTableau, sparsevec::SparseVector};
 use ppvm_traits::config::Config;
 
+/// One branch produced by a noise channel: its tableau, coefficient, and the
+/// cached `(word_fingerprint, phase_loss_hash)` pair, so a merge can recompute
+/// the full fingerprint (`word_fp ^ phase_loss`) without re-hashing the tableau.
+pub type Branch<T, I, C> = (GeneralizedTableau<T, I, C>, <T as Config>::Coeff, u64, u64);
+
 pub trait EntryStore<T: Config, I, C: SparseVector<Complex<T::Coeff>, I>>: Clone {
     fn with_capacity(cap: usize) -> Self;
     fn len(&self) -> usize;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 
     fn iter<'a>(&'a self) -> impl Iterator<Item = (&'a GeneralizedTableau<T, I, C>, &'a T::Coeff)>
     where
@@ -43,11 +52,7 @@ pub trait EntryStore<T: Config, I, C: SparseVector<Complex<T::Coeff>, I>>: Clone
     /// Each branch carries its parent's word-fingerprint and its own
     /// phase/loss hash (third and fourth tuple fields), so the full
     /// fingerprint is `word_fp ^ phase_loss` — no re-hashing of the tableau.
-    fn insert_or_merge_batch(
-        &mut self,
-        branches: Vec<(GeneralizedTableau<T, I, C>, T::Coeff, u64, u64)>,
-        cutoff: &T::Coeff,
-    ) -> bool;
+    fn insert_or_merge_batch(&mut self, branches: Vec<Branch<T, I, C>>, cutoff: &T::Coeff) -> bool;
 
     fn retain<F>(&mut self, f: F)
     where
@@ -59,7 +64,7 @@ pub trait EntryStore<T: Config, I, C: SparseVector<Complex<T::Coeff>, I>>: Clone
     /// storage backends that don't cache `word_fp` and `phase_loss` separately
     /// (e.g. map-keyed buckets), the split is `(fp, 0)`; either component may
     /// be XORed against the change delta — the merge sees their XOR.
-    fn drain_where<F>(&mut self, pred: F) -> Vec<(GeneralizedTableau<T, I, C>, T::Coeff, u64, u64)>
+    fn drain_where<F>(&mut self, pred: F) -> Vec<Branch<T, I, C>>
     where
         F: FnMut(&GeneralizedTableau<T, I, C>) -> bool;
 }

--- a/crates/ppvm-tableau-sum/src/storage/mod.rs
+++ b/crates/ppvm-tableau-sum/src/storage/mod.rs
@@ -5,7 +5,7 @@ pub mod entry_store;
 pub mod map;
 pub mod vec;
 
-pub use entry_store::EntryStore;
+pub use entry_store::{Branch, EntryStore};
 use fxhash::FxHashMap;
 use gxhash::GxHasher;
 use num::{

--- a/crates/ppvm-tableau/src/data.rs
+++ b/crates/ppvm-tableau/src/data.rs
@@ -59,13 +59,13 @@ impl<T: Config> Tableau<T> {
         let pw_cache = PhasedPauliWordNoHash::<T::Storage, T::BuildHasher>::new(n_qubits);
         for i in 0..n_qubits {
             // destabilizer
-            let mut pw = pw_cache.clone();
+            let mut pw = pw_cache;
             pw.set(i, Pauli::X);
             data.push(pw);
         }
         for i in 0..n_qubits {
             // stabilizer
-            let mut pw = pw_cache.clone();
+            let mut pw = pw_cache;
             pw.set(i, Pauli::Z);
             data.push(pw);
         }
@@ -155,8 +155,8 @@ impl<T: Config> Tableau<T> {
         let n = self.n_qubits;
         let (destabilizers, stabilizers) = self.data.split_at_mut(n);
 
-        // Clone g_q once before the loop
-        let g_q = stabilizers[q_idx].clone();
+        // Copy g_q once before the loop
+        let g_q = stabilizers[q_idx];
 
         // Check if there are other stabilizers that anticommute with Z_addr0
         // If so, replace with g_j = g_j * g_q


### PR DESCRIPTION
## Why

`main` does not pass its own Rust pre-commit hooks, so **every** Rust commit is
rejected by `prek`:

- `cargo fmt --all -- --check` — fails
- `cargo clippy --workspace -- -D warnings` — fails (16 lints across
  `ppvm-pauli-word`, `ppvm-tableau`, `ppvm-tableau-sum`)

This blocks any workflow that commits through the hooks (including automated
performance tuning of `ppvm-tableau`). This PR fixes the violations **properly**
— no `#[allow]`, no `--no-verify`.

## What

**rustfmt**
- `#[rustfmt::skip]` on the `create_sum_interface!` macro: rustfmt formats its
  `#[pyo3(signature = (...))]` attribute non-idempotently, so `cargo fmt` and
  `cargo fmt --check` never converge (no number of `cargo fmt` passes satisfies
  the check).
- Reformat pre-existing drift in `ppvm-pauli-sum` benches/examples.

**clippy**
- `clone_on_copy`: drop redundant `.clone()` on `Copy` types (×5).
- `type_complexity`: factor the noise-branch tuple into a
  `Branch<T, I, C>` type alias.
- `len_without_is_empty`: add `is_empty` companions to `len` on the
  `EntryStore` trait, `GeneralizedTableauSum`, and the `create_sum_interface!`
  pyclass macro (fixes 32 call sites at once).
- `too_many_arguments`: group `single_qubit_loss_branch`'s paired fingerprint
  args into a single `(u64, u64)`.
- drop a redundant `mut` binding in the sampler.

## Testing

- `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings`,
  `cargo check --workspace --all-targets`, and `hawkeye check` all pass.
- `cargo test -p ppvm-tableau -p ppvm-tableau-sum -p ppvm-pauli-word` — all pass.
- No behavior change (the clippy fixes are no-ops on `Copy`/redundant code;
  the type alias and arg-grouping are signature-only).

## Out of scope (follow-up)

The **Python** hooks also fail on `main` but only gate commits that touch
Python files, so they are intentionally left out of this Rust-only PR:

- `ruff format --check` — drift in 3 files
- `ty check` — **72 pre-existing diagnostics** (mostly "argument does not match
  any known parameter of bound method" against the native bindings)

These warrant a separate Python-focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
