### PR TITLE
fix(stim-parser): high-contrast colour for diagnostic spans

### DIFF
--- a/crates/stim-parser/src/diagnostics/mod.rs
+++ b/crates/stim-parser/src/diagnostics/mod.rs
@@ -104,24 +104,29 @@ impl Diagnostics {
 
     /// Render a rich, source-pointing report (à la `rustc` / `ariadne`): each
     /// diagnostic shows the offending source line with a caret under its span.
-    /// Plain text — no ANSI colour — so it reads cleanly in tracebacks, logs,
-    /// and notebooks. Falls back to the terse [`Display`](fmt::Display) form if
-    /// rendering ever fails.
+    ///
+    /// The offending span is highlighted with a fixed, high-contrast ANSI
+    /// colour — red for errors, yellow for warnings — so it stands out in a
+    /// terminal traceback (and in Jupyter, which interprets ANSI). We pin an
+    /// explicit colour rather than letting `ariadne`'s default generator pick
+    /// one: its auto palette is pastel and reads as washed-out / too light.
+    /// Falls back to the terse [`Display`](fmt::Display) form if rendering ever
+    /// fails.
     pub fn render(&self) -> String {
-        use ariadne::{Config, Label, Report, ReportKind, Source};
+        use ariadne::{Color, Config, Label, Report, ReportKind, Source};
 
         const ID: &str = "<stim>";
         let mut buf = Vec::new();
         for d in &self.items {
-            let kind = match d.severity {
-                Severity::Error => ReportKind::Error,
-                Severity::Warning => ReportKind::Warning,
+            let (kind, color) = match d.severity {
+                Severity::Error => (ReportKind::Error, Color::Red),
+                Severity::Warning => (ReportKind::Warning, Color::Yellow),
             };
             let span = (ID, d.span.start..d.span.end);
             let report = Report::build(kind, span.clone())
-                .with_config(Config::default().with_color(false))
+                .with_config(Config::default().with_color(true))
                 .with_message(&d.message)
-                .with_label(Label::new(span).with_message(&d.message))
+                .with_label(Label::new(span).with_message(&d.message).with_color(color))
                 .finish();
             if report
                 .write((ID, Source::from(self.source.as_ref())), &mut buf)
@@ -177,6 +182,25 @@ mod tests {
         assert!(Diagnostics::new(vec![], Arc::from("")).is_empty());
     }
 
+    /// Drop ANSI SGR sequences (`ESC [ … <letter>`) so text assertions can run
+    /// against the colourised report without depending on a regex crate.
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut chars = s.chars();
+        while let Some(c) = chars.next() {
+            if c == '\u{1b}' {
+                for c2 in chars.by_ref() {
+                    if c2.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
     #[test]
     fn render_points_at_the_source_span() {
         // `X` (byte 8) is the offending target in "H 0\nM 0 X\n".
@@ -184,12 +208,17 @@ mod tests {
         let diags = Diagnostics::new(vec![diag], Arc::from("H 0\nM 0 X\n"));
         let report = diags.render();
         assert!(
-            report.contains("M 0 X"),
-            "report should show the offending source line:\n{report}"
+            report.contains('\u{1b}'),
+            "the offending span should be highlighted with ANSI colour:\n{report:?}"
+        );
+        let plain = strip_ansi(&report);
+        assert!(
+            plain.contains("M 0 X"),
+            "report should show the offending source line:\n{plain}"
         );
         assert!(
-            report.contains("invalid target"),
-            "report should include the message:\n{report}"
+            plain.contains("invalid target"),
+            "report should include the message:\n{plain}"
         );
     }
 }

--- a/ppvm-python/test/test_stim_api.py
+++ b/ppvm-python/test/test_stim_api.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 The PPVM Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import re
+
 import pytest
 
 from ppvm import GeneralizedTableau, MeasurementResult, PauliSum, StimProgram
@@ -209,6 +211,8 @@ def test_parse_error_points_at_the_source():
     with pytest.raises(ValueError) as exc:
         StimProgram.parse("H 0\nCX 0 1\nM 0 X\n")
     msg = str(exc.value)
-    assert "M 0 X" in msg  # the offending source line is shown
-    assert "invalid target" in msg  # ...with the diagnostic message
-    assert "3" in msg  # ...located at line 3
+    assert "\x1b[" in msg  # the offending span is highlighted with ANSI colour
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", msg)  # strip colour for text assertions
+    assert "M 0 X" in plain  # the offending source line is shown
+    assert "invalid target" in plain  # ...with the diagnostic message
+    assert "3" in plain  # ...located at line 3


### PR DESCRIPTION
## Problem

`ppvm.StimProgram.parse(...)` raises a `ValueError` whose message is rendered
by `stim_parser::Diagnostics::render()`. The diagnostic *content* and
source-pointing layout are correct, but the **highlight on the offending span
was too light / hard to read**.

The render path used `Config::default().with_color(false)` — fully monochrome,
so the flagged token had no emphasis at all. ariadne's only built-in
alternative is its *default colour generator*, whose auto palette is pastel and
reads as washed-out — exactly the "too light" complaint.

```
ValueError: Error: invalid target "X"
   ╭─[ <stim>:3:5 ]
   │
 3 │ M 0 X
   │     ┬
   │     ╰── invalid target "X"
───╯
```

## Fix

Enable ANSI colour with a **fixed, high-contrast** colour instead of the auto
generator (`crates/stim-parser/src/diagnostics/mod.rs`):

- `Color::Red` for errors, `Color::Yellow` for warnings, applied via
  `Label::with_color(...)`.
- The offending token, its caret (`┬`/`╰──`), and the `Error:` header now
  render in standard ANSI red; surrounding context stays dim grey, so the
  flagged span pops in IPython/terminal and in Jupyter (which interprets ANSI).

## Tests

- **Rust** (`render_points_at_the_source_span`): now asserts the output is
  colourised (`\x1b` present) and strips ANSI before the text assertions, via a
  small inline stripper (no regex dependency). 229/229 `stim-parser` tests pass.
- **Python** (`test_parse_error_points_at_the_source`): asserts `\x1b[` present,
  then `re.sub`-strips colour before the content checks. Full `test_stim_api.py`
  22/22 pass.

## Tradeoff

Re-enabling colour reverses the previous "plain text for clean logs" choice:
raw escape codes will now appear in **non-ANSI sinks** (plain log files,
captured strings with no terminal). Interactive terminals and Jupyter render it
correctly. The render output is handed to a `PyValueError` with no known sink,
so TTY-conditional colouring isn't reliable here — hence unconditional,
readable colour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)