### PR TITLE
feat(wasm): build the full workspace (minus python-native) for browser wasm32

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,3 +2,10 @@
 # build/test commands match CI without per-command RUSTFLAGS.
 [target.'cfg(target_arch = "x86_64")']
 rustflags = ["-C", "target-feature=+aes,+sse2"]
+
+# On wasm32 (browser) `getrandom` has no default entropy source. Select its JS
+# backend so `rand` (e.g. `rand::make_rng()` in the tableau simulators) reads
+# from the Web Crypto API. Pairs with the `getrandom`/`wasm_js` feature enabled
+# in ppvm-tableau's wasm-only dependency table. No per-command RUSTFLAGS needed.
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg", 'getrandom_backend="wasm_js"']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,28 @@ jobs:
       - name: Run ppvm-stim tests with rayon feature
         run: cargo test -p ppvm-stim --features rayon
 
+  # Cross-compile the whole workspace for browser wasm so a wasm regression
+  # surfaces in CI. `ppvm-python-native` is a CPython extension (never a wasm
+  # target) and is excluded. Native-only acceleration deps (gxhash, dashmap →
+  # rayon, ahash) are pruned automatically by the `cfg(not(target_arch =
+  # "wasm32"))` dependency tables, and `rand`'s entropy uses the getrandom
+  # `wasm_js` backend wired in `.cargo/config.toml` — so no extra flags here.
+  wasm-build:
+    name: wasm32 build (browser)
+    needs: pre-commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build workspace for wasm32-unknown-unknown
+        run: cargo build --target wasm32-unknown-unknown --workspace --exclude ppvm-python-native
+
   python-tests:
     name: Python tests
     needs: pre-commit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,11 +542,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1005,6 +1007,7 @@ dependencies = [
  "bnum",
  "criterion 0.7.0",
  "fxhash",
+ "getrandom 0.4.1",
  "insta",
  "itertools 0.14.0",
  "num",

--- a/crates/ppvm-pauli-sum/Cargo.toml
+++ b/crates/ppvm-pauli-sum/Cargo.toml
@@ -11,9 +11,14 @@ num = "0.4.3"
 itertools = "0.14.0"
 bon = "3.7.2"
 approx = { version = "0.5.1", optional = true }
+indexmap = { version = "2.11.4", optional = true }
+
+# Native-only optional deps: dashmap pulls rayon (OS threads) and gxhash needs
+# AES intrinsics — neither builds on wasm32. Pruned there; the matching features
+# go inert (see the `not(target_arch = "wasm32")` gates on the config modules).
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dashmap = { version = "6.1.0", features = ["rayon"], optional = true }
 gxhash = { version = "3.5.0", features = ["deterministic"], optional = true }
-indexmap = { version = "2.11.4", optional = true }
 
 [dev-dependencies]
 criterion = "0.7.0"

--- a/crates/ppvm-pauli-sum/src/config/indexmap.rs
+++ b/crates/ppvm-pauli-sum/src/config/indexmap.rs
@@ -28,6 +28,10 @@ impl<const N: usize, C: Coefficient, St: Strategy, W: PauliWordTrait> Config
 }
 
 /// `IndexMap`-backed [`Config`] with `[u8; N]` storage and `gxhash`.
+///
+/// `gxhash` is AES-based and native-only, so this config is unavailable on
+/// `wasm32`; use [`ByteFxHash`] there.
+#[cfg(all(feature = "gxhash", not(target_arch = "wasm32")))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ByteGxHash<
     const N: usize,
@@ -36,6 +40,7 @@ pub struct ByteGxHash<
     W: PauliWordTrait = PauliWord<[u8; N], gxhash::GxBuildHasher>,
 >(PhantomData<(C, St, W)>);
 
