### PR TITLE
fix(wasm): compile for wasm32 generically, without pointer-width gates

### DIFF
--- a/crates/ppvm-pauli-sum/src/config/fx64hash.rs
+++ b/crates/ppvm-pauli-sum/src/config/fx64hash.rs
@@ -8,19 +8,28 @@ use ppvm_pauli_word::word::PauliWord;
 use ppvm_traits::config::Config;
 use ppvm_traits::traits::{Coefficient, NoStrategy, PauliWordTrait, Strategy};
 
-/// `HashMap`-backed [`Config`] with `[u64; N]` storage and `FxHasher`.
+/// `HashMap`-backed [`Config`] with native-word (`[usize; N]`) storage and
+/// `FxHasher`.
+///
+/// The storage element is `usize`, i.e. the target's native machine word:
+/// `u64` on 64-bit targets (identical layout and performance to a hardcoded
+/// `[u64; N]`) and `u32` on 32-bit targets such as `wasm32`. Using `usize`
+/// rather than `u64` keeps this config available on every target — `bitvec`
+/// only implements `BitStore` for `u64` on 64-bit pointer widths, but always
+/// implements it for `usize`. (The `Byte8` name refers to the 64-bit word
+/// this config packs into on native targets.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Byte8<
     const N: usize,
     C: Coefficient,
     St: Strategy = NoStrategy,
-    W: PauliWordTrait = PauliWord<[u64; N], fxhash::FxBuildHasher>,
+    W: PauliWordTrait = PauliWord<[usize; N], fxhash::FxBuildHasher>,
 >(PhantomData<(C, St, W)>);
 
 impl<const N: usize, C: Coefficient, St: Strategy, W: PauliWordTrait> Config
     for Byte8<N, C, St, W>
 {
-    type Storage = [u64; N];
+    type Storage = [usize; N];
     type Coeff = C;
     type BuildHasher = fxhash::FxBuildHasher;
     type PauliWordType = W;

--- a/crates/ppvm-pauli-word/src/phase/data.rs
+++ b/crates/ppvm-pauli-word/src/phase/data.rs
@@ -3,8 +3,6 @@
 
 use std::hash::BuildHasher;
 
-use num::Integer;
-
 use crate::word::PauliWord;
 use ppvm_traits::char::Pauli;
 use ppvm_traits::traits::{HashFinalize, PauliStorage, PauliWordTrait};
@@ -125,8 +123,8 @@ impl<A: PauliStorage, H: BuildHasher + Default + Clone + HashFinalize, W: PauliW
     }
 }
 
-impl<H: BuildHasher + Default + Clone + HashFinalize> From<String>
-    for PhasedPauliWord<u64, H, PauliWord<u64, H>>
+impl<A: PauliStorage, H: BuildHasher + Default + Clone + HashFinalize> From<String>
+    for PhasedPauliWord<A, H, PauliWord<A, H>>
 {
     fn from(s: String) -> Self {
         let mut chars = s.chars();
@@ -137,9 +135,10 @@ impl<H: BuildHasher + Default + Clone + HashFinalize> From<String>
             (Some('-'), _) => 2,         // -1
             _ => panic!("Invalid phase format"),
         };
-        // Remaining characters are the Pauli string
-        let s: String = s.chars().skip(if phase.is_odd() { 2 } else { 1 }).collect();
-        let words: PauliWord<u64, H> = s.into();
+        // Remaining characters are the Pauli string. Odd phases (`+i`/`-i`)
+        // carry a two-char prefix; even phases (`+`/`-`) carry one.
+        let s: String = s.chars().skip(if phase & 1 == 1 { 2 } else { 1 }).collect();
+        let words: PauliWord<A, H> = s.into();
         Self {
             word: words,
             phase,
@@ -148,8 +147,8 @@ impl<H: BuildHasher + Default + Clone + HashFinalize> From<String>
     }
 }
 
