### PR TITLE
ci: extension-only cross-OS verification, gated on Linux + docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,16 +85,20 @@ jobs:
       - name: Run Python tests
         run: uv run --project ppvm-python --group dev pytest ppvm-python/test/ docs/examples/
 
-  # Verify the workspace and the PyO3 extension compile, link, and test on all
-  # three desktop OSes. The deep test suites above run on Linux only; this job
-  # is the cross-platform compilation/linking gate.
-  cross-platform:
-    name: Build (${{ matrix.os }})
-    needs: pre-commit
+  # The pure-Rust crates are platform-agnostic and fully verified on Linux by
+  # the jobs above. The PyO3 extension is the only OS-sensitive artifact (macOS
+  # `-undefined dynamic_lookup`, Windows `python3.lib`), so it is the only thing
+  # rebuilt on other OSes — and building it via maturin compiles the entire
+  # crate tree on that OS as a side effect, so a cross-OS compile regression
+  # still surfaces here. `needs:` the Linux test jobs so macOS/Windows runners
+  # only spin up once Linux is green (no point paying for them otherwise).
+  extension-cross-platform:
+    name: Extension (${{ matrix.os }})
+    needs: [rust-tests, python-tests]
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -103,25 +107,13 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      # Compiles every crate and target (lib, tests, benches, examples) without
-      # linking — the portable "does it build" gate, identical on each OS.
-      - name: Check the workspace compiles
-        run: cargo check --workspace --all-targets
-
-      # Links the cdylib too, which exercises the macOS `-undefined
-      # dynamic_lookup` flag from ppvm-python-native's build.rs. Skipped on
-      # Windows, where linking the extension needs python3.lib — that path is
-      # covered by the maturin build below instead.
-      - name: Build the workspace
-        if: runner.os != 'Windows'
-        run: cargo build --workspace
-
       - uses: astral-sh/setup-uv@v5
 
-      # maturin links the abi3 extension the per-OS way (dynamic_lookup on
-      # macOS, python3.lib on Windows); pytest confirms it imports and runs.
-      - name: Build the extension via maturin
+      # Compiles ppvm-python-native and its whole dependency tree, then links
+      # the abi3 extension the per-OS way (maturin handles dynamic_lookup /
+      # python3.lib for us).
+      - name: Build the extension (maturin via uv)
         run: uv sync --project ppvm-python --group dev
 
-      - name: Run Python tests
+      - name: Run the extension's Python tests
         run: uv run --project ppvm-python --group dev pytest ppvm-python/test/

--- a/docs/src/pages/develop.astro
+++ b/docs/src/pages/develop.astro
@@ -400,6 +400,56 @@ npm run build          # extract everything, then `astro build` → dist/</code>
       <code><a href="https://github.com/QuEraComputing/ppvm/blob/main/docs/README.md">docs/README.md</a></code>.
     </p>
 
+    <h3>Continuous integration</h3>
+
+    <p>
+      CI lives in <code>.github/workflows/ci.yml</code> and is staged so the
+      cheap, platform-independent checks gate the expensive cross-OS ones:
+    </p>
+    <ol>
+      <li>
+        <strong><code>pre-commit</code></strong> (Linux) runs the full
+        <code>prek</code> hook suite — rustfmt, clippy, <code>cargo check
+        --workspace --all-targets</code>, ruff, ty, hawkeye, and the file
+        hygiene hooks. Every other job <code>needs:</code> it, so a lint or
+        type failure stops the run before any test minutes are spent.
+      </li>
+      <li>
+        <strong><code>rust-tests</code></strong> and
+        <strong><code>python-tests</code></strong> (Linux) run
+        <code>cargo test --workspace</code> and the <code>pytest</code>
+        suites. The pure-Rust crates are platform-agnostic, so Linux is the
+        only OS that runs the full test suites.
+      </li>
+      <li>
+        <strong><code>extension-cross-platform</code></strong> (macOS +
+        Windows) is the only cross-OS job. It builds the PyO3 extension via
+        maturin and runs the extension's <code>pytest</code> suite. It
+        <code>needs: [rust-tests, python-tests]</code>, so the macOS/Windows
+        runners only start once Linux is fully green.
+      </li>
+    </ol>
+    <p>
+      <strong>Why cross-OS is extension-only.</strong> The compiled PyO3
+      module is the only artifact whose build is OS-sensitive — macOS needs
+      <code>-undefined dynamic_lookup</code> (added by
+      <code>ppvm-python-native/build.rs</code>; maturin sets it too), Windows
+      links <code>python3.lib</code>, and Linux needs neither. Building that
+      extension with maturin also compiles <code>ppvm-python-native</code> and
+      its entire dependency tree on the target OS, so a cross-platform compile
+      regression in any crate still surfaces here — without separately running
+      <code>cargo build</code> for the whole workspace three times.
+    </p>
+    <p>
+      <strong>No global <code>RUSTFLAGS</code>.</strong> gxhash's
+      <code>+aes,+sse2</code> target features are set <em>arch-scoped</em> in
+      <code>.cargo/config.toml</code>
+      (<code>cfg(target_arch = "x86_64")</code>), not as a workflow-wide
+      <code>RUSTFLAGS</code> — those x86 features are invalid on the aarch64
+      <code>macos-latest</code> runner and would fail to compile there. Linux
+      and Windows (x86_64) still pick them up from the config.
+    </p>
+
     <h2 id="architecture"><span class="sec-num">§ 3</span>Architecture</h2>
 
     <p>


### PR DESCRIPTION
Follow-up to #134. Restructures CI now that the Python packaging settled, and documents the setup.

### What changes
- **Cross-OS is now extension-only.** The pure-Rust crates are platform-agnostic, so the full `cargo test` / `pytest` suites stay **Linux-only**. The PyO3 extension is the one OS-sensitive artifact (macOS `-undefined dynamic_lookup`, Windows `python3.lib`), so the old build-everything-on-three-OSes matrix is replaced by an `extension-cross-platform` job (**macOS + Windows**) that builds the extension via maturin and runs its pytest suite. Building it also compiles the whole crate tree on each OS, so cross-platform compile regressions still surface.
- **Linux-first gating.** The cross-OS job `needs: [rust-tests, python-tests]`, so macOS/Windows runners only start once Linux is green.
- **Docs.** The developer guide (§ 2) now documents the CI job graph, why cross-OS is extension-scoped, and the arch-scoped gxhash `RUSTFLAGS`.

<details>
<summary>Resulting job graph</summary>

```
pre-commit (Linux)                      # lint/format/type gate; everything needs it
├── rust-tests (Linux)                  # cargo test --workspace
├── python-tests (Linux)                # pytest + docs/examples
└── extension-cross-platform (macOS, Windows)   # needs: [rust-tests, python-tests]
        uv sync (maturin build) + pytest         #   only runs once Linux is green
```
</details>

**Validation:** `ci.yml` YAML validated; the cross-OS legs were already proven green on #134 (macOS + Windows built and tested the extension there).