+#[cfg(all(feature = "gxhash", not(target_arch = "wasm32")))]
 impl<const N: usize, C: Coefficient, St: Strategy, W: PauliWordTrait> Config
     for ByteGxHash<N, C, St, W>
 {
@@ -54,6 +59,7 @@ pub type ByteFxHashF64<
     Wd = PauliWord<[u8; N], fxhash::FxBuildHasher>,
 > = ByteFxHash<N, f64, St, Wd>;
 /// [`ByteGxHash`] specialised to `f64` coefficients.
+#[cfg(all(feature = "gxhash", not(target_arch = "wasm32")))]
 pub type ByteGxHashF64<
     const N: usize,
     St = NoStrategy,

--- a/crates/ppvm-pauli-sum/src/config/mod.rs
+++ b/crates/ppvm-pauli-sum/src/config/mod.rs
@@ -9,7 +9,9 @@ pub mod fx64hash;
 pub mod fxhash;
 
 /// Pre-built configs backed by `dashmap::DashMap` for concurrent access.
-#[cfg(feature = "dashmap")]
+/// Native-only: `dashmap` pulls `rayon`, which needs OS threads, so this
+/// module is unavailable on `wasm32`.
+#[cfg(all(feature = "dashmap", not(target_arch = "wasm32")))]
 pub mod dashmap;
 
 /// Pre-built configs backed by `indexmap::IndexMap`, preserving

--- a/crates/ppvm-pauli-word/Cargo.toml
+++ b/crates/ppvm-pauli-word/Cargo.toml
@@ -11,9 +11,13 @@ fxhash = "0.2.1"
 num = "0.4.3"
 anyhow = "1.0.100"
 itertools = "0.14.0"
-gxhash = { version = "3.5.0", features = ["deterministic"], optional = true }
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 bincode = { version = "2.0.1", optional = true }
+
+# gxhash needs AES intrinsics and does not build on wasm32; pruned there (the
+# `gxhash` feature goes inert). No non-test code in this crate names the crate.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+gxhash = { version = "3.5.0", features = ["deterministic"], optional = true }
 
 [features]
 default = ["gxhash"]

--- a/crates/ppvm-stim/Cargo.toml
+++ b/crates/ppvm-stim/Cargo.toml
@@ -16,6 +16,9 @@ itertools = "0.14"
 num = "0.4.3"
 thiserror = "2"
 stim-parser = { version = "0.1.0", path = "../stim-parser" }
+
+# rayon needs OS threads — native only.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rayon = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/crates/ppvm-tableau-sum/Cargo.toml
+++ b/crates/ppvm-tableau-sum/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 [dependencies]
 bitvec = "1.0.1"
 fxhash = "0.2.1"
-gxhash = "3.5.0"
 num = "0.4.3"
 ppvm-traits = { version = "0.1.0", path = "../ppvm-traits" }
 ppvm-pauli-word = { version = "0.1.0", path = "../ppvm-pauli-word" }
@@ -14,6 +13,12 @@ ppvm-pauli-sum = { version = "0.1.0", path = "../ppvm-pauli-sum" }
 ppvm-tableau = { version = "0.1.0", path = "../ppvm-tableau" }
 rand = "0.10.1"
 smallvec = "1.15"
+
+# Native-only deps: gxhash (AES, used for the word_fingerprint hasher — see the
+# target-gated alias in src/storage/mod.rs) and rayon (OS threads). Pruned on
+# wasm32; fxhash backs the fingerprint there.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+gxhash = "3.5.0"
 rayon = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/crates/ppvm-tableau-sum/src/storage/mod.rs
+++ b/crates/ppvm-tableau-sum/src/storage/mod.rs
@@ -7,7 +7,16 @@ pub mod vec;
 
 pub use entry_store::{Branch, EntryStore};
 use fxhash::FxHashMap;
-use gxhash::GxHasher;
+
+// Hasher for the structural `word_fingerprint`. gxhash (AES-based) is fastest on
+// native but needs hardware AES and does not build on wasm32, so fall back to
+// fxhash there. The fingerprint is a transient in-memory dedup key — collisions
+// are resolved by `structurally_equal`, and it is never persisted or compared
+// across builds — so the hasher may differ per target without affecting results.
+#[cfg(target_arch = "wasm32")]
+use fxhash::FxHasher as FingerprintHasher;
+#[cfg(not(target_arch = "wasm32"))]
+use gxhash::GxHasher as FingerprintHasher;
 use num::{
     Complex, One, Zero,
     complex::{Complex64, ComplexFloat},
@@ -33,7 +42,7 @@ where
     I:,
     C: SparseVector<Complex<T::Coeff>, I>,
 {
-    let mut hasher = GxHasher::default();
+    let mut hasher = FingerprintHasher::default();
     for row in tab.tableau.data.iter() {
         // Hash the Pauli bits directly: the `PauliWord` hash cache is disabled
         // for tableau rows (`REHASH = false`), so `row.word.hash()` would feed

--- a/crates/ppvm-tableau/Cargo.toml
+++ b/crates/ppvm-tableau/Cargo.toml
@@ -17,7 +17,18 @@ ppvm-traits = { version = "0.1.0", path = "../ppvm-traits" }
 ppvm-pauli-sum = { version = "0.1.0", path = "../ppvm-pauli-sum" }
 rand = "0.10.1"
 smallvec = "1.15"
+
+# rayon needs OS threads — native only.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rayon = { version = "1.10", optional = true }
+
+# On wasm32, rand's entropy crate (getrandom) has no default source. Enable its
+# browser backend's `wasm_js` feature here (paired with the
+# `getrandom_backend="wasm_js"` rustflag in .cargo/config.toml); feature
+# unification then wires entropy for every crate that pulls rand transitively
+# (ppvm-tableau-sum, ppvm-stim, the top-level ppvm crate).
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.4", features = ["wasm_js"] }
 
 [dev-dependencies]
 criterion = "0.7.0"

--- a/crates/ppvm-traits/Cargo.toml
+++ b/crates/ppvm-traits/Cargo.toml
@@ -8,10 +8,17 @@ bitvec = "1.0.1"
 bytemuck = { version = "1", features = ["min_const_generics"] }
 fxhash = "0.2.1"
 num = "0.4.3"
+indexmap = { version = "2.11.4", optional = true }
+
+# Native-only optional deps: gxhash needs AES intrinsics, dashmap/rayon need OS
+# threads, and ahash pulls getrandom — none build on wasm32. They are pruned on
+# wasm, where the matching features go inert (see the `not(target_arch =
+# "wasm32")` code gates), so a wasm build silently drops these acceleration
+# paths. On 64-bit native nothing changes.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ahash = { version = "0.8.12", optional = true }
 dashmap = { version = "6.1.0", features = ["rayon"], optional = true }
 gxhash = { version = "3.5.0", features = ["deterministic"], optional = true }
-indexmap = { version = "2.11.4", optional = true }
 rayon = { version = "1.11.0", optional = true }
 
 [dev-dependencies]

--- a/crates/ppvm-traits/src/map/hashmap.rs
+++ b/crates/ppvm-traits/src/map/hashmap.rs
@@ -318,7 +318,7 @@ mod indexmap_impl {
     impl_acmap_retain!(indexmap::IndexMap);
 }
 
-#[cfg(feature = "ahash")]
+#[cfg(all(feature = "ahash", not(target_arch = "wasm32")))]
 mod ahash_impl {
     use super::*;
 

--- a/crates/ppvm-traits/src/map/mod.rs
+++ b/crates/ppvm-traits/src/map/mod.rs
@@ -3,5 +3,5 @@
 
 mod hashmap;
 
-#[cfg(feature = "dashmap")]
+#[cfg(all(feature = "dashmap", not(target_arch = "wasm32")))]
 mod dashmap;

--- a/crates/ppvm-traits/src/traits/hash.rs
+++ b/crates/ppvm-traits/src/traits/hash.rs
@@ -65,7 +65,7 @@ impl HashFinalize for fxhash::FxBuildHasher {
 // max bucket 6, essentially ideal, vs fxhash's 2257 at 64 qubits), so the
 // identity default is exactly right — folding would only pay the tag/bucket
 // coupling cost above with no distribution benefit.
-#[cfg(feature = "gxhash")]
+#[cfg(all(feature = "gxhash", not(target_arch = "wasm32")))]
 impl HashFinalize for gxhash::GxBuildHasher {}
 
 #[cfg(test)]
@@ -99,7 +99,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "gxhash")]
+    #[cfg(all(feature = "gxhash", not(target_arch = "wasm32")))]
     #[test]
     fn gxhash_never_folds() {
         // gxhash already distributes its low bits, so it is the identity at

--- a/docs/src/pages/develop.astro
+++ b/docs/src/pages/develop.astro
@@ -166,6 +166,46 @@ cargo bench --bench micro -- "gates/single-qubit/h"</code></pre>
       <code>--no-default-features --features=indexmap,ahash</code> or similar.
     </p>
 
+    <h3>WebAssembly (wasm32)</h3>
+
+    <p>
+      The whole workspace except <code>ppvm-python-native</code> (a CPython
+      extension, never a wasm target) cross-compiles to browser wasm with no
+      extra flags:
+    </p>
+<pre><code class="language-bash">rustup target add wasm32-unknown-unknown
+
+# The simulators, Pauli engine, Stim parser, and top-level `ppvm` crate.
+cargo build --target wasm32-unknown-unknown --workspace --exclude ppvm-python-native</code></pre>
+
+    <p>
+      The build is wasm-clean automatically. Native-only acceleration
+      dependencies — <code>gxhash</code> (AES intrinsics), <code>dashmap</code> →
+      <code>rayon</code> (OS threads), and <code>ahash</code> — live in
+      <code>[target.'cfg(not(target_arch = "wasm32"))'.dependencies]</code>
+      tables, so on wasm they are pruned and the matching features go inert
+      (the code that names those crates is gated with the same
+      <code>not(target_arch = "wasm32")</code>). The <code>fx64hash</code> configs
+      use native-word <code>[usize; N]</code> storage (<code>u64</code> on
+      64-bit, <code>u32</code> on wasm) since <code>bitvec</code> only implements
+      <code>BitStore</code> for <code>u64</code> on 64-bit pointer widths.
+      <code>ppvm-tableau-sum</code>'s structural fingerprint falls back from
+      <code>gxhash</code> to <code>fxhash</code> on wasm.
+    </p>
+
+    <p>
+      <code>rand</code>'s entropy (<code>rand::make_rng()</code>) has no default
+      source on <code>wasm32-unknown-unknown</code>, so the getrandom
+      <code>wasm_js</code> backend (Web Crypto API) is selected via a
+      <code>--cfg getrandom_backend="wasm_js"</code> rustflag in
+      <code>.cargo/config.toml</code> plus the <code>wasm_js</code> feature in
+      <code>ppvm-tableau</code>'s wasm-only dependency table — so the JS runtime
+      supplies randomness. There are no OS threads on wasm: the <code>rayon</code>
+      feature is unavailable, and the Stim parser runs its recursive grammar
+      inline instead of on a dedicated stack thread. The <code>wasm32 build</code>
+      CI job compiles the workspace for this target on every PR.
+    </p>
+
     <h3>Python</h3>
 <pre><code class="language-bash"># Requires uv (https://docs.astral.sh/uv/)
 # The native module compiles automatically via maturin on first run.


### PR DESCRIPTION
## Summary

Follow-up to #143 (now merged): #143 made the *compile gates* generic; this PR
closes the **dependency / feature-graph** blockers so the whole workspace
except `ppvm-python-native` cross-compiles to **`wasm32-unknown-unknown`**
(browser / wasm-bindgen) — `cargo build --target wasm32-unknown-unknown` with
**no extra flags**. Native builds keep gxhash/dashmap/ahash/rayon and are
byte-for-byte unchanged.

## Mechanism (automatic)

Cargo prunes a dependency under `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]`
on wasm, but the **feature named after it stays on**, so `#[cfg(feature = "X")]`
code would still try to compile against the absent crate. The fix is two
coordinated moves per native-only dep: target-gate the dep **and** gate its code
sites with the same `not(target_arch = "wasm32")`. The features then go inert on
wasm, so **no `default-features = false` propagation through the inter-crate deps
is needed**.

## Changes

- **`ppvm-traits`** — target-gate `ahash`/`dashmap`/`gxhash`/`rayon`; gate the
  dashmap map module, the ahash `ACMap` impls, and the `gxhash` `HashFinalize` impl.
- **`ppvm-pauli-word`** — target-gate `gxhash`.
- **`ppvm-pauli-sum`** — target-gate `dashmap`/`gxhash`; gate the
  `config::dashmap` module and `config::indexmap`'s `ByteGxHash`/`ByteGxHashF64`
  (also fixes a latent `indexmap`-without-`gxhash` coupling).
- **`ppvm-tableau-sum`** — target-gate `gxhash`/`rayon`; `word_fingerprint`
  falls back from `GxHasher` to `fxhash::FxHasher` on wasm (a transient in-memory
  dedup hash, resolved by `structurally_equal`, never persisted or compared
  across platforms).
- **`ppvm-tableau` / `ppvm-stim`** — target-gate `rayon` (no OS threads on wasm).
- **rand entropy** — `rand::make_rng()` has no default source on
  `wasm32-unknown-unknown`, so select getrandom's `wasm_js` (Web Crypto) backend
  via a `--cfg getrandom_backend="wasm_js"` rustflag in `.cargo/config.toml` plus
  the `wasm_js` feature in `ppvm-tableau`'s wasm-only dep table; feature
  unification covers tableau-sum / stim / top-level `ppvm`.
- **CI** — new `wasm32 build (browser)` job cross-compiles the workspace on every PR.
- **docs** — WebAssembly subsection in `develop.astro`.

## Verification

- Native `cargo test --workspace` (excl. python-native's macOS test-link issue):
  **744 passed, 0 failed**.
- Native `--all-targets` and the `ppvm-python-native` cdylib build unchanged.
- Full workspace builds for `wasm32-unknown-unknown` — incl. `ppvm-tableau`,
  `ppvm-tableau-sum`, `ppvm-stim`, and the top-level `ppvm` crate.
- On wasm the dependency tree drops `ahash`/`gxhash`/`getrandom 0.3` entirely,
  leaving only `getrandom 0.4` (`wasm_js`) for `rand`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)