### PR TITLE
fix(docs): repair Pages URLs/base for public project page

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,10 +2,14 @@ name: Docs
 
 # Deploy the Astro docs site at `docs/` to GitHub Pages.
 #
+# The repo is public, so Pages serves from the project page
+# `https://queracomputing.github.io/ppvm/` — every build is based under
+# `/ppvm/` (gh-pages branch root maps to the `/ppvm/` URL prefix).
+#
 # Behaviour:
-# - Push to `main`            → build with PPVM_BASE=/        and publish
+# - Push to `main`            → build with PPVM_BASE=/ppvm/   and publish
 #                               to the gh-pages branch root.
-# - Pull request (opened /    → build with PPVM_BASE=/pr-preview/pr-<N>
+# - Pull request (opened /    → build with PPVM_BASE=/ppvm/pr-preview/pr-<N>
 #   synchronize / reopened)     and let rossjrw/pr-preview-action publish
 #                               the build to gh-pages under
 #                               `pr-preview/pr-<N>/`. Triggered only when
@@ -106,9 +110,9 @@ jobs:
         id: compute-base
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "base=/pr-preview/pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "base=/ppvm/pr-preview/pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           else
-            echo "base=/" >> "$GITHUB_OUTPUT"
+            echo "base=/ppvm/" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Compute git ref for source links
@@ -132,7 +136,7 @@ jobs:
         # hatches a developer would use locally.
         working-directory: docs
         env:
-          PPVM_SITE: https://congenial-bassoon-l436wp3.pages.github.io
+          PPVM_SITE: https://queracomputing.github.io
           PPVM_BASE: ${{ steps.compute-base.outputs.base }}
           PPVM_GIT_REF: ${{ steps.compute-ref.outputs.ref }}
           RUSTFLAGS: "-C target-feature=+aes,+sse2"

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 A fast quantum circuit simulator written in Rust, with Python bindings.
 
-[![Docs](https://img.shields.io/badge/docs-6437FF)](https://congenial-bassoon-l436wp3.pages.github.io/)
-[![CI - rust](https://github.com/QuEraComputing/ppvm/actions/workflows/rust-ci.yml/badge.svg)](https://github.com/QuEraComputing/ppvm/actions/workflows/rust-ci.yml)
-[![CI - python](https://github.com/QuEraComputing/ppvm/actions/workflows/python-ci.yml/badge.svg)](https://github.com/QuEraComputing/ppvm/actions/workflows/python-ci.yml)
+[![Docs](https://img.shields.io/badge/docs-online-6437FF)](https://queracomputing.github.io/ppvm/)
+[![CI](https://github.com/QuEraComputing/ppvm/actions/workflows/ci.yml/badge.svg)](https://github.com/QuEraComputing/ppvm/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
 ## Install
@@ -52,7 +51,7 @@ r0, r1 = tab.measure(0), tab.measure(1)
 print(f"Qubit 0: {r0}, Qubit 1: {r1}")  # always correlated
 ```
 
-See the [documentation](https://congenial-bassoon-l436wp3.pages.github.io/) for the Rust API, Stim integration, and symbolic propagation.
+See the [documentation](https://queracomputing.github.io/ppvm/) for the Rust API, Stim integration, and symbolic propagation.
 
 ## License & contributing
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,13 +1,13 @@
 import { defineConfig } from "astro/config";
 
 // `site` + `base` are read from env in CI so the same astro config powers
-// three deploy targets:
-//   · local dev:           PPVM_SITE=http://localhost:4321         PPVM_BASE=/
-//   · main → gh-pages:     PPVM_SITE=https://congenial-bassoon-l436wp3.pages.github.io  PPVM_BASE=/
-//   · PR preview deploy:   PPVM_SITE=https://congenial-bassoon-l436wp3.pages.github.io  PPVM_BASE=/pr-preview/pr-<N>
-const site =
-  process.env.PPVM_SITE ??
-  "https://congenial-bassoon-l436wp3.pages.github.io";
+// three deploy targets. The repo is public, so Pages serves from the
+// `queracomputing.github.io/ppvm/` project page — every deploy except
+// local dev is therefore based under `/ppvm/`:
+//   · local dev:           PPVM_SITE=http://localhost:4321              PPVM_BASE=/
+//   · main → gh-pages:     PPVM_SITE=https://queracomputing.github.io   PPVM_BASE=/ppvm/
+//   · PR preview deploy:   PPVM_SITE=https://queracomputing.github.io   PPVM_BASE=/ppvm/pr-preview/pr-<N>
+const site = process.env.PPVM_SITE ?? "https://queracomputing.github.io";
 const base = process.env.PPVM_BASE ?? "/";
 
 export default defineConfig({


### PR DESCRIPTION
## Problem

Open-sourcing the repo moved GitHub Pages from the **private** random subdomain (`congenial-bassoon-l436wp3.pages.github.io`, served at root) to the **public project page** `https://queracomputing.github.io/ppvm/` (served under `/ppvm/`). The docs config still assumed the old root-served subdomain, breaking two things:

### 1. README badges
- **Docs badge link → 404** (dead private subdomain). Verified: the subdomain returns `HTTP 404`; `https://queracomputing.github.io/ppvm/` returns `HTTP 200` (and is the repo's GitHub-API `homepage`).
- **Docs badge image malformed** — `badge/docs-6437FF` rendered as a "docs | 6437FF" text badge instead of a coloured pill.
- **CI badges pointed at non-existent workflows** (`rust-ci.yml`, `python-ci.yml`). There is one workflow — `ci.yml` — running both the rust and python jobs.

### 2. Live docs page broken
The site was built with `base=/` (correct when the private repo served at the subdomain root), but the public project page serves under `/ppvm/`. Every emitted asset/nav link 404s. Verified on the live site:

| URL | Status |
|-----|--------|
| `…/ppvm/_astro/…` style asset | built as `/_astro/…` → **404** |
| `…/quickstart` | **404** |
| `…/ppvm/quickstart` | **200** |

## Fix

- **`README.md`** — Docs badge + prose link → `https://queracomputing.github.io/ppvm/`; badge syntax → `docs-online-6437FF`; collapse the two broken CI badges into one accurate `ci.yml` badge.
- **`docs/astro.config.mjs`** — default `site` → `https://queracomputing.github.io`; refresh the deploy-target comment block.
- **`.github/workflows/docs.yml`** — build with `PPVM_BASE=/ppvm/` on `main` and `/ppvm/pr-preview/pr-<N>` on PRs; `PPVM_SITE` → `https://queracomputing.github.io`.

The docs templates already derive every link from `import.meta.env.BASE_URL`, so setting the correct build-time `base` repairs all assets and navigation at once. The `pr-preview-action` `umbrella-dir: pr-preview` already lands previews at `gh-pages/pr-preview/pr-<N>/`, which matches the new `/ppvm/pr-preview/pr-<N>` base.

## Verification

- Live-URL probes (404 vs 200) above pin down the root cause.
- Base-aware templates confirmed via `grep` for `import.meta.env.BASE_URL` (no hardcoded `href="/"` in layouts/components).
- **The PR preview deploy from this PR is the end-to-end gate** — it now builds under `/ppvm/pr-preview/pr-<N>/` and should render fully styled with working navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)