### PR TITLE
feat(stim-parser): source-pointing diagnostics (ariadne)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ariadne"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f5e3dca4e09a6f340a61a0e9c7b61e030c69fc27bf29d73218f7e5e3b7638f"
+dependencies = [
+ "unicode-width",
+ "yansi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,6 +1463,7 @@ dependencies = [
 name = "stim-parser"
 version = "0.1.0"
 dependencies = [
+ "ariadne",
  "chumsky",
  "proptest",
 ]
@@ -1546,6 +1557,12 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
@@ -1941,6 +1958,12 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/crates/ppvm-python-native/src/stim_program.rs
+++ b/crates/ppvm-python-native/src/stim_program.rs
@@ -67,7 +67,8 @@ impl Deref for PyStimProgram {
 }
 
 fn stim_to_pyerr(e: ppvm_stim::Diagnostics) -> PyErr {
-    PyValueError::new_err(format!("{e}"))
+    // Rich, source-pointing report (offending line + caret), plain text.
+    PyValueError::new_err(e.render())
 }
 
 fn stim_to_pyerr_exec(e: ppvm_stim::ExecError) -> PyErr {

--- a/crates/stim-parser/Cargo.toml
+++ b/crates/stim-parser/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+ariadne = "0.5"
 chumsky = "0.12.0"
 
 [dev-dependencies]

--- a/crates/stim-parser/src/diagnostics/mod.rs
+++ b/crates/stim-parser/src/diagnostics/mod.rs
@@ -69,16 +69,24 @@ pub trait DiagnosticSink {
 pub struct Aborted;
 
 /// Aggregate returned by the Tier-1 `parse`/`parse_extended` functions on
-/// failure. Owns a `LineMap` so `Display` can render `line:col`.
+/// failure. Owns the source text, so it can render both terse `line:col`
+/// summaries ([`Display`](fmt::Display)) and rich, source-pointing reports
+/// ([`render`](Diagnostics::render)).
 #[derive(Debug, Clone)]
 pub struct Diagnostics {
     items: Vec<Diagnostic>,
+    source: Arc<str>,
     line_map: Arc<LineMap>,
 }
 
 impl Diagnostics {
-    pub fn new(items: Vec<Diagnostic>, line_map: Arc<LineMap>) -> Self {
-        Diagnostics { items, line_map }
+    pub fn new(items: Vec<Diagnostic>, source: Arc<str>) -> Self {
+        let line_map = Arc::new(LineMap::new(&source));
+        Diagnostics {
+            items,
+            source,
+            line_map,
+        }
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &Diagnostic> {
@@ -87,6 +95,42 @@ impl Diagnostics {
 
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
+    }
+
+    /// The source text these diagnostics refer to.
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    /// Render a rich, source-pointing report (à la `rustc` / `ariadne`): each
+    /// diagnostic shows the offending source line with a caret under its span.
+    /// Plain text — no ANSI colour — so it reads cleanly in tracebacks, logs,
+    /// and notebooks. Falls back to the terse [`Display`](fmt::Display) form if
+    /// rendering ever fails.
+    pub fn render(&self) -> String {
+        use ariadne::{Config, Label, Report, ReportKind, Source};
+
+        const ID: &str = "<stim>";
+        let mut buf = Vec::new();
+        for d in &self.items {
+            let kind = match d.severity {
+                Severity::Error => ReportKind::Error,
+                Severity::Warning => ReportKind::Warning,
+            };
+            let span = (ID, d.span.start..d.span.end);
+            let report = Report::build(kind, span.clone())
+                .with_config(Config::default().with_color(false))
+                .with_message(&d.message)
+                .with_label(Label::new(span).with_message(&d.message))
+                .finish();
+            if report
+                .write((ID, Source::from(self.source.as_ref())), &mut buf)
+                .is_err()
+            {
+                return self.to_string();
+            }
+        }
+        String::from_utf8(buf).unwrap_or_else(|_| self.to_string())
     }
 }
 
@@ -116,13 +160,12 @@ mod tests {
 
     #[test]
     fn diagnostics_display_renders_line_col() {
-        let line_map = Arc::new(LineMap::new("X 0\nBADINSTR 0"));
         let diag = Diagnostic::error(
             Span::new(4, 12),
             "unknown-instruction",
             "unknown instruction 'BADINSTR'",
         );
-        let diags = Diagnostics::new(vec![diag], line_map);
+        let diags = Diagnostics::new(vec![diag], Arc::from("X 0\nBADINSTR 0"));
         assert_eq!(
             diags.to_string(),
             "error at line 2, col 1: unknown instruction 'BADINSTR'"
@@ -131,7 +174,22 @@ mod tests {
 
     #[test]
     fn diagnostics_is_empty_when_no_items() {
-        let line_map = Arc::new(LineMap::new(""));
-        assert!(Diagnostics::new(vec![], line_map).is_empty());
+        assert!(Diagnostics::new(vec![], Arc::from("")).is_empty());
+    }
+
+    #[test]
+    fn render_points_at_the_source_span() {
+        // `X` (byte 8) is the offending target in "H 0\nM 0 X\n".
+        let diag = Diagnostic::error(Span::new(8, 9), "invalid-target", "invalid target \"X\"");
+        let diags = Diagnostics::new(vec![diag], Arc::from("H 0\nM 0 X\n"));
+        let report = diags.render();
+        assert!(
+            report.contains("M 0 X"),
+            "report should show the offending source line:\n{report}"
+        );
+        assert!(
+            report.contains("invalid target"),
+            "report should include the message:\n{report}"
+        );
     }
 }

--- a/crates/stim-parser/src/lib.rs
+++ b/crates/stim-parser/src/lib.rs
@@ -12,13 +12,13 @@ pub(crate) mod syntax;
 use std::sync::Arc;
 
 use crate::ast::{ExtendedProgram, Program};
-use crate::diagnostics::{Diagnostics, FailFast, LineMap};
+use crate::diagnostics::{Diagnostics, FailFast};
 use crate::pipeline::Pipeline;
 use crate::syntax::run_on_parser_stack;
 
 /// Build a [`Diagnostics`] from a fail-fast sink that aborted a parse stage.
 fn fail(sink: FailFast, src: &str) -> Diagnostics {
-    Diagnostics::new(sink.into_items(), Arc::new(LineMap::new(src)))
+    Diagnostics::new(sink.into_items(), Arc::from(src))
 }
 
 /// Parse Stim source into the vanilla [`Program`] AST. Uses a fail-fast

--- a/ppvm-python/test/test_stim_api.py
+++ b/ppvm-python/test/test_stim_api.py
@@ -203,3 +203,12 @@ def test_stim_program_repr_html_is_highlighted():
     assert html.startswith("<pre")
     assert "<span" in html  # tokens are wrapped in coloured spans
     assert "</pre>" in html
+
+
+def test_parse_error_points_at_the_source():
+    with pytest.raises(ValueError) as exc:
+        StimProgram.parse("H 0\nCX 0 1\nM 0 X\n")
+    msg = str(exc.value)
+    assert "M 0 X" in msg  # the offending source line is shown
+    assert "invalid target" in msg  # ...with the diagnostic message
+    assert "3" in msg  # ...located at line 3


### PR DESCRIPTION
## Summary

Parse/validate/lower failures now render as rich, source-pointing reports (à la `rustc`/`ariadne`) instead of a terse one-liner. The offending line is shown with a caret under the exact span.

Before:
```
ValueError: error at line 3, col 5: invalid target "X"
```
After (`StimProgram.parse("H 0\nCX 0 1\nM 0 X\n")`):
```
Error: invalid target "X"
   ╭─[ <stim>:3:5 ]
   │
 3 │ M 0 X
   │     ┬
   │     ╰── invalid target "X"
───╯
```

## Changes
- `stim-parser`: `Diagnostics` now owns the source text (`Arc<str>`) and gains a public **`render()`** that produces the report via [`ariadne`](https://github.com/zesterer/ariadne) (the chumsky author's diagnostic renderer). Plain text — no ANSI colour — so it reads cleanly in tracebacks, logs, and notebooks. The terse `Display` (`error at line L, col C: …`) is retained for programmatic/`ppvm-stim` use.
- `ppvm-python-native`: `StimProgram.parse()` / `from_file()` surface `render()` in the raised `ValueError`.
- New dependency: `ariadne = "0.5"` (stim-parser only).

## Test Plan
- [x] `cargo test --workspace` green (56 test binaries)
- [x] `stim-parser` diagnostics unit test asserts the report shows the source line + message; full crate suite green (96 lib + integration)
- [x] Python `test_parse_error_points_at_the_source` asserts the `ValueError` contains the offending line, message, and line number; 22 stim Python tests pass
- [x] `cargo clippy -p stim-parser -p ppvm-stim -p ppvm-python-native --all-targets -- -D warnings` clean

Branched off `main` after #150 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)