-impl<H: BuildHasher + Default + Clone + HashFinalize> From<&str>
-    for PhasedPauliWord<u64, H, PauliWord<u64, H>>
+impl<A: PauliStorage, H: BuildHasher + Default + Clone + HashFinalize> From<&str>
+    for PhasedPauliWord<A, H, PauliWord<A, H>>
 {
     fn from(s: &str) -> Self {
         s.to_string().into()

--- a/crates/stim-parser/src/parser.rs
+++ b/crates/stim-parser/src/parser.rs
@@ -51,27 +51,39 @@ pub(crate) struct RawTarget {
 /// 2–8 MiB), deeply nested programs overflow somewhere past ~24 levels
 /// in debug builds. Running on an oversized dedicated stack lets us
 /// support thousands of nested REPEATs without rewriting the grammar.
+#[cfg(not(target_arch = "wasm32"))]
 const PARSER_STACK_SIZE: usize = 16 * 1024 * 1024;
 
-/// Run `f` on a dedicated thread with [`PARSER_STACK_SIZE`] bytes of
-/// stack. Used by both [`parse`] and [`parse_extended`] (which also
-/// recurses into REPEAT bodies during the interpret pass).
+/// Run `f` with a large stack for the recursive chumsky grammar. On targets
+/// with OS threads this spawns a dedicated [`PARSER_STACK_SIZE`]-byte thread;
+/// on `wasm32` (no `std::thread`) `f` runs inline on the caller's stack, so
+/// deeply nested REPEAT bodies rely on the wasm stack instead (configurable
+/// via the linker `stack-size` arg). Used by both [`parse`] and
+/// [`parse_extended`] (which also recurses into REPEAT bodies during the
+/// interpret pass).
 pub(crate) fn run_on_parser_stack<R, F>(f: F) -> R
 where
     R: Send,
     F: FnOnce() -> R + Send,
 {
-    std::thread::scope(|s| {
-        let handle = std::thread::Builder::new()
-            .stack_size(PARSER_STACK_SIZE)
-            .name("stim-parser".to_string())
-            .spawn_scoped(s, f)
-            .expect("failed to spawn parser thread");
-        match handle.join() {
-            Ok(value) => value,
-            Err(payload) => std::panic::resume_unwind(payload),
-        }
-    })
+    #[cfg(target_arch = "wasm32")]
+    {
+        f()
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        std::thread::scope(|s| {
+            let handle = std::thread::Builder::new()
+                .stack_size(PARSER_STACK_SIZE)
+                .name("stim-parser".to_string())
+                .spawn_scoped(s, f)
+                .expect("failed to spawn parser thread");
+            match handle.join() {
+                Ok(value) => value,
+                Err(payload) => std::panic::resume_unwind(payload),
+            }
+        })
+    }
 }
 
 /// Parse Stim source into a [`Program`].


### PR DESCRIPTION
## Summary

An alternative to #138 that makes the affected crates compile for `wasm32`
(32-bit pointer width, no OS threads) **without hardcoded `target_pointer_width`
gates**. Where #138 gates the 64-bit-only code paths *off* on 32-bit targets,
this keeps every API available on all targets by choosing storage and
constructors that are generic over the target word size. Behavior on 64-bit
native builds is unchanged.

Two of #138's three gates disappear entirely; the third (threads) is genuinely
about thread availability, not pointer width, and stays.

## Changes

- **`ppvm-pauli-sum`** — the `fx64hash` configs now use native-word
  **`[usize; N]`** storage instead of a hardcoded `[u64; N]`. `usize` is `u64`
  on 64-bit (identical layout and performance) and `u32` on `wasm32`. `bitvec`
  only implements `BitStore` for `u64` on 64-bit pointer widths, but **always**
  for `usize` — so `fx64hash::Byte8F64` stays available on every target instead
  of vanishing on `wasm32`. The switch is transparent to downstream code, which
  names the `Byte8F64` alias rather than the storage type.

- **`ppvm-pauli-word`** — the `PhasedPauliWord` `From<String>`/`From<&str>`
  constructors are now generic over `A: PauliStorage` instead of hardcoded to
  `u64`. The underlying `PauliWord<A, H>: From<String>` was already generic, so
  this removes a self-inflicted `u64` restriction (and adds string constructors
  for `[u8; N]` storage that didn't exist before). The sole `num::Integer` use
  (`phase.is_odd()`) becomes `phase & 1 == 1`, dropping the import.

- **`stim-parser`** — `wasm32` has no `std::thread`, so run the recursive
  chumsky grammar inline on the caller's stack there instead of on a dedicated
  16 MiB thread. This is a thread-availability fallback (`target_arch = "wasm32"`),
  not a pointer-width gate.

## Verification

- `cargo test --workspace` (excluding the `ppvm-python-native` test target,
  whose macOS Python-symbol link issue is pre-existing): **737 passed, 0 failed**.
- Full workspace `--all-targets` (all `Byte8F64` consumers) and the
  `ppvm-python-native` cdylib build unchanged on 64-bit.
- `ppvm-traits`, `ppvm-pauli-word`, `ppvm-pauli-sum`, `stim-parser` build for
  `wasm32-unknown-unknown`.
- Negative test: temporarily restoring `[u64; N]` reproduces
  `the trait bound [u64; N]: bitvec::view::BitViewSized is not satisfied` on
  `wasm32`; `[usize; N]` compiles. So the storage change is exactly what unblocks it.

## Out of scope (separate, pre-existing wasm blocker)

The crates' **default features** pull native-only deps that don't build on
`wasm32-unknown-unknown` — `ahash → getrandom` (needs the `wasm_js` backend),
`gxhash` (no wasm support), `dashmap → rayon`. The wasm builds above were done
with `--no-default-features`. #138 didn't address this either; a wasm-friendly
feature story (propagating `default-features = false` through the inter-crate
path deps and/or gating those hashers off on wasm) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)