### PR TITLE
Add cargo-machete prek hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,21 +52,6 @@ jobs:
           SKIP: no-commit-to-branch
         run: mise exec -- prek run --all-files
 
-  # Detect unused dependencies across the whole workspace. cargo-machete is a
-  # purely syntactic check (it parses each crate's Cargo.toml and source, no
-  # compilation), so it needs neither a Rust toolchain nor the pre-commit gate
-  # and runs in parallel for fast feedback. Run from the repo root, it recurses
-  # into every workspace member, so all crates are covered. False positives
-  # (e.g. a dep used only behind cfg) can be silenced per-crate with
-  # `[package.metadata.cargo-machete] ignored = [...]`.
-  cargo-machete:
-    name: Unused dependencies (cargo-machete)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: bnjbvr/cargo-machete@v0.9.2
-
   rust-tests:
     name: Rust tests
     needs: pre-commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,21 @@ jobs:
           SKIP: no-commit-to-branch
         run: mise exec -- prek run --all-files
 
+  # Detect unused dependencies across the whole workspace. cargo-machete is a
+  # purely syntactic check (it parses each crate's Cargo.toml and source, no
+  # compilation), so it needs neither a Rust toolchain nor the pre-commit gate
+  # and runs in parallel for fast feedback. Run from the repo root, it recurses
+  # into every workspace member, so all crates are covered. False positives
+  # (e.g. a dep used only behind cfg) can be silenced per-crate with
+  # `[package.metadata.cargo-machete] ignored = [...]`.
+  cargo-machete:
+    name: Unused dependencies (cargo-machete)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: bnjbvr/cargo-machete@v0.9.2
+
   rust-tests:
     name: Rust tests
     needs: pre-commit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,8 +916,6 @@ dependencies = [
 name = "ppvm"
 version = "0.1.0"
 dependencies = [
- "fxhash",
- "num",
  "ppvm-pauli-sum",
  "ppvm-sym",
  "ppvm-tableau",
@@ -963,7 +961,6 @@ name = "ppvm-python-native"
 version = "0.1.0"
 dependencies = [
  "bnum",
- "num",
  "paste",
  "ppvm-pauli-sum",
  "ppvm-stim",
@@ -1040,7 +1037,6 @@ dependencies = [
  "mimalloc",
  "num",
  "ppvm-pauli-sum",
- "ppvm-pauli-word",
  "ppvm-tableau",
  "ppvm-traits",
  "rand 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-fxhash = "0.2.1"
-num = "0.4.3"
 ppvm-pauli-sum = { version = "0.1.0", path = "crates/ppvm-pauli-sum" }
 ppvm-tableau = { version = "0.1.0", path = "crates/ppvm-tableau" }
 ppvm-sym = { version = "0.1.0", path = "crates/ppvm-sym" }

--- a/crates/ppvm-python-native/Cargo.toml
+++ b/crates/ppvm-python-native/Cargo.toml
@@ -13,7 +13,6 @@ test = false
 
 [dependencies]
 bnum = "0.13.0"
-num = "0.4.3"
 paste = "1.0.15"
 ppvm-pauli-sum = { version = "0.1.0", path = "../ppvm-pauli-sum" }
 ppvm-stim = { version = "0.1.0", path = "../ppvm-stim", features = ["rayon"] }

--- a/crates/ppvm-tableau-sum/Cargo.toml
+++ b/crates/ppvm-tableau-sum/Cargo.toml
@@ -8,7 +8,6 @@ bitvec = "1.0.1"
 fxhash = "0.2.1"
 num = "0.4.3"
 ppvm-traits = { version = "0.1.0", path = "../ppvm-traits" }
-ppvm-pauli-word = { version = "0.1.0", path = "../ppvm-pauli-word" }
 ppvm-pauli-sum = { version = "0.1.0", path = "../ppvm-pauli-sum" }
 ppvm-tableau = { version = "0.1.0", path = "../ppvm-tableau" }
 rand = "0.10.1"

--- a/docs/src/pages/develop.astro
+++ b/docs/src/pages/develop.astro
@@ -470,6 +470,18 @@ npm run build          # extract everything, then `astro build` → dist/</code>
       </li>
     </ol>
     <p>
+      <strong>Unused dependencies.</strong> A <code>cargo-machete</code>
+      <code>prek</code> hook flags unused crate dependencies across the whole
+      workspace (run from the repo root, <a href="https://github.com/bnjbvr/cargo-machete">cargo-machete</a>
+      recurses into every member). It is part of the hook suite, so it runs both
+      locally on commit and in CI via the <code>pre-commit</code> job — there is
+      no separate machete CI job. The binary is provisioned by <code>mise</code>
+      (<code>cargo:cargo-machete</code> in <code>mise.toml</code>), so the
+      mise-action step that sets up the other hooks installs it too. Silence a
+      false positive per-crate with
+      <code>[package.metadata.cargo-machete] ignored = [&hellip;]</code>.
+    </p>
+    <p>
       <strong>Why cross-OS is extension-only.</strong> The compiled PyO3
       module is the only artifact whose build is OS-sensitive — macOS needs
       <code>-undefined dynamic_lookup</code> (added by
@@ -616,6 +628,7 @@ chore: restore lockfile consistency</code></pre>
     <ul>
       <li>Run <code>cargo fmt --all</code> before committing Rust.</li>
       <li>Run <code>cargo clippy --workspace --all-targets</code>; fix or justify all warnings.</li>
+      <li>Run <code>cargo machete</code> to catch unused dependencies; it's also a <code>prek</code> hook, run on commit and in CI.</li>
       <li>Python is formatted with <code>ruff format</code> and linted with <code>ruff check</code>.</li>
       <li>Public Rust items should have doc comments; <code>cargo doc --no-deps</code> must build cleanly because the API site is built from rustdoc JSON.</li>
       <li>

--- a/mise.toml
+++ b/mise.toml
@@ -2,3 +2,5 @@
 prek = "latest"
 # License header checker/formatter (used by prek hawkeye hook)
 "github:korandoru/hawkeye" = "latest"
+# Unused-dependency checker
+"cargo:cargo-machete" = "0.9.2"

--- a/ppvm-python/demo/hello_world.py
+++ b/ppvm-python/demo/hello_world.py
@@ -1,0 +1,32 @@
+"""Encode a message into a computational-basis state with GeneralizedTableau.
+
+Each bit of the ASCII encoding of "Hello, world!" gets one qubit. Starting
+from the all-zero state, we flip every qubit whose target bit is 1 with an X
+gate, then measure all qubits back out and decode them into the string.
+"""
+
+from ppvm import GeneralizedTableau
+
+MESSAGE = "Hello, world!"
+
+# ASCII bytes -> bit list, MSB first within each byte.
+data = MESSAGE.encode("ascii")
+bits = [(byte >> (7 - i)) & 1 for byte in data for i in range(8)]
+
+# One qubit per bit; flip every qubit whose target bit is 1.
+tab = GeneralizedTableau(n_qubits=len(bits))
+for q, bit in enumerate(bits):
+    if bit:
+        tab.x(q)
+
+# Measure all qubits and decode the outcomes back into a string.
+measured = [int(tab.measure(q)) for q in range(len(bits))]
+decoded = bytes(
+    int("".join(str(b) for b in measured[i : i + 8]), 2)
+    for i in range(0, len(measured), 8)
+).decode("ascii")
+
+print(f"qubits:  {len(bits)}")
+print(f"decoded: {decoded!r}")
+assert decoded == MESSAGE, f"round-trip failed: {decoded!r}"
+print("round-trip OK")

--- a/ppvm-python/demo/squin_kernel.py
+++ b/ppvm-python/demo/squin_kernel.py
@@ -1,0 +1,14 @@
+from ppvm import GeneralizedTableauSimulator
+from bloqade import squin
+
+@squin.kernel
+def main():
+    q = squin.qalloc(2)
+
+    squin.h(q[0])
+    squin.cnot(q[0], q[1])
+
+sim = GeneralizedTableauSimulator(2)
+task = sim.task(main)
+task.run()
+print(task.state)

--- a/prek.toml
+++ b/prek.toml
@@ -47,6 +47,21 @@ entry = "cargo clippy --workspace -- -D warnings"
 pass_filenames = false
 types = ["rust"]
 
+# Rust: unused-dependency check across the whole workspace.
+# cargo-machete is installed via mise (see mise.toml); `mise exec --` is used so
+# the hook works even outside a mise-activated shell. This is the sole machete
+# check: it runs locally on commit and in CI via the `pre-commit` job (which
+# runs the full hook suite) — there is no separate cargo-machete CI job.
+[[repos]]
+repo = "local"
+[[repos.hooks]]
+id = "cargo-machete"
+name = "cargo machete (unused deps)"
+language = "system"
+entry = "mise exec -- cargo-machete"
+pass_filenames = false
+types = ["rust"]
+
 # Python: ruff format check
 [[repos]]
 repo = "local"


### PR DESCRIPTION
Adds cargo machete prek hook to detect unused dependency. This will run locally and as part of the CI. Also, removed some unused dependencies and pushed some (completely unrelated) python demo scripts I had lying around.